### PR TITLE
Cache parsed activities in IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "esbuild": "^0.27.3",
+        "fake-indexeddb": "^6.0.0",
         "jsdom": "^28.0.0",
         "vitest": "^3.0.0",
         "wrangler": "^3.90.0"
@@ -2181,6 +2182,16 @@
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.27.3",
+    "fake-indexeddb": "^6.0.0",
     "jsdom": "^28.0.0",
     "vitest": "^3.0.0",
     "wrangler": "^3.90.0"

--- a/shared.css
+++ b/shared.css
@@ -83,6 +83,17 @@ input[type="text"] {
 .mmp-table thead th { color: var(--muted); font-weight: 500; }
 .hint { color: var(--muted); font-size: 0.85rem; }
 
+.link-button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.link-button:hover { filter: brightness(1.15); }
+
 footer {
   border-top: 1px solid var(--border);
   padding: 1rem 1.5rem;

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,13 @@ import { parseFit } from './fit.js';
 import { extractMmp, DURATIONS_S } from './mmp.js';
 import { rollingBest } from './aggregate.js';
 import { formatDuration, formatPower } from './format.js';
+import {
+  loadActivities,
+  saveActivities,
+  hasActivity,
+  clearActivities,
+  activityCount,
+} from './storage.js';
 
 const dropZone = document.getElementById('archive-drop');
 const fileInput = document.getElementById('archive-input');
@@ -28,6 +35,21 @@ if (dropZone && fileInput) {
   });
 }
 
+// Hydrate from IndexedDB on page load — returning visitors see their
+// curve instantly without re-uploading.
+hydrateFromCache();
+
+async function hydrateFromCache() {
+  try {
+    const cached = await loadActivities();
+    if (cached.length > 0) {
+      renderCurves(cached, { fromCache: true });
+    }
+  } catch (err) {
+    console.warn('cache hydrate failed', err);
+  }
+}
+
 async function handleArchive(file) {
   setProgress(`Unzipping ${file.name}…`);
   const files = await unzipArchive(file);
@@ -36,37 +58,58 @@ async function handleArchive(file) {
 
   setProgress(`Found ${entries.length} activities (${fitEntries.length} FIT). Parsing…`);
 
-  const activityMmps = [];
+  const newActivities = [];
   let withPower = 0;
+  let skipped = 0;
+
   for (let i = 0; i < fitEntries.length; i++) {
     const path = fitEntries[i];
     try {
       const { bytes } = decodeEntry(files, path);
       const activity = await parseFit(bytes);
       if (activity?.powerStream) {
-        const mmp = extractMmp(activity.powerStream);
-        activityMmps.push({ startTime: activity.startTime, durationS: activity.durationS, mmp });
+        if (await hasActivity(activity.startTime)) {
+          skipped++;
+        } else {
+          const mmp = extractMmp(activity.powerStream);
+          newActivities.push({
+            startTime: activity.startTime,
+            durationS: activity.durationS,
+            distanceM: activity.distanceM,
+            mmp,
+          });
+        }
         withPower++;
       }
     } catch (err) {
       console.warn('parse failed', path, err);
     }
     if (i % 5 === 0 || i === fitEntries.length - 1) {
-      setProgress(`Parsed ${i + 1}/${fitEntries.length} (${withPower} with power)…`);
+      setProgress(
+        `Parsed ${i + 1}/${fitEntries.length} (${withPower} with power, ${skipped} already cached)…`
+      );
       await tick();
     }
   }
 
-  if (activityMmps.length === 0) {
+  if (newActivities.length > 0) {
+    setProgress(`Saving ${newActivities.length} new activities to local cache…`);
+    await saveActivities(newActivities);
+  }
+
+  const all = await loadActivities();
+  if (all.length === 0) {
     setProgress('No power-equipped activities found in the archive.');
     return;
   }
 
-  setProgress(`Done. ${withPower} power activities. Building curve…`);
-  renderCurves(activityMmps);
+  setProgress(
+    `Done. ${all.length} activities cached locally (${newActivities.length} new this run).`
+  );
+  renderCurves(all);
 }
 
-function renderCurves(activityMmps) {
+function renderCurves(activityMmps, { fromCache = false } = {}) {
   const allTime = rollingBest(activityMmps);
   const last90 = rollingBest(activityMmps, { windowDays: 90 });
   const last30 = rollingBest(activityMmps, { windowDays: 30 });
@@ -90,9 +133,21 @@ function renderCurves(activityMmps) {
       </thead>
       <tbody>${rows}</tbody>
     </table>
-    <p class="hint">${activityMmps.length} activities with power processed locally. Nothing has been uploaded.</p>
+    <p class="hint">
+      ${activityMmps.length} activities cached locally${fromCache ? ' (from previous visit)' : ''}.
+      <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
+    </p>
   `;
   resultsEl.hidden = false;
+  document.getElementById('clear-cache').addEventListener('click', handleClearCache);
+}
+
+async function handleClearCache() {
+  if (!confirm('Clear all cached activity data from this browser?')) return;
+  await clearActivities();
+  resultsEl.hidden = true;
+  resultsEl.innerHTML = '';
+  setProgress(`Cache cleared. ${await activityCount()} activities remaining.`);
 }
 
 function setProgress(msg) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,78 @@
+// IndexedDB cache for parsed activity records. Keeps returning visits
+// instant: we never re-parse the zip if the user has been here before.
+// startTime (unix ms) is the natural key — two rides can't start in the
+// same millisecond.
+
+const DB_NAME = 'power-predict';
+const DB_VERSION = 1;
+const STORE = 'activities';
+
+function openDb() {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'startTime' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function withStore(mode, fn) {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, mode);
+    const store = tx.objectStore(STORE);
+    let result;
+    Promise.resolve(fn(store))
+      .then((r) => { result = r; })
+      .catch(reject);
+    tx.oncomplete = () => resolve(result);
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+  });
+}
+
+export async function loadActivities() {
+  return withStore('readonly', (store) =>
+    new Promise((resolve, reject) => {
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror = () => reject(req.error);
+    })
+  );
+}
+
+export async function saveActivities(activities) {
+  if (activities.length === 0) return;
+  return withStore('readwrite', (store) => {
+    for (const a of activities) store.put(a);
+  });
+}
+
+export async function hasActivity(startTime) {
+  return withStore('readonly', (store) =>
+    new Promise((resolve, reject) => {
+      const req = store.getKey(startTime);
+      req.onsuccess = () => resolve(req.result !== undefined);
+      req.onerror = () => reject(req.error);
+    })
+  );
+}
+
+export async function clearActivities() {
+  return withStore('readwrite', (store) => store.clear());
+}
+
+export async function activityCount() {
+  return withStore('readonly', (store) =>
+    new Promise((resolve, reject) => {
+      const req = store.count();
+      req.onsuccess = () => resolve(req.result || 0);
+      req.onerror = () => reject(req.error);
+    })
+  );
+}

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import {
+  loadActivities,
+  saveActivities,
+  hasActivity,
+  clearActivities,
+  activityCount,
+} from '../src/storage.js';
+
+describe('storage', () => {
+  beforeEach(async () => {
+    await clearActivities();
+  });
+
+  it('save + load round-trip', async () => {
+    await saveActivities([
+      { startTime: 1000, durationS: 60, mmp: { 60: 250 } },
+      { startTime: 2000, durationS: 120, mmp: { 60: 300 } },
+    ]);
+    const all = await loadActivities();
+    expect(all).toHaveLength(2);
+    expect(all.map((a) => a.startTime).sort()).toEqual([1000, 2000]);
+  });
+
+  it('hasActivity reflects existence', async () => {
+    await saveActivities([{ startTime: 42, durationS: 10, mmp: {} }]);
+    expect(await hasActivity(42)).toBe(true);
+    expect(await hasActivity(99)).toBe(false);
+  });
+
+  it('put with same startTime overwrites', async () => {
+    await saveActivities([{ startTime: 5, durationS: 10, mmp: { 60: 100 } }]);
+    await saveActivities([{ startTime: 5, durationS: 10, mmp: { 60: 200 } }]);
+    const all = await loadActivities();
+    expect(all).toHaveLength(1);
+    expect(all[0].mmp[60]).toBe(200);
+  });
+
+  it('clearActivities empties the store', async () => {
+    await saveActivities([{ startTime: 1, durationS: 1, mmp: {} }]);
+    await clearActivities();
+    expect(await activityCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Persists per-activity metadata + MMP arrays to IndexedDB after first parse (~1 KB per ride, so even a decade of riding is well under 5 MB)
- On page load, hydrates the curve from cache instantly — no re-upload required
- During archive parse, skips activities already in cache so re-imports are nearly free
- Adds a Clear cached data control to wipe local state

Raw streams are still discarded after parsing — only derived numbers persist.

## Test plan
- [ ] Drop archive, refresh page, confirm curve renders immediately from cache
- [ ] Re-drop the same archive, confirm "X already cached" counter increments and parse completes faster
- [ ] Click Clear cached data, confirm table disappears and IDB is empty (DevTools → Application → IndexedDB)