### PR TITLE
Editorial redesign: cream paper, oxblood ink, Fraunces serif

### DIFF
--- a/docs/strava-archive-guide.html
+++ b/docs/strava-archive-guide.html
@@ -4,38 +4,36 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Get your Strava archive — Power Predict</title>
+  <meta name="description" content="Step-by-step: request your Strava data archive, then drop it into Power Predict.">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="../dist/app.min.css">
-  <style>
-    main { max-width: 720px; }
-    main h2 { margin-top: 2rem; }
-    main h3 { margin-top: 1.5rem; font-size: 1.05rem; }
-    main p, main li { line-height: 1.6; }
-    main ol li, main ul li { margin-bottom: 0.4rem; }
-    main code { background: var(--card); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.9em; }
-    main table { width: 100%; border-collapse: collapse; margin: 0.75rem 0; font-size: 0.9rem; }
-    main th, main td { padding: 0.4rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
-    main th { color: var(--muted); font-weight: 500; }
-    .back-link { color: var(--muted); text-decoration: none; font-size: 0.9rem; }
-    .back-link:hover { color: var(--fg); }
-  </style>
 </head>
 <body>
   <header class="site-header">
-    <h1>Power Predict</h1>
-    <p class="tagline"><a href="../" class="back-link">&larr; Back to home</a></p>
+    <a href="../" class="wordmark" aria-label="Power Predict">
+      <span class="wordmark__power">Power</span>
+      <span class="wordmark__rule" aria-hidden="true"></span>
+      <span class="wordmark__predict">Predict</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="../">Home</a>
+      <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">Source</a>
+    </nav>
   </header>
 
-  <main>
+  <main class="article">
+    <p class="kicker">A field manual / 01</p>
     <h1>Get your Strava archive</h1>
 
-    <p>Power Predict needs your full ride history to build an accurate power-duration curve. The fastest way to import it &mdash; and the only one that doesn't burn through Strava's tight API rate limits &mdash; is to request your account archive directly from Strava and drop the zip into Power Predict.</p>
+    <p class="lead">Power Predict needs your full ride history to build an accurate power-duration curve. The fastest way to import it &mdash; and the only one that doesn't burn through Strava's tight API rate limits &mdash; is to request your account archive directly from Strava and drop the zip into Power Predict.</p>
 
-    <p>The archive contains every ride you've ever uploaded, including the raw power streams. <strong>Strava prepares it offline and emails you when it's ready</strong> &mdash; usually within a few hours, sometimes faster, sometimes the next day.</p>
+    <p>The archive contains every ride you've ever uploaded, including the raw power streams. Strava prepares it offline and emails you when it's ready &mdash; usually within a few hours, sometimes faster, sometimes the next day.</p>
 
-    <h2>Step 1 &mdash; Request the archive</h2>
+    <h2>Step 1 — Request the archive</h2>
     <ol>
-      <li>Go to <a href="https://www.strava.com/account" target="_blank" rel="noopener">Strava &rarr; Settings &rarr; My Account</a>.</li>
+      <li>Go to <a href="https://www.strava.com/account" target="_blank" rel="noopener">Strava &rsaquo; Settings &rsaquo; My Account</a>.</li>
       <li>Scroll to the bottom and click <strong>Download or Delete Your Account</strong>.</li>
       <li>Click <strong>Get Started</strong> under "Download Request (optional)".</li>
       <li>Click <strong>Request Your Archive</strong>.</li>
@@ -43,13 +41,13 @@
 
     <p>You will <strong>not</strong> lose your account. The "Download or Delete" page bundles both options, but the archive request is independent of deletion.</p>
 
-    <h2>Step 2 &mdash; Wait for the email</h2>
+    <h2>Step 2 — Wait for the email</h2>
 
-    <p>Strava will email a link titled <strong>"Your Strava Data Export"</strong> to the address on your account, typically within 1&ndash;6 hours. The link expires after about 7 days, so download promptly.</p>
+    <p>Strava emails a link titled <strong>"Your Strava Data Export"</strong> within roughly 1&ndash;6 hours. The link expires after about 7 days, so download it promptly.</p>
 
-    <h2>Step 3 &mdash; Download and drop in</h2>
+    <h2>Step 3 — Download and drop in</h2>
 
-    <p>You'll get a file like <code>strava_export_&lt;id&gt;.zip</code> (often hundreds of MB if you have a lot of rides). Save it somewhere you can find it.</p>
+    <p>You'll get a file like <code>strava_export_&lt;id&gt;.zip</code>, often hundreds of megabytes if you have a long history. Save it somewhere you can find it.</p>
 
     <p>Open Power Predict and drag the zip onto the upload area. Everything happens in your browser:</p>
     <ul>
@@ -62,39 +60,39 @@
 
     <h2>What's in the archive</h2>
 
-    <p>For reference, the zip contains:</p>
     <table>
       <thead><tr><th>Path</th><th>Contents</th></tr></thead>
       <tbody>
-        <tr><td><code>activities.csv</code></td><td>Metadata for every activity (date, name, distance, duration, etc.)</td></tr>
-        <tr><td><code>activities/&lt;id&gt;.fit.gz</code></td><td>Full FIT file per activity &mdash; power, HR, cadence, GPS at 1Hz</td></tr>
-        <tr><td><code>activities/&lt;id&gt;.tcx.gz</code> / <code>.gpx.gz</code></td><td>Older or non-FIT activities</td></tr>
-        <tr><td><code>media/</code></td><td>Photos attached to activities (Power Predict ignores these)</td></tr>
-        <tr><td><code>profile.csv</code>, <code>bikes.csv</code>, etc.</td><td>Account profile info (also ignored)</td></tr>
+        <tr><td><code>activities.csv</code></td><td>Metadata for every activity (date, name, distance, duration).</td></tr>
+        <tr><td><code>activities/&lt;id&gt;.fit.gz</code></td><td>Full FIT file — power, HR, cadence, GPS at 1 Hz.</td></tr>
+        <tr><td><code>activities/&lt;id&gt;.tcx.gz</code> / <code>.gpx.gz</code></td><td>Older or non-FIT activities.</td></tr>
+        <tr><td><code>media/</code></td><td>Activity photos. Power Predict ignores these.</td></tr>
+        <tr><td><code>profile.csv</code>, <code>bikes.csv</code></td><td>Account info. Also ignored.</td></tr>
       </tbody>
     </table>
 
     <h2>Troubleshooting</h2>
 
-    <h3>"My archive is huge."</h3>
-    <p>That's normal &mdash; mine is over a gigabyte. Power Predict streams it entry-by-entry; you don't need to extract it manually.</p>
+    <h3>My archive is huge</h3>
+    <p>That's normal &mdash; a long history easily clears a gigabyte. Power Predict streams it entry-by-entry; you don't need to extract it manually.</p>
 
-    <h3>"Some activities don't have power."</h3>
-    <p>Power Predict only uses activities with a power meter recording. Older rides, rides on a different bike, and rides recorded by phone-only typically have no power stream. They're skipped automatically.</p>
+    <h3>Some activities don't have power</h3>
+    <p>Power Predict only uses activities with a power-meter recording. Older rides, rides on a different bike, and phone-only recordings typically have no power stream. They're skipped automatically.</p>
 
-    <h3>"My archive email never came."</h3>
-    <p>Check spam. If it's been more than 24 hours, request again from the same page &mdash; old requests don't block new ones.</p>
+    <h3>The archive email never came</h3>
+    <p>Check spam. After 24 hours, request again from the same page &mdash; old requests don't block new ones.</p>
 
-    <h3>"I'm worried about uploading my data."</h3>
-    <p>Power Predict parses the archive entirely in your browser using JavaScript. The zip never leaves your machine during onboarding. You can verify this by opening DevTools &rarr; Network while you drop the file: there will be no upload requests.</p>
+    <h3>I'm worried about uploading my data</h3>
+    <p>Power Predict parses the archive entirely in your browser using JavaScript. The zip never leaves your machine during onboarding. You can verify this by opening DevTools &rsaquo; Network while you drop the file: there will be no upload requests.</p>
 
     <h2>Updating later</h2>
 
     <p>You only need to do the archive dance once. After the initial import, you can connect Strava via OAuth and Power Predict will pull individual new rides as you complete them &mdash; no more archive requests required.</p>
   </main>
 
-  <footer>
-    <p><a href="../" class="back-link">&larr; Back to home</a></p>
+  <footer class="site-footer">
+    <p><a href="../">&larr; Back to Power Predict</a></p>
+    <p>Independent project. Not endorsed by Strava.</p>
   </footer>
 </body>
 </html>

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#f4eee2"/>
+  <text x="32" y="46" text-anchor="middle"
+        font-family="Georgia, 'Iowan Old Style', serif"
+        font-size="46" font-style="italic" font-weight="500"
+        fill="#7a1f24">P</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,48 +3,64 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Power Predict</title>
+  <title>Power Predict — what you can actually hold</title>
+  <meta name="description" content="Predict the watts you can sustain for any race duration, fitted to your Strava history.">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="dist/app.min.css">
 </head>
 <body>
   <header class="site-header">
-    <h1>Power Predict</h1>
-    <p class="tagline">Predict your sustainable race power from Strava history.</p>
+    <a href="/" class="wordmark" aria-label="Power Predict">
+      <span class="wordmark__power">Power</span>
+      <span class="wordmark__rule" aria-hidden="true"></span>
+      <span class="wordmark__predict">Predict</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="docs/strava-archive-guide.html">Archive Guide</a>
+      <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">Source</a>
+    </nav>
   </header>
 
   <main>
-    <section class="onboard">
-      <h2>Get started</h2>
-      <ol>
-        <li>Request your Strava archive &mdash; <a href="docs/strava-archive-guide.html">step-by-step guide</a>.</li>
-        <li>Drop the zip below. Your power streams are processed in your browser &mdash; only the derived numbers leave your machine.</li>
-        <li>Optionally connect Strava so new rides sync automatically.</li>
-      </ol>
-      <div id="archive-drop" class="drop-zone">
-        <p>Drag your <code>strava_export_*.zip</code> here, or click to choose.</p>
-        <input type="file" id="archive-input" accept=".zip" hidden>
-      </div>
-      <p id="progress" class="progress" hidden></p>
+    <section class="lede">
+      <p class="kicker">A field manual for cyclists who race with watts</p>
+      <h1 class="headline">What you can <em>actually</em> hold for the whole race.</h1>
+      <p class="dek">Power Predict reads your Strava history, fits a critical-power model to your best efforts, and tells you what's realistic — adjusted for how recent your fitness peaked and whether you were really trying.</p>
     </section>
+
+    <ol class="steps" aria-label="How it works">
+      <li>
+        <span class="step-num">01 / Request</span>
+        <h3>Ask Strava for your archive</h3>
+        <p>They prepare it offline and email a link within hours. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
+      </li>
+      <li>
+        <span class="step-num">02 / Drop</span>
+        <h3>Drag the zip onto the page</h3>
+        <p>Parsed in your browser. Raw streams never leave your machine.</p>
+      </li>
+      <li>
+        <span class="step-num">03 / Read</span>
+        <h3>See your power-duration curve</h3>
+        <p>Connect Strava later so new rides flow in automatically.</p>
+      </li>
+    </ol>
+
+    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Upload Strava archive">
+      <input type="file" id="archive-input" accept=".zip" hidden>
+      <span class="drop__label">Drop your archive</span>
+      <span class="drop__hint">strava_export_*.zip · or click to browse</span>
+    </div>
+    <p id="progress" class="progress" hidden></p>
 
     <section id="results" hidden></section>
-
-    <section class="predict" hidden>
-      <h2>Predict</h2>
-      <form id="predict-form">
-        <label>
-          Target duration
-          <input type="text" id="target-duration" placeholder="45m or 2h30m">
-        </label>
-        <button type="submit">Predict</button>
-      </form>
-      <output id="predict-result"></output>
-    </section>
   </main>
 
-  <footer>
-    <p>Built with the Strava API. Not endorsed by Strava.</p>
+  <footer class="site-footer">
+    <p>Independent project. Not endorsed by Strava.</p>
+    <p>Built by <a href="https://iammike.org" target="_blank" rel="noopener">Mike Collins</a> · <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">GitHub</a></p>
   </footer>
 
   <script src="dist/app.min.js"></script>

--- a/shared.css
+++ b/shared.css
@@ -1,103 +1,578 @@
+/* Power Predict — editorial cycling-magazine aesthetic.
+   Cream paper, oxblood ink, Fraunces serif display, Schibsted Grotesk body,
+   JetBrains Mono numerics, hairline rules, magazine-grade data table. */
+
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..700&family=JetBrains+Mono:wght@400;500&family=Schibsted+Grotesk:wght@400;500;600;700&display=swap');
+
 :root {
-  --bg: #0e1116;
-  --fg: #e6edf3;
-  --muted: #8b949e;
-  --accent: #fc4c02;          /* Strava orange */
-  --accent-fg: #ffffff;
-  --card: #161b22;
-  --border: #30363d;
+  /* Palette — cream paper, ink, oxblood accent */
+  --paper:        #f4eee2;
+  --paper-soft:   #ede5d3;
+  --paper-deep:   #e3d9c1;
+  --ink:          #1a1612;
+  --ink-soft:     #34291f;
+  --muted:        #7a6f60;
+  --hair:         rgba(26, 22, 18, 0.16);
+  --hair-strong:  rgba(26, 22, 18, 0.32);
+  --oxblood:      #7a1f24;
+  --oxblood-deep: #5e161a;
+  --burnt:        #c14a1a;
+
+  /* Type system */
+  --serif: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+  --sans:  'Schibsted Grotesk', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --mono:  'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Layout rhythm */
+  --measure: 64ch;
+  --gutter: clamp(1.25rem, 4vw, 3rem);
+  --rule-soft: 1px solid var(--hair);
+  --rule-strong: 1px solid var(--hair-strong);
 }
 
 * { box-sizing: border-box; }
 
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  background: var(--bg);
-  color: var(--fg);
-  line-height: 1.5;
+  font-family: var(--sans);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 17px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "cv11", "kern";
+  position: relative;
+  min-height: 100vh;
 }
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.10 0 0 0 0 0.08 0 0 0 0 0.07 0 0 0 0.05 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: multiply;
+  opacity: 0.55;
+  z-index: 0;
+}
+
+a { color: var(--oxblood); text-underline-offset: 3px; }
+a:hover { color: var(--oxblood-deep); }
+
+::selection { background: var(--oxblood); color: var(--paper); }
+
+/* HEADER */
 
 .site-header {
-  padding: 2rem 1.5rem 1rem;
-  border-bottom: 1px solid var(--border);
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1.5rem;
+  padding: clamp(1.25rem, 3vw, 2rem) var(--gutter);
+  border-bottom: var(--rule-soft);
 }
 
-.site-header h1 { margin: 0; font-size: 1.75rem; }
-.tagline { color: var(--muted); margin: 0.25rem 0 0; }
+.wordmark {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  line-height: 1;
+  text-decoration: none;
+  color: var(--ink);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35em;
+  font-variation-settings: "opsz" 144, "SOFT" 50;
+  letter-spacing: -0.015em;
+}
+.wordmark__power {
+  font-style: italic;
+  color: var(--oxblood);
+  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
+}
+.wordmark__rule {
+  display: inline-block;
+  width: 1.4em;
+  height: 1px;
+  background: var(--hair-strong);
+  margin: 0 0.1em 0.3em;
+  vertical-align: middle;
+}
+.wordmark__predict { letter-spacing: -0.02em; }
 
-main { padding: 1.5rem; max-width: 720px; margin: 0 auto; }
-section { margin-bottom: 2.5rem; }
-h2 { font-size: 1.25rem; margin-top: 0; }
+.site-nav {
+  display: flex;
+  gap: 1.75rem;
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.site-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: color 160ms ease, border-color 160ms ease;
+}
+.site-nav a:hover {
+  color: var(--oxblood);
+  border-bottom-color: var(--oxblood);
+}
 
-.drop-zone {
-  border: 2px dashed var(--border);
-  border-radius: 8px;
-  padding: 2rem;
+/* MAIN */
+
+main {
+  position: relative;
+  z-index: 1;
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4.5rem) var(--gutter) 4rem;
+}
+
+.lede { max-width: 36rem; }
+
+.kicker {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--oxblood);
+  margin: 0 0 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.kicker::before {
+  content: "";
+  width: 2.5rem;
+  height: 1px;
+  background: var(--oxblood);
+  display: inline-block;
+}
+
+.headline {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.5rem, 6vw, 4.25rem);
+  line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0 0 1.5rem;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+  max-width: 18ch;
+}
+.headline em {
+  font-style: italic;
+  color: var(--oxblood);
+  font-variation-settings: "opsz" 144, "SOFT" 100, "WONK" 1;
+}
+
+.dek {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  margin: 0;
+  max-width: 52ch;
+  font-variation-settings: "opsz" 36;
+}
+
+.steps {
+  list-style: none;
+  padding: 0;
+  margin: clamp(3rem, 6vw, 5rem) 0 2rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: var(--rule-strong);
+}
+.steps > li {
+  padding: 1.5rem 1.5rem 1.5rem 0;
+  border-bottom: var(--rule-soft);
+  border-right: var(--rule-soft);
+}
+.steps > li:nth-child(3n) { border-right: none; }
+.steps > li:nth-child(2),
+.steps > li:nth-child(3) { padding-left: 1.5rem; }
+
+.step-num {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  color: var(--oxblood);
+  display: block;
+  margin-bottom: 0.65rem;
+}
+.steps h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.18rem;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  margin: 0 0 0.5rem;
+}
+.steps p {
+  margin: 0;
+  font-size: 0.94rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.steps a {
+  color: var(--oxblood);
+  text-decoration: none;
+  border-bottom: 1px solid var(--oxblood);
+  white-space: nowrap;
+}
+.steps a:hover { color: var(--oxblood-deep); border-bottom-color: var(--oxblood-deep); }
+
+/* DROP */
+
+.drop {
+  position: relative;
+  margin: 1.5rem 0 0;
+  padding: clamp(2.5rem, 6vw, 4rem) 2rem;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair-strong);
   text-align: center;
   cursor: pointer;
-  transition: border-color 120ms ease, background 120ms ease;
+  transition: background 200ms ease, border-color 200ms ease;
 }
-.drop-zone:hover, .drop-zone.is-active {
-  border-color: var(--accent);
-  background: rgba(252, 76, 2, 0.05);
+.drop::before, .drop::after {
+  content: "";
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--ink);
+  transition: border-color 200ms ease, width 200ms ease, height 200ms ease;
 }
-
-button {
-  background: var(--accent);
-  color: var(--accent-fg);
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  cursor: pointer;
-  font-weight: 600;
+.drop::before {
+  top: -1px; left: -1px;
+  border-right: none; border-bottom: none;
 }
-button:hover { filter: brightness(1.05); }
-
-input[type="text"] {
-  background: var(--card);
-  color: var(--fg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.5rem;
-  font: inherit;
+.drop::after {
+  bottom: -1px; right: -1px;
+  border-left: none; border-top: none;
+}
+.drop:hover, .drop.is-active, .drop:focus-visible {
+  background: var(--paper);
+  border-color: var(--oxblood);
+  outline: none;
+}
+.drop:hover::before, .drop:hover::after,
+.drop.is-active::before, .drop.is-active::after,
+.drop:focus-visible::before, .drop:focus-visible::after {
+  border-color: var(--oxblood);
+  width: 22px; height: 22px;
+}
+.drop__label {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
+  font-variation-settings: "opsz" 72, "SOFT" 100;
+  display: block;
+  color: var(--ink);
+  margin-bottom: 0.6rem;
+}
+.drop__hint {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  color: var(--muted);
+  letter-spacing: 0.06em;
 }
 
 .progress {
-  margin-top: 1rem;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-soft);
+  margin: 1.25rem 0 0;
+  font-variation-settings: "opsz" 24;
+}
+
+/* RESULTS */
+
+#results {
+  margin-top: clamp(3rem, 6vw, 4.5rem);
+}
+
+.results-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.5rem;
+  border-bottom: 2px solid var(--ink);
+  padding-bottom: 0.6rem;
+  margin: 0 0 0.5rem;
+}
+.results-head h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  letter-spacing: -0.015em;
+  margin: 0;
+  font-variation-settings: "opsz" 144, "SOFT" 50;
+}
+.results-head__meta {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   color: var(--muted);
-  font-size: 0.9rem;
 }
 
 .mmp-table {
   width: 100%;
   border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 0.92rem;
+  font-variant-numeric: tabular-nums;
   margin-top: 0.5rem;
 }
-.mmp-table th, .mmp-table td {
-  padding: 0.4rem 0.6rem;
+.mmp-table th,
+.mmp-table td {
+  padding: 0.6rem 1rem;
   text-align: right;
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--rule-soft);
 }
-.mmp-table th:first-child, .mmp-table td:first-child { text-align: left; }
-.mmp-table thead th { color: var(--muted); font-weight: 500; }
-.hint { color: var(--muted); font-size: 0.85rem; }
+.mmp-table th:first-child,
+.mmp-table td:first-child {
+  text-align: left;
+  font-family: var(--serif);
+  font-style: italic;
+  font-variation-settings: "opsz" 24, "SOFT" 60;
+  color: var(--ink-soft);
+  font-size: 1rem;
+}
+.mmp-table thead th {
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.7rem;
+  color: var(--muted);
+  border-bottom: 1px solid var(--ink);
+}
+.mmp-table thead th.featured { color: var(--oxblood); }
+.mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
+.mmp-table tbody tr:hover td { background: var(--paper-soft); }
+
+.results-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+.results-foot__note {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin: 0;
+  font-variation-settings: "opsz" 24;
+}
 
 .link-button {
   background: none;
   border: none;
-  color: var(--accent);
-  padding: 0;
+  padding: 0 0 1px;
   font: inherit;
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight: 500;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--oxblood);
   cursor: pointer;
-  text-decoration: underline;
+  border-bottom: 1px solid var(--oxblood);
+  transition: color 160ms ease, border-color 160ms ease;
 }
-.link-button:hover { filter: brightness(1.15); }
+.link-button:hover {
+  color: var(--oxblood-deep);
+  border-bottom-color: var(--oxblood-deep);
+}
 
-footer {
-  border-top: 1px solid var(--border);
-  padding: 1rem 1.5rem;
+/* ARTICLE PAGES */
+
+.article {
+  position: relative;
+  z-index: 1;
+  max-width: 38rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4.5rem) var(--gutter) 4rem;
+}
+.article h1 {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 2rem;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+.article h2 {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  margin: 2.5rem 0 0.75rem;
+  font-variation-settings: "opsz" 36;
+}
+.article h3 {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 1.75rem 0 0.5rem;
+  color: var(--ink-soft);
+}
+.article p, .article li {
+  font-size: 1.02rem;
+  line-height: 1.65;
+  color: var(--ink-soft);
+}
+.article ol, .article ul { padding-left: 1.4rem; }
+.article ol li, .article ul li { margin-bottom: 0.4rem; }
+.article code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  background: var(--paper-soft);
+  padding: 0.1em 0.4em;
+  border: 1px solid var(--hair);
+}
+.article a {
+  color: var(--oxblood);
+  text-decoration: none;
+  border-bottom: 1px solid var(--oxblood);
+}
+.article a:hover { color: var(--oxblood-deep); border-bottom-color: var(--oxblood-deep); }
+
+.article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0 1.5rem;
+  font-size: 0.95rem;
+}
+.article th, .article td {
+  text-align: left;
+  padding: 0.55rem 0.75rem;
+  border-bottom: var(--rule-soft);
+  vertical-align: top;
+}
+.article thead th {
+  font-family: var(--sans);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.72rem;
   color: var(--muted);
-  font-size: 0.85rem;
-  text-align: center;
+  border-bottom: 1px solid var(--ink);
+}
+
+.lead {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.18rem;
+  line-height: 1.55;
+  color: var(--ink);
+  margin-bottom: 2rem;
+  font-variation-settings: "opsz" 36;
+}
+
+/* FOOTER */
+
+.site-footer {
+  position: relative;
+  z-index: 1;
+  margin-top: 4rem;
+  padding: 1.75rem var(--gutter);
+  border-top: var(--rule-soft);
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+  flex-wrap: wrap;
+}
+.site-footer a {
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--hair);
+  transition: border-color 160ms ease;
+}
+.site-footer a:hover { border-bottom-color: var(--ink); }
+
+/* ANIMATION */
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.lede > *,
+.steps > li,
+.drop {
+  opacity: 0;
+  animation: rise 720ms cubic-bezier(.2, .8, .2, 1) forwards;
+}
+.kicker      { animation-delay: 80ms; }
+.headline    { animation-delay: 180ms; }
+.dek         { animation-delay: 360ms; }
+.steps > li:nth-child(1) { animation-delay: 540ms; }
+.steps > li:nth-child(2) { animation-delay: 640ms; }
+.steps > li:nth-child(3) { animation-delay: 740ms; }
+.drop        { animation-delay: 880ms; }
+
+#results[data-revealed] {
+  animation: rise 600ms cubic-bezier(.2, .8, .2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+  .lede > *, .steps > li, .drop { opacity: 1; }
+}
+
+/* RESPONSIVE */
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding-top: 1.25rem;
+    padding-bottom: 1rem;
+  }
+  .site-nav { gap: 1.25rem; }
+
+  .steps { grid-template-columns: 1fr; }
+  .steps > li,
+  .steps > li:nth-child(2),
+  .steps > li:nth-child(3) {
+    padding: 1.25rem 0;
+    border-right: none;
+  }
+
+  .results-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+  .mmp-table th, .mmp-table td { padding: 0.5rem 0.4rem; }
+  .mmp-table th:first-child, .mmp-table td:first-child { padding-left: 0; }
+  .mmp-table th:last-child, .mmp-table td:last-child { padding-right: 0; }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -120,25 +120,36 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       <tr>
         <td>${formatDuration(d)}</td>
         <td>${last30[d] !== undefined ? formatPower(last30[d]) : '—'}</td>
-        <td>${last90[d] !== undefined ? formatPower(last90[d]) : '—'}</td>
+        <td class="featured">${last90[d] !== undefined ? formatPower(last90[d]) : '—'}</td>
         <td>${formatPower(allTime[d])}</td>
       </tr>`)
     .join('');
 
   resultsEl.innerHTML = `
-    <h2>Mean Maximal Power</h2>
+    <header class="results-head">
+      <h2>Mean Maximal Power</h2>
+      <span class="results-head__meta">Watts · by duration</span>
+    </header>
     <table class="mmp-table">
       <thead>
-        <tr><th>Duration</th><th>Last 30d</th><th>Last 90d</th><th>All-time</th></tr>
+        <tr>
+          <th>Duration</th>
+          <th>Last 30d</th>
+          <th class="featured">Last 90d</th>
+          <th>All-time</th>
+        </tr>
       </thead>
       <tbody>${rows}</tbody>
     </table>
-    <p class="hint">
-      ${activityMmps.length} activities cached locally${fromCache ? ' (from previous visit)' : ''}.
+    <div class="results-foot">
+      <p class="results-foot__note">
+        ${activityMmps.length} activities cached locally${fromCache ? ', loaded from your last visit.' : '.'}
+      </p>
       <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
-    </p>
+    </div>
   `;
   resultsEl.hidden = false;
+  resultsEl.dataset.revealed = '';
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
 }
 


### PR DESCRIPTION
Closes #19.

## Summary
Replaces the dark-on-black palette with a cycling-magazine aesthetic. Solves the link-contrast issue (oxblood on cream is highly readable) and gives the site a distinct identity rather than feeling like a generic dashboard.

**Palette:** cream paper · warm ink · oxblood accent
**Type:** Fraunces (display, italic accents) · Schibsted Grotesk (body) · JetBrains Mono (numerics)
**Details:** hairline rules, paper-grain overlay, drop zone with corner ticks that grow on hover/focus, magazine-style data table with the Last 90d column featured in oxblood as the practical race-prediction window, page-load stagger animations (`prefers-reduced-motion` respected).

Touches landing page, archive guide, and the dynamically rendered MMP table. New `favicon.svg`.

## Test plan
- [ ] Pull the branch, `npm run build && npm run serve`, hit http://localhost:8000
- [ ] Confirm headline / kicker / steps stagger in
- [ ] Confirm drop-zone corner ticks animate on hover
- [ ] Drop archive (or use cached data from previous visit) — table renders with featured Last 90d column
- [ ] Visit `/docs/strava-archive-guide.html` for matching article style
- [ ] Set `Reduce Motion` in macOS System Settings → confirm animations are skipped
- [ ] Mobile: resize to ~360px wide, steps collapse to single column, header stacks