### PR TITLE
Phase 3 first cut: CP fit + predict form

### DIFF
--- a/docs/strava-archive-guide.html
+++ b/docs/strava-archive-guide.html
@@ -24,12 +24,12 @@
   </header>
 
   <main class="article">
-    <p class="kicker">A field manual / 01</p>
+    <p class="kicker">Onboarding · Step 1</p>
     <h1>Get your Strava archive</h1>
 
-    <p class="lead">Power Predict needs your full ride history to build an accurate power-duration curve. The fastest way to import it &mdash; and the only one that doesn't burn through Strava's tight API rate limits &mdash; is to request your account archive directly from Strava and drop the zip into Power Predict.</p>
+    <p class="lead">Power Predict needs your ride history to build an accurate power-duration curve. The simplest way to import it is to request your account archive from Strava and drop the zip into the app.</p>
 
-    <p>The archive contains every ride you've ever uploaded, including the raw power streams. Strava prepares it offline and emails you when it's ready &mdash; usually within a few hours, sometimes faster, sometimes the next day.</p>
+    <p>The archive contains every activity you've uploaded, including the raw power streams. Strava prepares it offline and emails a download link, usually within a few hours.</p>
 
     <h2>Step 1 — Request the archive</h2>
     <ol>

--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
 
   <main>
     <section class="lede">
-      <p class="kicker">A field manual for cyclists who race with watts</p>
-      <h1 class="headline">What you can <em>actually</em> hold for the whole race.</h1>
-      <p class="dek">Power Predict reads your Strava history, fits a critical-power model to your best efforts, and tells you what's realistic — adjusted for how recent your fitness peaked and whether you were really trying.</p>
+      <p class="kicker">Critical-power modeling from your Strava history</p>
+      <h1 class="headline">How many <em>watts</em>. For how long.</h1>
+      <p class="dek">Power Predict fits a critical-power model to your best efforts and predicts the wattage you can sustain for a target race duration, weighted toward your recent fitness.</p>
     </section>
 
     <ol class="steps" aria-label="How it works">

--- a/shared.css
+++ b/shared.css
@@ -402,6 +402,176 @@ main {
   border-bottom-color: var(--oxblood-deep);
 }
 
+/* PREDICT */
+
+.predict {
+  margin-top: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.fit-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  margin: 1rem 0 1.75rem;
+  padding: 0;
+  border-top: var(--rule-soft);
+  border-bottom: var(--rule-soft);
+}
+.fit-stats > div {
+  padding: 0.85rem 1rem;
+  border-right: var(--rule-soft);
+}
+.fit-stats > div:last-child { border-right: none; }
+.fit-stats dt {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  margin: 0 0 0.25rem;
+}
+.fit-stats dd {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 1.35rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--ink);
+  font-variation-settings: "opsz" 36;
+}
+
+.predict-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.predict-form__field {
+  flex: 1 1 16rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.predict-form__field span {
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+.predict-form input {
+  font-family: var(--mono);
+  font-size: 1rem;
+  background: transparent;
+  color: var(--ink);
+  border: none;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.5rem 0;
+  outline: none;
+  transition: border-color 160ms ease;
+}
+.predict-form input::placeholder { color: var(--muted); opacity: 0.7; }
+.predict-form input:focus { border-bottom-color: var(--oxblood); }
+
+.predict-form button {
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--paper);
+  background: var(--oxblood);
+  border: none;
+  padding: 0.75rem 1.4rem;
+  cursor: pointer;
+  transition: background 160ms ease, transform 160ms ease;
+}
+.predict-form button:hover { background: var(--oxblood-deep); }
+.predict-form button:active { transform: translateY(1px); }
+
+.predict-output {
+  display: block;
+  margin-top: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair-strong);
+  position: relative;
+}
+.predict-output::before, .predict-output::after {
+  content: "";
+  position: absolute;
+  width: 12px; height: 12px;
+  border: 1px solid var(--oxblood);
+}
+.predict-output::before {
+  top: -1px; left: -1px;
+  border-right: none; border-bottom: none;
+}
+.predict-output::after {
+  bottom: -1px; right: -1px;
+  border-left: none; border-top: none;
+}
+.predict-output__label {
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  margin: 0 0 0.4rem;
+}
+.predict-output__value {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  line-height: 1;
+  color: var(--oxblood);
+  margin: 0;
+  letter-spacing: -0.02em;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+}
+.predict-output__unit {
+  font-family: var(--mono);
+  font-size: 0.45em;
+  font-weight: 500;
+  color: var(--ink-soft);
+  margin-left: 0.25em;
+  letter-spacing: 0.04em;
+}
+.predict-output__band {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--ink-soft);
+  margin: 0.6rem 0 0;
+  font-variation-settings: "opsz" 24;
+}
+.predict-output__flag {
+  font-family: var(--mono);
+  font-style: normal;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--burnt);
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid currentColor;
+}
+.predict-output__error {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--oxblood);
+  margin: 0;
+  font-variation-settings: "opsz" 24;
+}
+
+@media (max-width: 720px) {
+  .fit-stats { grid-template-columns: repeat(2, 1fr); }
+  .fit-stats > div:nth-child(2n) { border-right: none; }
+  .fit-stats > div:nth-child(-n+2) { border-bottom: var(--rule-soft); }
+}
+
 /* ARTICLE PAGES */
 
 .article {

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,8 @@ import {
   clearActivities,
   activityCount,
 } from './storage.js';
+import { fitCp2, predictPower, mmpToPoints } from './cpfit.js';
+import { parseDuration } from './duration.js';
 
 const dropZone = document.getElementById('archive-drop');
 const fileInput = document.getElementById('archive-input');
@@ -109,10 +111,16 @@ async function handleArchive(file) {
   renderCurves(all);
 }
 
+// Held in module scope so the predict form can read it on submit.
+let currentFit = null;
+
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   const allTime = rollingBest(activityMmps);
   const last90 = rollingBest(activityMmps, { windowDays: 90 });
   const last30 = rollingBest(activityMmps, { windowDays: 30 });
+
+  // Fit CP/W' on the 90-day curve (falls back to all-time if too sparse).
+  currentFit = fitCp2(mmpToPoints(last90)) || fitCp2(mmpToPoints(allTime));
 
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)
@@ -147,10 +155,82 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       </p>
       <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
     </div>
+    ${renderPredictBlock()}
   `;
   resultsEl.hidden = false;
   resultsEl.dataset.revealed = '';
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
+  wirePredictForm();
+}
+
+function renderPredictBlock() {
+  if (!currentFit) {
+    return `
+      <section class="predict">
+        <header class="results-head">
+          <h2>Predict</h2>
+          <span class="results-head__meta">Need 2+ MMP points in 3-20 min</span>
+        </header>
+        <p class="results-foot__note">Not enough data yet to fit a critical-power model. Drop more activities to populate the 3-20 minute MMP window.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="predict">
+      <header class="results-head">
+        <h2>Predict</h2>
+        <span class="results-head__meta">Critical-power model · last 90 days</span>
+      </header>
+
+      <dl class="fit-stats">
+        <div><dt>CP</dt><dd>${formatPower(currentFit.cpW)}</dd></div>
+        <div><dt>W'</dt><dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd></div>
+        <div><dt>RMSE</dt><dd>${currentFit.rmse.toFixed(1)} W</dd></div>
+        <div><dt>Points</dt><dd>${currentFit.nPoints}</dd></div>
+      </dl>
+
+      <form class="predict-form" id="predict-form">
+        <label class="predict-form__field">
+          <span>Target duration</span>
+          <input type="text" id="predict-input" placeholder="45m or 2h30m" autocomplete="off" spellcheck="false" required>
+        </label>
+        <button type="submit">Predict</button>
+      </form>
+      <output class="predict-output" id="predict-output" hidden></output>
+    </section>
+  `;
+}
+
+function wirePredictForm() {
+  const form = document.getElementById('predict-form');
+  if (!form) return;
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const input = document.getElementById('predict-input');
+    const out = document.getElementById('predict-output');
+    const seconds = parseDuration(input.value);
+    if (!seconds) {
+      out.hidden = false;
+      out.innerHTML = `<p class="predict-output__error">Couldn't parse that. Try "45m", "1h30m", or "90s".</p>`;
+      return;
+    }
+    const result = predictPower(currentFit, seconds);
+    if (!result) {
+      out.hidden = false;
+      out.innerHTML = `<p class="predict-output__error">Prediction failed.</p>`;
+      return;
+    }
+    out.hidden = false;
+    out.innerHTML = `
+      <p class="predict-output__label">Predicted for ${formatDuration(seconds)}</p>
+      <p class="predict-output__value">${Math.round(result.powerW)}<span class="predict-output__unit">W</span></p>
+      <p class="predict-output__band">
+        Range ${Math.round(result.low)}–${Math.round(result.high)} W
+        ${result.extrapolated ? '<span class="predict-output__flag">extrapolated</span>' : ''}
+      </p>
+    `;
+  });
 }
 
 async function handleClearCache() {

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -1,0 +1,99 @@
+// 2-parameter Critical Power model.
+//
+// P(t) = CP + W'/t
+//
+// CP (W) is the asymptote — the power you could theoretically hold
+// indefinitely. W' (J) is the finite work above CP you can do before
+// exhausting that anaerobic reserve.
+//
+// We fit by linear regression on the hyperbolic form: with x = 1/t
+// and y = P, the model becomes y = W' * x + CP — slope is W',
+// intercept is CP.
+//
+// Standard CP fitting window is 3-20 minutes. Below 3 min, anaerobic
+// contribution distorts the fit; above 20 min, fatigue effects pull
+// the curve below the simple hyperbola.
+
+export const DEFAULT_FIT_RANGE = { minS: 180, maxS: 1200 };
+
+// Convert an MMP map ({60: 350, 300: 280, ...}) to an array of points.
+export function mmpToPoints(mmp) {
+  const out = [];
+  for (const [d, p] of Object.entries(mmp)) {
+    const durationS = Number(d);
+    if (Number.isFinite(durationS) && Number.isFinite(p)) {
+      out.push({ durationS, powerW: p });
+    }
+  }
+  return out;
+}
+
+// Linear-regression fit. Returns null if there aren't at least 2
+// points within the fitting window.
+export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
+  const filtered = points.filter(
+    (p) => p.durationS >= range.minS && p.durationS <= range.maxS
+  );
+  if (filtered.length < 2) return null;
+
+  const n = filtered.length;
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+  for (const { durationS, powerW } of filtered) {
+    const x = 1 / durationS;
+    sumX += x;
+    sumY += powerW;
+    sumXY += x * powerW;
+    sumX2 += x * x;
+  }
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return null;
+  const wPrimeJ = (n * sumXY - sumX * sumY) / denom;
+  const cpW = (sumY - wPrimeJ * sumX) / n;
+
+  let sse = 0;
+  for (const { durationS, powerW } of filtered) {
+    const predicted = cpW + wPrimeJ / durationS;
+    sse += (powerW - predicted) ** 2;
+  }
+  const rmse = Math.sqrt(sse / n);
+
+  return {
+    cpW,
+    wPrimeJ,
+    rmse,
+    nPoints: n,
+    range,
+    minObservedS: filtered.reduce((m, p) => Math.min(m, p.durationS), Infinity),
+    maxObservedS: filtered.reduce((m, p) => Math.max(m, p.durationS), -Infinity),
+  };
+}
+
+// Predict sustainable power for a target duration.
+// Returns { powerW, low, high, extrapolated, fit } or null.
+//
+// The band is built from the fit's RMSE plus an extrapolation penalty:
+// the further outside [minObservedS, maxObservedS] the target sits,
+// the wider the band gets. The penalty grows linearly with log(t/edge).
+export function predictPower(fit, durationS) {
+  if (!fit || !Number.isFinite(durationS) || durationS <= 0) return null;
+
+  const powerW = fit.cpW + fit.wPrimeJ / durationS;
+  let extrapolated = false;
+  let extrapolationPenalty = 0;
+  if (durationS < fit.minObservedS) {
+    extrapolated = true;
+    extrapolationPenalty = Math.log(fit.minObservedS / durationS) * 8;
+  } else if (durationS > fit.maxObservedS) {
+    extrapolated = true;
+    extrapolationPenalty = Math.log(durationS / fit.maxObservedS) * 8;
+  }
+
+  const halfBand = fit.rmse + extrapolationPenalty;
+  return {
+    powerW,
+    low: powerW - halfBand,
+    high: powerW + halfBand,
+    extrapolated,
+    fit,
+  };
+}

--- a/src/duration.js
+++ b/src/duration.js
@@ -1,0 +1,16 @@
+// Parse human duration strings into seconds.
+// Accepts: "45m", "2h", "1h30m", "90s", "2h30m45s", with case-insensitive
+// units and flexible whitespace. Returns null for unparseable input.
+
+const RE = /^\s*(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?\s*$/i;
+
+export function parseDuration(input) {
+  if (typeof input !== 'string') return null;
+  const m = input.match(RE);
+  if (!m || (!m[1] && !m[2] && !m[3])) return null;
+  const h = Number(m[1] || 0);
+  const min = Number(m[2] || 0);
+  const s = Number(m[3] || 0);
+  const total = h * 3600 + min * 60 + s;
+  return total > 0 ? total : null;
+}

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { fitCp2, predictPower, mmpToPoints } from '../src/cpfit.js';
+
+// Generate synthetic MMP points from a known CP/W' so we can verify
+// the fit recovers them.
+function synth(cp, wPrime, durationsS) {
+  return durationsS.map((t) => ({ durationS: t, powerW: cp + wPrime / t }));
+}
+
+describe('fitCp2', () => {
+  it('recovers CP and W\' on noiseless synthetic data', () => {
+    const points = synth(280, 22000, [180, 300, 600, 900, 1200]);
+    const fit = fitCp2(points);
+    expect(fit.cpW).toBeCloseTo(280, 4);
+    expect(fit.wPrimeJ).toBeCloseTo(22000, 1);
+    expect(fit.rmse).toBeLessThan(0.01);
+    expect(fit.nPoints).toBe(5);
+  });
+
+  it('returns null when fewer than 2 points fall in the fitting window', () => {
+    expect(fitCp2([])).toBeNull();
+    expect(fitCp2([{ durationS: 600, powerW: 300 }])).toBeNull();
+    // Both points outside the default window
+    expect(fitCp2([
+      { durationS: 30, powerW: 600 },
+      { durationS: 60, powerW: 500 },
+    ])).toBeNull();
+  });
+
+  it('respects a custom fitting range', () => {
+    const all = synth(250, 18000, [60, 180, 600, 1200, 3600]);
+    const tight = fitCp2(all, { minS: 300, maxS: 1500 });
+    expect(tight.nPoints).toBe(2); // 600 and 1200
+    expect(tight.cpW).toBeCloseTo(250, 4);
+  });
+
+  it('handles modest noise gracefully', () => {
+    const clean = synth(290, 21000, [180, 240, 360, 480, 720, 1080, 1200]);
+    // ±2W noise
+    const noisy = clean.map((p, i) => ({ ...p, powerW: p.powerW + (i % 2 === 0 ? 2 : -2) }));
+    const fit = fitCp2(noisy);
+    expect(fit.cpW).toBeCloseTo(290, 0);
+    expect(fit.rmse).toBeGreaterThan(0);
+    expect(fit.rmse).toBeLessThan(5);
+  });
+});
+
+describe('predictPower', () => {
+  const fit = fitCp2(synth(280, 22000, [180, 300, 600, 900, 1200]));
+
+  it('predicts P = CP + W/t', () => {
+    const out = predictPower(fit, 2700); // 45 min
+    expect(out.powerW).toBeCloseTo(280 + 22000 / 2700, 3);
+  });
+
+  it('flags extrapolation outside the observed range', () => {
+    const longer = predictPower(fit, 3600); // 60m, beyond max observed 1200s
+    expect(longer.extrapolated).toBe(true);
+    expect(longer.high - longer.low).toBeGreaterThan(0);
+
+    const inside = predictPower(fit, 600);
+    expect(inside.extrapolated).toBe(false);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(predictPower(null, 600)).toBeNull();
+    expect(predictPower(fit, 0)).toBeNull();
+    expect(predictPower(fit, -1)).toBeNull();
+    expect(predictPower(fit, NaN)).toBeNull();
+  });
+
+  it('confidence band widens as duration moves further outside observed range', () => {
+    const just = predictPower(fit, 1500);   // a bit outside
+    const far = predictPower(fit, 7200);    // way outside
+    expect(far.high - far.low).toBeGreaterThan(just.high - just.low);
+  });
+});
+
+describe('mmpToPoints', () => {
+  it('converts an MMP map to point objects', () => {
+    const points = mmpToPoints({ 60: 350, 300: 280 });
+    expect(points).toHaveLength(2);
+    expect(points.map((p) => p.durationS).sort((a, b) => a - b)).toEqual([60, 300]);
+  });
+
+  it('skips invalid values', () => {
+    const points = mmpToPoints({ 60: 350, 300: null, 600: undefined });
+    expect(points).toHaveLength(1);
+  });
+});

--- a/tests/duration.test.js
+++ b/tests/duration.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseDuration } from '../src/duration.js';
+
+describe('parseDuration', () => {
+  it('parses minutes', () => {
+    expect(parseDuration('45m')).toBe(45 * 60);
+    expect(parseDuration('1m')).toBe(60);
+  });
+
+  it('parses hours', () => {
+    expect(parseDuration('2h')).toBe(2 * 3600);
+  });
+
+  it('parses h+m combinations', () => {
+    expect(parseDuration('1h30m')).toBe(3600 + 30 * 60);
+    expect(parseDuration('2h30m45s')).toBe(2 * 3600 + 30 * 60 + 45);
+  });
+
+  it('parses seconds', () => {
+    expect(parseDuration('90s')).toBe(90);
+  });
+
+  it('is case- and whitespace-tolerant', () => {
+    expect(parseDuration(' 1H 30M ')).toBe(3600 + 30 * 60);
+    expect(parseDuration('45M')).toBe(45 * 60);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(parseDuration('')).toBeNull();
+    expect(parseDuration('abc')).toBeNull();
+    expect(parseDuration('45')).toBeNull();
+    expect(parseDuration('0m')).toBeNull();
+    expect(parseDuration(null)).toBeNull();
+    expect(parseDuration(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #11, closes #13. Also reapplies the lede + guide copy revisions that didn't make it into PR #31's squash merge.

## Summary
- **`src/cpfit.js`** — linear-regression fit of P = CP + W'/t over the standard 3-20 min window. Returns `{cpW, wPrimeJ, rmse, nPoints, range, minObservedS, maxObservedS}`. `predictPower(fit, durationS)` returns `{powerW, low, high, extrapolated}` — band widens as target moves outside the observed MMP duration range.
- **`src/duration.js`** — parser for "45m", "1h30m", "2h30m45s", "90s".
- **16 new tests** across `cpfit` and `duration`.
- App fits CP/W' on the rolling 90-day MMP (falls back to all-time when sparse), shows a CP / W' / RMSE / Points stat row, and renders a predict form. Output is big oxblood watts in a corner-ticked paper card with a low/high range and an "extrapolated" badge when applicable.

## Test plan
- [ ] Pull branch, `npm run build && npm run serve`
- [ ] Open with cached IDB data — predict block should appear under the MMP table with non-zero CP and W'
- [ ] Enter `45m` → see a wattage + range
- [ ] Enter `4h` → wattage + range with `EXTRAPOLATED` badge
- [ ] Enter garbage like `abc` → friendly error
- [ ] Mobile: stat row collapses to 2x2, form stacks
- [ ] Confirm reduce-motion still respected