### PR TITLE
Stream archive parsing with progress bar

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -290,11 +290,37 @@ main {
 }
 
 .progress {
+  margin: 1.25rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.progress__text {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+.progress__bar {
+  display: block;
+  height: 3px;
+  background: var(--paper-deep);
+  position: relative;
+  overflow: hidden;
+}
+.progress__bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--oxblood);
+  transition: width 120ms linear;
+}
+/* Plain-text progress used for save / done states */
+.progress:not(:has(.progress__bar)) {
   font-family: var(--serif);
   font-style: italic;
   font-size: 1rem;
   color: var(--ink-soft);
-  margin: 1.25rem 0 0;
   font-variation-settings: "opsz" 24;
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import { unzipArchive, listActivityEntries, decodeEntry } from './archive.js';
+import { streamArchive } from './archive.js';
 import { parseFit } from './fit.js';
 import { extractMmp, DURATIONS_S } from './mmp.js';
 import { rollingBest } from './aggregate.js';
@@ -53,22 +53,19 @@ async function hydrateFromCache() {
 }
 
 async function handleArchive(file) {
-  setProgress(`Unzipping ${file.name}…`);
-  const files = await unzipArchive(file);
-  const entries = listActivityEntries(files);
-  const fitEntries = entries.filter((p) => /\.fit(\.gz)?$/i.test(p));
-
-  setProgress(`Found ${entries.length} activities (${fitEntries.length} FIT). Parsing…`);
+  setProgressPhase('Reading', { bytesRead: 0, totalBytes: file.size });
 
   const newActivities = [];
+  let parsedCount = 0;
   let withPower = 0;
   let skipped = 0;
+  let lastTotalActivities = 0;
 
-  for (let i = 0; i < fitEntries.length; i++) {
-    const path = fitEntries[i];
+  const onActivity = async ({ name, ext, bytes }) => {
+    if (ext !== 'fit') return; // TCX/GPX in a follow-up issue
     try {
-      const { bytes } = decodeEntry(files, path);
       const activity = await parseFit(bytes);
+      parsedCount++;
       if (activity?.powerStream) {
         if (await hasActivity(activity.startTime)) {
           skipped++;
@@ -84,14 +81,29 @@ async function handleArchive(file) {
         withPower++;
       }
     } catch (err) {
-      console.warn('parse failed', path, err);
+      console.warn('parse failed', name, err);
     }
-    if (i % 5 === 0 || i === fitEntries.length - 1) {
-      setProgress(
-        `Parsed ${i + 1}/${fitEntries.length} (${withPower} with power, ${skipped} already cached)…`
-      );
-      await tick();
-    }
+  };
+
+  const onProgress = ({ bytesRead, totalBytes, activitiesSeen }) => {
+    const phase = activitiesSeen > 0 ? 'Reading + parsing' : 'Reading';
+    lastTotalActivities = activitiesSeen;
+    setProgressPhase(phase, {
+      bytesRead,
+      totalBytes,
+      activitiesSeen,
+      parsedCount,
+      withPower,
+      skipped,
+    });
+  };
+
+  try {
+    await streamArchive(file, { onProgress, onActivity });
+  } catch (err) {
+    console.error('archive stream failed', err);
+    setProgress(`Archive read failed: ${err.message || err}`);
+    return;
   }
 
   if (newActivities.length > 0) {
@@ -101,14 +113,39 @@ async function handleArchive(file) {
 
   const all = await loadActivities();
   if (all.length === 0) {
-    setProgress('No power-equipped activities found in the archive.');
+    setProgress(
+      `No power-equipped activities found in the archive (${lastTotalActivities} activity files seen).`
+    );
     return;
   }
 
   setProgress(
-    `Done. ${all.length} activities cached locally (${newActivities.length} new this run).`
+    `Done. ${all.length} activities cached locally (${newActivities.length} new this run, ${skipped} already cached, ${withPower} with power).`
   );
   renderCurves(all);
+}
+
+function setProgressPhase(phase, { bytesRead, totalBytes, activitiesSeen, parsedCount, withPower, skipped }) {
+  const pct = totalBytes ? Math.min(100, (bytesRead / totalBytes) * 100) : 0;
+  const readPart = `${phase}: ${formatBytes(bytesRead)} / ${formatBytes(totalBytes)} (${pct.toFixed(0)}%)`;
+  const parsePart = activitiesSeen
+    ? ` · ${parsedCount}/${activitiesSeen} parsed${withPower ? `, ${withPower} with power` : ''}${skipped ? `, ${skipped} cached` : ''}`
+    : '';
+  if (!progressEl) return;
+  progressEl.hidden = false;
+  progressEl.innerHTML = `
+    <span class="progress__text">${readPart}${parsePart}</span>
+    <span class="progress__bar"><span class="progress__bar-fill" style="width: ${pct}%"></span></span>
+  `;
+}
+
+function formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let i = 0;
+  let v = bytes;
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+  return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
 // Held in module scope so the predict form can read it on submit.
@@ -245,8 +282,4 @@ function setProgress(msg) {
   if (!progressEl) return;
   progressEl.textContent = msg;
   progressEl.hidden = false;
-}
-
-function tick() {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/src/archive.js
+++ b/src/archive.js
@@ -1,42 +1,119 @@
-// Strava archive (zip) unpacking. Yields one activity entry at a time so
-// the UI can stream progress and we never hold every parsed file in memory
-// at once.
+// Streaming Strava-archive ingest.
+//
+// fflate's `Unzip` lets us push chunks from `file.stream()` and pull
+// activity entries out as they complete, so we can report progress
+// smoothly and start parsing FIT files before the rest of the zip
+// has even been read. Important when the archive is multiple GB.
 
-import { unzip, gunzipSync, strFromU8 } from 'fflate';
+import { Unzip, AsyncUnzipInflate, gunzipSync, strFromU8 } from 'fflate';
 
 const ACTIVITY_PATH = /^activities\/[^/]+\.(fit|tcx|gpx)(\.gz)?$/i;
 
-export async function unzipArchive(file) {
-  const buf = new Uint8Array(await file.arrayBuffer());
-  return new Promise((resolve, reject) => {
-    unzip(buf, (err, files) => (err ? reject(err) : resolve(files)));
+// Stream an archive. Calls `onProgress({ bytesRead, totalBytes,
+// filesSeen, activitiesSeen })` as bytes flow through, and
+// `onActivity({ name, ext, bytes })` for each activity entry as it
+// finishes decompressing. `onCsv(text)` receives `activities.csv`
+// content if present.
+//
+// Resolves with summary counts when the whole archive has been
+// streamed and every activity callback has resolved.
+export async function streamArchive(file, { onProgress, onActivity, onCsv } = {}) {
+  const totalBytes = file.size;
+  let bytesRead = 0;
+  let filesSeen = 0;
+  let activitiesSeen = 0;
+  const pending = [];
+
+  const tick = () => onProgress?.({ bytesRead, totalBytes, filesSeen, activitiesSeen });
+
+  await new Promise((resolve, reject) => {
+    const unzipper = new Unzip((entry) => {
+      filesSeen++;
+      const isActivity = ACTIVITY_PATH.test(entry.name);
+      const isActivitiesCsv = entry.name === 'activities.csv';
+
+      if (!isActivity && !isActivitiesCsv) {
+        // Non-activity entries: we still have to drain them to keep
+        // the stream healthy, but we don't allocate or process.
+        entry.ondata = () => {};
+        entry.start();
+        return;
+      }
+
+      if (isActivity) activitiesSeen++;
+
+      const chunks = [];
+      let totalSize = 0;
+      entry.ondata = (err, chunk, final) => {
+        if (err) {
+          // Non-fatal — skip this entry.
+          console.warn('zip entry error', entry.name, err);
+          return;
+        }
+        if (chunk) {
+          chunks.push(chunk);
+          totalSize += chunk.length;
+        }
+        if (final) {
+          const bytes = concatChunks(chunks, totalSize);
+          if (isActivity && onActivity) {
+            pending.push(
+              decodeActivity(entry.name, bytes)
+                .then(onActivity)
+                .catch((err) => console.warn('activity decode failed', entry.name, err))
+            );
+          } else if (isActivitiesCsv && onCsv) {
+            try { onCsv(strFromU8(bytes)); } catch (e) { console.warn('csv decode failed', e); }
+          }
+        }
+      };
+      entry.start();
+    });
+    unzipper.register(AsyncUnzipInflate);
+
+    (async () => {
+      try {
+        const reader = file.stream().getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            unzipper.push(new Uint8Array(0), true);
+            break;
+          }
+          unzipper.push(value);
+          bytesRead += value.length;
+          tick();
+        }
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    })();
   });
+
+  await Promise.all(pending);
+  return { filesSeen, activitiesSeen, bytesRead };
 }
 
-export function listActivityEntries(files) {
-  const out = [];
-  for (const path of Object.keys(files)) {
-    if (ACTIVITY_PATH.test(path)) out.push(path);
+function concatChunks(chunks, total) {
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
   }
   return out;
 }
 
-// Decode an entry into { name, ext, bytes }. Auto-gunzips .fit.gz / .tcx.gz.
-export function decodeEntry(files, path) {
-  let bytes = files[path];
+async function decodeActivity(path, bytes) {
   let p = path;
+  let b = bytes;
   if (p.endsWith('.gz')) {
-    bytes = gunzipSync(bytes);
+    b = gunzipSync(b);
     p = p.slice(0, -3);
   }
   const ext = p.split('.').pop().toLowerCase();
   const name = p.split('/').pop();
-  return { name, ext, bytes };
-}
-
-// activities.csv may carry pretty names + manual activity metadata. Useful
-// later for activity titles; we ignore it during MMP extraction.
-export function readActivitiesCsv(files) {
-  const raw = files['activities.csv'];
-  return raw ? strFromU8(raw) : null;
+  return { name, ext, bytes: b };
 }


### PR DESCRIPTION
## Why
A 1.8 GB Strava archive blocked for ~30s on the one-shot unzip with no UI feedback. Reported by user testing.

## What
- `src/archive.js` switched to fflate's `Unzip` streaming class, fed from `file.stream()` chunks
- Progress callback fires on every chunk read, reporting bytes-read / total + activities seen + parsed
- FIT files parse as soon as their entry completes, in parallel with the rest of the zip being consumed — no more "wait for whole archive then start parsing" gap
- Memory: never holds the full decompressed archive at once
- New progress UI in the page: live byte counts in JetBrains Mono + a 3px oxblood progress bar
- TCX/GPX still skipped here (issue #8 covers those)

## Test plan
- [ ] Pull branch, drop your 1.8 GB archive
- [ ] Confirm "Reading 200 MB / 1.8 GB (11%)" and bar fills smoothly throughout
- [ ] Once activities start showing up, message switches to "Reading + parsing X / Y · N parsed, M with power, K cached"
- [ ] After read completes, "Saving N new activities to local cache…", then final "Done." line
- [ ] Refresh the page and re-drop the same archive — `K cached` count should match the parsed count and saving count should be near zero