### PR TITLE
Fix empty predict box, add version tag, fatigue decay, methodology doc

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Methodology — Power Predict</title>
+  <meta name="description" content="How Power Predict turns your Strava history into a sustainable-watts forecast.">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="../dist/app.min.css">
+</head>
+<body>
+  <header class="site-header">
+    <a href="../" class="wordmark" aria-label="Power Predict">
+      <span class="wordmark__power">Power</span>
+      <span class="wordmark__rule" aria-hidden="true"></span>
+      <span class="wordmark__predict">Predict</span>
+    </a>
+    <nav class="site-nav" aria-label="Primary">
+      <a href="../">Home</a>
+      <a href="strava-archive-guide.html">Archive Guide</a>
+      <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">Source</a>
+    </nav>
+  </header>
+
+  <main class="article">
+    <p class="kicker">How it works</p>
+    <h1>Methodology</h1>
+
+    <p class="lead">Power Predict turns your Strava archive into a sustainable-watts forecast in four steps: extract per-activity power streams, build a mean-maximal-power curve, fit a critical-power model, and apply a fatigue decay for endurance durations.</p>
+
+    <h2>1. Per-activity power streams</h2>
+
+    <p>Each FIT file in your Strava archive contains a 1 Hz stream of power-meter readings. Power Predict reads these in your browser and builds a per-activity <strong>mean maximal power</strong> array &mdash; the best average watts you held across every duration window from 1 second up to several hours, using a sliding-window scan over prefix sums.</p>
+
+    <p>Activities without a power stream (older rides, phone-only recordings) are skipped. Only the derived MMP arrays are persisted; raw streams stay in browser memory just long enough to compute, then get discarded.</p>
+
+    <h2>2. Rolling-best aggregation</h2>
+
+    <p>We take the maximum across activities at each duration to build an aggregate MMP curve, computed in three windows:</p>
+
+    <ul>
+      <li><strong>Last 30 days</strong> &mdash; sensitive to current form, but noisy if you haven't done many quality efforts recently.</li>
+      <li><strong>Last 90 days</strong> &mdash; the practical race-prediction window. Stable enough to fit a model, recent enough to reflect current fitness.</li>
+      <li><strong>All time</strong> &mdash; ceiling reference. Useful context, not used for prediction.</li>
+    </ul>
+
+    <p>Power Predict fits the model on Last 90 days by default and falls back to All time if 90 days has too few points in the fitting window.</p>
+
+    <h2>3. The Critical Power model</h2>
+
+    <p>For durations from roughly 3 minutes to 20 minutes, sustainable power is well-described by the <strong>2-parameter Critical Power model</strong>:</p>
+
+    <p class="formula"><em>P</em>(<em>t</em>) = CP + <em>W</em>′ / <em>t</em></p>
+
+    <p>where</p>
+
+    <ul>
+      <li><strong>CP</strong> (watts) is the asymptote &mdash; the power you could theoretically hold indefinitely if no other systems failed first.</li>
+      <li><strong>W&prime;</strong> (joules) is the finite work you can do above CP before exhausting that anaerobic reserve.</li>
+    </ul>
+
+    <p>With <em>x</em> = 1 / <em>t</em>, the formula becomes a line, and we fit it by ordinary least squares. <em>W&prime;</em> falls out as the slope, CP as the intercept. Power Predict reports the fit's RMSE alongside CP and W&prime; so you can see how well your data matches the model.</p>
+
+    <h3>Why 3-20 minutes</h3>
+
+    <p>Below about 3 minutes, anaerobic / neuromuscular contributions distort the simple two-parameter relationship. Above 20 minutes, fatigue and substrate-depletion effects pull power below the model's prediction. Fits done outside this window are unreliable.</p>
+
+    <h2>4. Fatigue decay for endurance durations</h2>
+
+    <p>If you ask the raw CP model what you can hold for 8 hours, it will answer "approximately CP" &mdash; the asymptote. That's wrong: real cyclists fade well below CP over those durations as glycogen runs low.</p>
+
+    <p>For predictions beyond the 20-minute window we apply a <strong>Riegel-style power-law decay</strong>:</p>
+
+    <p class="formula"><em>P</em>(<em>t</em>) = <em>P</em><sub>anchor</sub> × (<em>t</em><sub>anchor</sub> / <em>t</em>)<sup><em>k</em></sup></p>
+
+    <p>where <em>t</em><sub>anchor</sub> = 1200 s (20 min), <em>P</em><sub>anchor</sub> is the model's prediction at that duration, and <em>k</em> = 0.07 &mdash; Skiba's published fatigue exponent for trained cyclists. This matches Coggan's empirical observations of pro and amateur power profiles:</p>
+
+    <table>
+      <thead><tr><th>Duration</th><th>Fraction of CP (typical)</th><th>Power Predict default</th></tr></thead>
+      <tbody>
+        <tr><td>1 hour</td><td>≈ 95%</td><td>≈ 95%</td></tr>
+        <tr><td>4 hours</td><td>≈ 85%</td><td>≈ 86%</td></tr>
+        <tr><td>8 hours</td><td>≈ 75%</td><td>≈ 80%</td></tr>
+      </tbody>
+    </table>
+
+    <p>The "extrapolated" badge in the predict UI marks any duration outside your observed MMP range. The confidence band widens logarithmically with how far out you've reached.</p>
+
+    <h2>References</h2>
+
+    <ul>
+      <li>Riegel, P.S. <em>Athletic Records and Human Endurance</em>. American Scientist, 1981. The original power-law fatigue formula, derived from running.</li>
+      <li>Skiba, P. <em>Scientific Training for Endurance Athletes</em>. Source for the <em>k</em> = 0.07 fatigue exponent for cycling.</li>
+      <li>Coggan, A. and Allen, H. <em>Training and Racing with a Power Meter</em>. Empirical power-profile fractions of CP across durations.</li>
+      <li>Monod, H. and Scherrer, J. <em>The work capacity of a synergic muscular group.</em> Ergonomics, 1965. Origin of the critical-power concept.</li>
+      <li>Hill, A.V. <em>The physiological basis of athletic records</em>. 1925. Earliest hyperbolic power-duration model.</li>
+    </ul>
+
+    <h2>Limitations and planned improvements</h2>
+
+    <p>Today's predictions assume your last 90 days of data accurately reflect your current fitness. Issues planned for upcoming releases:</p>
+
+    <ul>
+      <li><strong>Recency weighting</strong> &mdash; weight recent efforts more heavily within the window so a peak ride from week 1 doesn't outweigh week 12.</li>
+      <li><strong>Effort-quality flagging</strong> &mdash; only count an MMP as a "true" point if the activity's overall intensity suggests you were going hard; treat tempo-pace bests as soft data points.</li>
+      <li><strong>Fitness drift normalization</strong> &mdash; rescale older efforts by the ratio of estimated FTP then vs. now, so a year-old peak doesn't dominate.</li>
+      <li><strong>Manual fitness override</strong> &mdash; a way to tell Power Predict "ignore my zone-2 base block, I'm actually fitter than that suggests" via a CP override or a custom date range.</li>
+    </ul>
+
+    <p>Track these on the <a href="https://github.com/iammike/power-predict/milestones" target="_blank" rel="noopener">project milestones</a>.</p>
+  </main>
+
+  <footer class="site-footer">
+    <p><a href="../">&larr; Back to Power Predict</a></p>
+    <p>Independent project. Not endorsed by Strava.</p>
+  </footer>
+</body>
+</html>

--- a/docs/strava-archive-guide.html
+++ b/docs/strava-archive-guide.html
@@ -19,6 +19,7 @@
     </a>
     <nav class="site-nav" aria-label="Primary">
       <a href="../">Home</a>
+      <a href="methodology.html">Methodology</a>
       <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">Source</a>
     </nav>
   </header>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <span class="wordmark__predict">Predict</span>
     </a>
     <nav class="site-nav" aria-label="Primary">
+      <a href="docs/methodology.html">Methodology</a>
       <a href="docs/strava-archive-guide.html">Archive Guide</a>
       <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">Source</a>
     </nav>
@@ -60,7 +61,7 @@
 
   <footer class="site-footer">
     <p>Independent project. Not endorsed by Strava.</p>
-    <p>Built by <a href="https://iammike.org" target="_blank" rel="noopener">Mike Collins</a> · <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">GitHub</a></p>
+    <p>Built by <a href="https://iammike.org" target="_blank" rel="noopener">Mike Collins</a> · <a href="https://github.com/iammike/power-predict" target="_blank" rel="noopener">GitHub</a> · build <span id="build-version">…</span></p>
   </footer>
 
   <script src="dist/app.min.js"></script>

--- a/shared.css
+++ b/shared.css
@@ -517,14 +517,16 @@ main {
 .predict-form button:active { transform: translateY(1px); }
 
 .predict-output {
-  display: block;
+  display: none;
   margin-top: 1.5rem;
   padding: 1.25rem 1.5rem;
   background: var(--paper-soft);
   border: 1px solid var(--hair-strong);
   position: relative;
 }
-.predict-output::before, .predict-output::after {
+.predict-output:not([hidden]) { display: block; }
+.predict-output:not([hidden])::before,
+.predict-output:not([hidden])::after {
   content: "";
   position: absolute;
   width: 12px; height: 12px;
@@ -684,6 +686,23 @@ main {
   color: var(--ink);
   margin-bottom: 2rem;
   font-variation-settings: "opsz" 36;
+}
+
+.formula {
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  text-align: center;
+  margin: 1rem auto;
+  padding: 1rem 1.5rem;
+  border-top: var(--rule-soft);
+  border-bottom: var(--rule-soft);
+  color: var(--ink);
+  font-variation-settings: "opsz" 36;
+}
+.formula em {
+  font-style: italic;
+  color: var(--oxblood);
+  font-variation-settings: "opsz" 36, "SOFT" 80, "WONK" 1;
 }
 
 /* FOOTER */

--- a/src/app.js
+++ b/src/app.js
@@ -125,18 +125,44 @@ async function handleArchive(file) {
   renderCurves(all);
 }
 
-function setProgressPhase(phase, { bytesRead, totalBytes, activitiesSeen, parsedCount, withPower, skipped }) {
-  const pct = totalBytes ? Math.min(100, (bytesRead / totalBytes) * 100) : 0;
-  const readPart = `${phase}: ${formatBytes(bytesRead)} / ${formatBytes(totalBytes)} (${pct.toFixed(0)}%)`;
-  const parsePart = activitiesSeen
-    ? ` · ${parsedCount}/${activitiesSeen} parsed${withPower ? `, ${withPower} with power` : ''}${skipped ? `, ${skipped} cached` : ''}`
-    : '';
+// Throttle progress writes to one animation frame and update only the
+// cached text node + bar-fill style.width — calling this on every
+// fflate chunk would otherwise paint-storm the page.
+let progressTextNode = null;
+let progressBarFill = null;
+let progressFrameQueued = false;
+let progressLatest = null;
+
+function ensureProgressDom() {
   if (!progressEl) return;
-  progressEl.hidden = false;
+  if (progressTextNode && progressBarFill && progressEl.contains(progressTextNode)) return;
   progressEl.innerHTML = `
-    <span class="progress__text">${readPart}${parsePart}</span>
-    <span class="progress__bar"><span class="progress__bar-fill" style="width: ${pct}%"></span></span>
+    <span class="progress__text"></span>
+    <span class="progress__bar"><span class="progress__bar-fill"></span></span>
   `;
+  progressTextNode = progressEl.querySelector('.progress__text');
+  progressBarFill = progressEl.querySelector('.progress__bar-fill');
+}
+
+function setProgressPhase(phase, payload) {
+  if (!progressEl) return;
+  ensureProgressDom();
+  progressEl.hidden = false;
+  progressLatest = { phase, payload };
+  if (progressFrameQueued) return;
+  progressFrameQueued = true;
+  requestAnimationFrame(() => {
+    progressFrameQueued = false;
+    if (!progressLatest) return;
+    const { phase, payload: p } = progressLatest;
+    const pct = p.totalBytes ? Math.min(100, (p.bytesRead / p.totalBytes) * 100) : 0;
+    const readPart = `${phase}: ${formatBytes(p.bytesRead)} / ${formatBytes(p.totalBytes)} (${pct.toFixed(0)}%)`;
+    const parsePart = p.activitiesSeen
+      ? ` · ${p.parsedCount}/${p.activitiesSeen} parsed${p.withPower ? `, ${p.withPower} with power` : ''}${p.skipped ? `, ${p.skipped} cached` : ''}`
+      : '';
+    progressTextNode.textContent = `${readPart}${parsePart}`;
+    progressBarFill.style.width = `${pct}%`;
+  });
 }
 
 function formatBytes(bytes) {
@@ -280,6 +306,34 @@ async function handleClearCache() {
 
 function setProgress(msg) {
   if (!progressEl) return;
+  // Reset cached refs so subsequent setProgressPhase rebuilds the DOM.
+  progressTextNode = null;
+  progressBarFill = null;
   progressEl.textContent = msg;
   progressEl.hidden = false;
 }
+
+// Build/version tag in the footer so we can confirm a deploy landed.
+// version.json is written by the deploy workflow at build time.
+(async () => {
+  const el = document.getElementById('build-version');
+  if (!el) return;
+  try {
+    const res = await fetch('version.json', { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const v = await res.json();
+    if (v?.commit) {
+      el.textContent = v.commit;
+      if (v.url) {
+        const a = document.createElement('a');
+        a.href = v.url;
+        a.target = '_blank';
+        a.rel = 'noopener';
+        a.textContent = v.commit;
+        el.replaceChildren(a);
+      }
+    }
+  } catch {
+    el.textContent = 'dev';
+  }
+})();

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -68,16 +68,43 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
   };
 }
 
-// Predict sustainable power for a target duration.
-// Returns { powerW, low, high, extrapolated, fit } or null.
+// Riegel-style fatigue decay applied beyond the CP-validity window.
+//   P(t) = P_anchor × (t_anchor / t)^k
+// With k ≈ 0.07 for trained cyclists (Skiba), this matches Coggan's
+// observed power profile: 1h ≈ 95% CP, 4h ≈ 85%, 8h ≈ 75%. Without
+// the decay, the raw CP model asymptotes at CP and badly overpredicts
+// for endurance durations.
 //
-// The band is built from the fit's RMSE plus an extrapolation penalty:
-// the further outside [minObservedS, maxObservedS] the target sits,
-// the wider the band gets. The penalty grows linearly with log(t/edge).
-export function predictPower(fit, durationS) {
-  if (!fit || !Number.isFinite(durationS) || durationS <= 0) return null;
+// References:
+//   - Riegel, "Athletic Records and Human Endurance" (1981)
+//   - Skiba, Scientific Training for Endurance Athletes
+//   - Coggan, Training and Racing with a Power Meter
+export const DEFAULT_DECAY = {
+  fromS: 1200,  // top of standard CP fitting window (20 min)
+  k: 0.07,
+};
 
-  const powerW = fit.cpW + fit.wPrimeJ / durationS;
+// Predict sustainable power for a target duration.
+// Returns { powerW, low, high, extrapolated, fit, decayed } or null.
+//
+// Pass `opts.decay = false` to disable fatigue decay (raw 2-param CP);
+// pass `opts.decay = { fromS, k }` to override.
+//
+// The confidence band is the fit RMSE plus an extrapolation penalty
+// that grows logarithmically with how far the target sits outside
+// the observed MMP range.
+export function predictPower(fit, durationS, opts = {}) {
+  if (!fit || !Number.isFinite(durationS) || durationS <= 0) return null;
+  const decay = opts.decay === false ? null : { ...DEFAULT_DECAY, ...(opts.decay || {}) };
+
+  let powerW = fit.cpW + fit.wPrimeJ / durationS;
+  let decayed = false;
+  if (decay && durationS > decay.fromS) {
+    const anchorPower = fit.cpW + fit.wPrimeJ / decay.fromS;
+    powerW = anchorPower * (decay.fromS / durationS) ** decay.k;
+    decayed = true;
+  }
+
   let extrapolated = false;
   let extrapolationPenalty = 0;
   if (durationS < fit.minObservedS) {
@@ -94,6 +121,7 @@ export function predictPower(fit, durationS) {
     low: powerW - halfBand,
     high: powerW + halfBand,
     extrapolated,
+    decayed,
     fit,
   };
 }

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -48,13 +48,37 @@ describe('fitCp2', () => {
 describe('predictPower', () => {
   const fit = fitCp2(synth(280, 22000, [180, 300, 600, 900, 1200]));
 
-  it('predicts P = CP + W/t', () => {
-    const out = predictPower(fit, 2700); // 45 min
-    expect(out.powerW).toBeCloseTo(280 + 22000 / 2700, 3);
+  it('predicts P = CP + W\'/t inside the CP window when decay is disabled', () => {
+    const out = predictPower(fit, 600, { decay: false });
+    expect(out.powerW).toBeCloseTo(280 + 22000 / 600, 3);
+    expect(out.decayed).toBe(false);
+  });
+
+  it('applies Riegel fatigue decay beyond the decay threshold', () => {
+    const out = predictPower(fit, 3600); // 60 min
+    // anchor at 20 min: 280 + 22000/1200 = 298.33
+    // decay factor: (1200/3600)^0.07 = 0.9255
+    // expected: 298.33 * 0.9255 ≈ 276.1
+    expect(out.decayed).toBe(true);
+    expect(out.powerW).toBeCloseTo(298.333 * (1200 / 3600) ** 0.07, 2);
+    // And critically: well below CP, matching Coggan's ~95% CP at 1h.
+    expect(out.powerW).toBeLessThan(fit.cpW);
+  });
+
+  it('respects an explicit decay override', () => {
+    const aggressive = predictPower(fit, 7200, { decay: { fromS: 600, k: 0.10 } });
+    const standard = predictPower(fit, 7200);
+    expect(aggressive.powerW).toBeLessThan(standard.powerW);
+  });
+
+  it('does not decay below the threshold', () => {
+    const out = predictPower(fit, 900); // 15 min, inside CP window
+    expect(out.decayed).toBe(false);
+    expect(out.powerW).toBeCloseTo(280 + 22000 / 900, 3);
   });
 
   it('flags extrapolation outside the observed range', () => {
-    const longer = predictPower(fit, 3600); // 60m, beyond max observed 1200s
+    const longer = predictPower(fit, 3600);
     expect(longer.extrapolated).toBe(true);
     expect(longer.high - longer.low).toBeGreaterThan(0);
 
@@ -70,8 +94,8 @@ describe('predictPower', () => {
   });
 
   it('confidence band widens as duration moves further outside observed range', () => {
-    const just = predictPower(fit, 1500);   // a bit outside
-    const far = predictPower(fit, 7200);    // way outside
+    const just = predictPower(fit, 1500);
+    const far = predictPower(fit, 7200);
     expect(far.high - far.low).toBeGreaterThan(just.high - just.low);
   });
 });


### PR DESCRIPTION
Bundles four fixes/additions reported in testing.

## 1. Empty predict-output box
`<output id="predict-output" hidden>` was showing as an empty bordered box because the `.predict-output` CSS rule used `display: block`, which overrides the `hidden` attribute. Default `display: none`; reveal via `:not([hidden])`.

## 2. Build version tag
Build SHA shown in the footer, fetched from `/version.json` at runtime. The deploy workflow already writes that file. Locally falls back to "dev". Lets us verify what's actually deployed.

## 3. rAF-throttled progress
Re-applies the responsive-UI fix that didn't make it through PR #33's squash merge. Bar fill is cached and updated once per animation frame; the read loop no longer paint-storms.

## 4. Fatigue decay (resolves "8h prediction = CP" issue)
Raw 2-param CP asymptotes to CP — the model says you can hold 307 W for 8 hours, which is wrong. Add a Riegel-style decay applied beyond the 20-min CP-validity window:

```
P(t) = P_anchor × (t_anchor / t)^k
```

with `t_anchor = 1200 s`, `k = 0.07` (Skiba). Matches Coggan's empirical 1h ≈ 95% CP, 4h ≈ 85%, 8h ≈ 75% profile.

For a 307 W CP / 22 kJ W' rider:
- Before: 1h 313 W · 4h 308 W · 8h 308 W
- After: 1h 287 W · 4h 263 W · 8h 251 W

Decay can be tuned or disabled via `predictPower(fit, t, { decay: { fromS, k } })` or `{ decay: false }`.

## 5. Methodology doc
New `docs/methodology.html` explains the full pipeline: per-activity MMP extraction → rolling-best aggregation → 2-param CP fit → fatigue decay. Includes the formulas, a comparison to Coggan's observed power profile, references (Riegel 1981, Skiba, Coggan & Allen, Monod & Scherrer 1965, Hill 1925), and a section on planned improvements (recency weighting, effort-quality flagging, fitness drift, manual override).

## Test plan
- [ ] Pull branch, drop archive — empty box no longer appears between table and form
- [ ] Footer shows build SHA (or "dev" locally); after deploy, the SHA links to the commit
- [ ] Refresh during a big-archive parse: progress bar moves smoothly, page stays interactive
- [ ] Enter `4h` in predict — wattage should be ~85% of CP, not ≈ CP
- [ ] Visit `/docs/methodology.html`