### PR TITLE
Fix stuck progress bar and version-tag null error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -125,44 +125,39 @@ async function handleArchive(file) {
   renderCurves(all);
 }
 
-// Throttle progress writes to one animation frame and update only the
-// cached text node + bar-fill style.width — calling this on every
-// fflate chunk would otherwise paint-storm the page.
-let progressTextNode = null;
-let progressBarFill = null;
-let progressFrameQueued = false;
-let progressLatest = null;
-
-function ensureProgressDom() {
-  if (!progressEl) return;
-  if (progressTextNode && progressBarFill && progressEl.contains(progressTextNode)) return;
-  progressEl.innerHTML = `
-    <span class="progress__text"></span>
-    <span class="progress__bar"><span class="progress__bar-fill"></span></span>
-  `;
-  progressTextNode = progressEl.querySelector('.progress__text');
-  progressBarFill = progressEl.querySelector('.progress__bar-fill');
-}
+// Throttle progress writes via timestamp (not rAF — rAF doesn't fire
+// when the main thread is blocked, leaving the bar permanently stuck).
+// Re-query the inner DOM each call rather than caching refs, since
+// caching across setProgress() resets was racy.
+let lastProgressUpdate = 0;
+const PROGRESS_THROTTLE_MS = 50;
 
 function setProgressPhase(phase, payload) {
   if (!progressEl) return;
-  ensureProgressDom();
+  const now = performance.now ? performance.now() : Date.now();
+  const isComplete = payload.totalBytes && payload.bytesRead >= payload.totalBytes;
+  const isFirst = !progressEl.querySelector('.progress__bar');
+  if (!isComplete && !isFirst && now - lastProgressUpdate < PROGRESS_THROTTLE_MS) return;
+  lastProgressUpdate = now;
+
+  if (isFirst) {
+    progressEl.innerHTML =
+      '<span class="progress__text"></span>' +
+      '<span class="progress__bar"><span class="progress__bar-fill"></span></span>';
+  }
   progressEl.hidden = false;
-  progressLatest = { phase, payload };
-  if (progressFrameQueued) return;
-  progressFrameQueued = true;
-  requestAnimationFrame(() => {
-    progressFrameQueued = false;
-    if (!progressLatest) return;
-    const { phase, payload: p } = progressLatest;
-    const pct = p.totalBytes ? Math.min(100, (p.bytesRead / p.totalBytes) * 100) : 0;
-    const readPart = `${phase}: ${formatBytes(p.bytesRead)} / ${formatBytes(p.totalBytes)} (${pct.toFixed(0)}%)`;
-    const parsePart = p.activitiesSeen
-      ? ` · ${p.parsedCount}/${p.activitiesSeen} parsed${p.withPower ? `, ${p.withPower} with power` : ''}${p.skipped ? `, ${p.skipped} cached` : ''}`
-      : '';
-    progressTextNode.textContent = `${readPart}${parsePart}`;
-    progressBarFill.style.width = `${pct}%`;
-  });
+
+  const pct = payload.totalBytes ? Math.min(100, (payload.bytesRead / payload.totalBytes) * 100) : 0;
+  const readPart =
+    `${phase}: ${formatBytes(payload.bytesRead)} / ${formatBytes(payload.totalBytes)} (${pct.toFixed(0)}%)`;
+  const parsePart = payload.activitiesSeen
+    ? ` · ${payload.parsedCount}/${payload.activitiesSeen} parsed${payload.withPower ? `, ${payload.withPower} with power` : ''}${payload.skipped ? `, ${payload.skipped} cached` : ''}`
+    : '';
+
+  const textEl = progressEl.querySelector('.progress__text');
+  const fillEl = progressEl.querySelector('.progress__bar-fill');
+  if (textEl) textEl.textContent = `${readPart}${parsePart}`;
+  if (fillEl) fillEl.style.width = `${pct}%`;
 }
 
 function formatBytes(bytes) {
@@ -306,9 +301,6 @@ async function handleClearCache() {
 
 function setProgress(msg) {
   if (!progressEl) return;
-  // Reset cached refs so subsequent setProgressPhase rebuilds the DOM.
-  progressTextNode = null;
-  progressBarFill = null;
   progressEl.textContent = msg;
   progressEl.hidden = false;
 }
@@ -316,24 +308,34 @@ function setProgress(msg) {
 // Build/version tag in the footer so we can confirm a deploy landed.
 // version.json is written by the deploy workflow at build time.
 (async () => {
-  const el = document.getElementById('build-version');
-  if (!el) return;
   try {
-    const res = await fetch('version.json', { cache: 'no-store' });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const v = await res.json();
-    if (v?.commit) {
-      el.textContent = v.commit;
-      if (v.url) {
-        const a = document.createElement('a');
-        a.href = v.url;
-        a.target = '_blank';
-        a.rel = 'noopener';
-        a.textContent = v.commit;
-        el.replaceChildren(a);
+    const el = document.getElementById('build-version');
+    if (!el) return;
+    let text = 'dev';
+    let href = null;
+    try {
+      const res = await fetch('version.json', { cache: 'no-store' });
+      if (res.ok) {
+        const v = await res.json();
+        if (v?.commit) {
+          text = v.commit;
+          href = v.url || null;
+        }
       }
+    } catch { /* keep "dev" */ }
+    const live = document.getElementById('build-version');
+    if (!live) return;
+    if (href) {
+      const a = document.createElement('a');
+      a.href = href;
+      a.target = '_blank';
+      a.rel = 'noopener';
+      a.textContent = text;
+      live.replaceChildren(a);
+    } else {
+      live.textContent = text;
     }
-  } catch {
-    el.textContent = 'dev';
+  } catch (err) {
+    console.warn('build version tag failed', err);
   }
 })();


### PR DESCRIPTION
Fixes the symptoms reported on the live site: bar never appeared, console threw \`Cannot set properties of null (setting 'textContent')\`.

## Root causes
1. **rAF doesn't fire when the main thread is blocked.** fflate's inflate, when the Worker fallback engages, runs synchronously. The first chunk could block long enough that the queued rAF never paints. Switch to 50 ms timestamp throttling — the next chunk after the threshold always writes.
2. **Cached element refs went stale across `setProgress()` resets.** The race produced null reads inside the rAF callback. Re-query the inner spans on every update; cheap, no cache invalidation to get wrong.
3. **Version-tag IIFE caught error path could write to a stale ref.** Re-fetch `#build-version` after the async hop and guard each `textContent` set.

## Test plan
- [ ] Pull branch, drop the 1.8 GB archive
- [ ] Bar appears immediately with "Reading 0 B / 1.8 GB"
- [ ] Bytes count increases smoothly, fill grows in real time
- [ ] Console clean — no \`Cannot set properties of null\` errors
- [ ] Footer continues to show the build SHA