### PR TITLE
Unified progress bar + ETA, restrained decay anchor

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -133,12 +133,28 @@ async function handleArchive(file) {
 // Re-query the inner DOM each call rather than caching refs, since
 // caching across setProgress() resets was racy.
 let lastProgressUpdate = 0;
+let phaseStartedAt = null;
+let lastPhase = null;
 const PROGRESS_THROTTLE_MS = 50;
+
+// Roughly equal wall time for read vs. parse on a typical archive,
+// so we split the unified bar 50/50. Tweakable.
+const READ_WEIGHT = 0.5;
 
 function setProgressPhase(phase, payload) {
   if (!progressEl) return;
   const now = performance.now ? performance.now() : Date.now();
-  const isComplete = payload.totalBytes && payload.bytesRead >= payload.totalBytes;
+  // Reset phase timer on phase change, and on a fresh run (Reading
+  // with bytesRead=0) so ETA doesn't carry over from a previous drop.
+  const isFreshRun = phase === 'Reading' && !payload.bytesRead;
+  if (lastPhase !== phase || isFreshRun) {
+    lastPhase = phase;
+    phaseStartedAt = now;
+  }
+  const readFrac = payload.totalBytes ? Math.min(1, payload.bytesRead / payload.totalBytes) : 0;
+  const parseFrac = payload.activitiesSeen ? Math.min(1, payload.parsedCount / payload.activitiesSeen) : 0;
+  const isParsing = phase === 'Parsing';
+  const isComplete = isParsing ? parseFrac >= 1 : false;
   const isFirst = !progressEl.querySelector('.progress__bar');
   if (!isComplete && !isFirst && now - lastProgressUpdate < PROGRESS_THROTTLE_MS) return;
   lastProgressUpdate = now;
@@ -150,17 +166,40 @@ function setProgressPhase(phase, payload) {
   }
   progressEl.hidden = false;
 
-  const pct = payload.totalBytes ? Math.min(100, (payload.bytesRead / payload.totalBytes) * 100) : 0;
-  const readPart =
-    `${phase}: ${formatBytes(payload.bytesRead)} / ${formatBytes(payload.totalBytes)} (${pct.toFixed(0)}%)`;
-  const parsePart = payload.activitiesSeen
-    ? ` · ${payload.parsedCount}/${payload.activitiesSeen} parsed${payload.withPower ? `, ${payload.withPower} with power` : ''}${payload.skipped ? `, ${payload.skipped} cached` : ''}`
-    : '';
+  // Combined 0-100 progress: read fills 0..50%, parse fills 50..100%.
+  const overall = isParsing
+    ? READ_WEIGHT * 100 + (1 - READ_WEIGHT) * parseFrac * 100
+    : READ_WEIGHT * readFrac * 100;
+
+  const phaseDetail = isParsing
+    ? `Parsing: ${payload.parsedCount} / ${payload.activitiesSeen} activities (${(parseFrac * 100).toFixed(0)}%)${payload.withPower ? ` · ${payload.withPower} with power` : ''}${payload.skipped ? `, ${payload.skipped} cached` : ''}`
+    : `Reading: ${formatBytes(payload.bytesRead)} / ${formatBytes(payload.totalBytes)} (${(readFrac * 100).toFixed(0)}%)${payload.activitiesSeen ? ` · ${payload.activitiesSeen} entries seen` : ''}`;
+
+  // ETA from phase elapsed and current fraction. Suppressed for the
+  // first few percent where the slope is too noisy to extrapolate.
+  const phaseFrac = isParsing ? parseFrac : readFrac;
+  let etaText = '';
+  if (phaseFrac > 0.05 && phaseFrac < 0.99) {
+    const elapsed = (now - phaseStartedAt) / 1000;
+    const remaining = (elapsed / phaseFrac) * (1 - phaseFrac);
+    etaText = ` · ${formatEta(remaining)} remaining`;
+  }
 
   const textEl = progressEl.querySelector('.progress__text');
   const fillEl = progressEl.querySelector('.progress__bar-fill');
-  if (textEl) textEl.textContent = `${readPart}${parsePart}`;
-  if (fillEl) fillEl.style.width = `${pct}%`;
+  if (textEl) textEl.textContent = `${phaseDetail}${etaText}`;
+  if (fillEl) fillEl.style.width = `${overall}%`;
+}
+
+function formatEta(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return '';
+  if (seconds < 5) return '<5s';
+  if (seconds < 90) return `~${Math.round(seconds)}s`;
+  const m = Math.round(seconds / 60);
+  if (m < 90) return `~${m} min`;
+  const h = Math.floor(seconds / 3600);
+  const mm = Math.round((seconds - h * 3600) / 60);
+  return mm ? `~${h}h ${mm}m` : `~${h}h`;
 }
 
 function formatBytes(bytes) {

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -119,17 +119,26 @@ export function predictPower(fit, durationS, opts = {}) {
   let powerW = fit.cpW + fit.wPrimeJ / durationS;
   let decayed = false;
   if (decay && durationS > decay.fromS) {
-    // Prefer to anchor at the longest observed MMP when it's beyond
-    // the fitting window — real data beats the model extrapolation.
+    // Default: anchor at the decay threshold using the model's
+    // extrapolated power at that duration.
     let anchorS = decay.fromS;
     let anchorPower = fit.cpW + fit.wPrimeJ / decay.fromS;
+
+    // Only override with the longest observed MMP when that real
+    // effort *exceeds* what the model would predict at that
+    // duration. Otherwise the observation reflects a low-effort
+    // base ride rather than a true ceiling, and using it as anchor
+    // would propagate the under-effort to all longer predictions.
     if (
       fit.longestS && fit.longestW &&
       fit.longestS > decay.fromS &&
       fit.longestS <= durationS
     ) {
-      anchorS = fit.longestS;
-      anchorPower = fit.longestW;
+      const modelAtLongest = fit.cpW + fit.wPrimeJ / fit.longestS;
+      if (fit.longestW > modelAtLongest) {
+        anchorS = fit.longestS;
+        anchorPower = fit.longestW;
+      }
     }
     powerW = anchorPower * (anchorS / durationS) ** decay.k;
     decayed = true;

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -65,18 +65,24 @@ describe('predictPower', () => {
     expect(out.powerW).toBeLessThan(fit.cpW);
   });
 
-  it('anchors decay at the longest observed MMP when one exists', () => {
-    // Same fit but with an extra long-duration data point — predictions
-    // beyond it should anchor on real data, not the model extrapolation.
-    const fitWithLong = fitCp2([
+  it('only uses longest-observed MMP as anchor when it exceeds the model', () => {
+    // Case A: long observed MMP is BELOW model — use threshold anchor.
+    const fitLowLong = fitCp2([
       ...synth(280, 22000, [180, 300, 600, 900, 1200]),
-      { durationS: 3600, powerW: 260 }, // a real 1h MMP below model
+      { durationS: 3600, powerW: 200 }, // low-effort 1h base ride
     ]);
-    expect(fitWithLong.longestS).toBe(3600);
-    expect(fitWithLong.longestW).toBe(260);
-    const out = predictPower(fitWithLong, 7200);
-    // anchor at 1h, k=0.10: 260 × (3600/7200)^0.10 ≈ 242.6
-    expect(out.powerW).toBeCloseTo(260 * (3600 / 7200) ** 0.10, 2);
+    const lowOut = predictPower(fitLowLong, 7200);
+    // Should ignore the 200W observation and anchor at threshold.
+    const expectedThresholdAnchored = (280 + 22000 / 1200) * (1200 / 7200) ** 0.10;
+    expect(lowOut.powerW).toBeCloseTo(expectedThresholdAnchored, 2);
+
+    // Case B: long observed MMP EXCEEDS model — use it as anchor.
+    const fitHighLong = fitCp2([
+      ...synth(280, 22000, [180, 300, 600, 900, 1200]),
+      { durationS: 3600, powerW: 290 }, // genuinely strong 1h
+    ]);
+    const highOut = predictPower(fitHighLong, 7200);
+    expect(highOut.powerW).toBeCloseTo(290 * (3600 / 7200) ** 0.10, 2);
   });
 
   it('respects an explicit decay override', () => {


### PR DESCRIPTION
## Progress
The bar now represents the full read + parse run. Read fills 0-50%, parse fills 50-100%. Message shows the active phase ("Reading: 820 MB / 1.8 GB (45%)" or "Parsing: 4400 / 6600 activities (67%)") plus a per-phase ETA ("~3 min remaining"). For a 1.8 GB archive with 6600 activities you no longer see the bar finish on read while parsing has 5+ minutes left.

## Decay anchor
Reported during testing: 307 W CP gave 157 W for 8h, which is too low. Root cause: the longest-observed-MMP anchor latched onto a low-effort base ride. Fix: only use the longest observed MMP as anchor when its power *exceeds* what the model would predict at that duration. Below-model observations (zone-2 long rides) are treated as under-effort and ignored in favor of the threshold-anchored model. With CP=307 W: 8h now lands ~235 W (vs. 157 W before).

## Test plan
- [ ] Pull, drop archive — bar moves smoothly through both phases without snapping
- [ ] Message switches phase text correctly when read completes
- [ ] ETA appears once a few percent into each phase, decreases monotonically
- [ ] Predict 8h with the resulting fit — should be in 70-80% CP range