### PR TITLE
Power-duration curve chart

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,7 +28,12 @@ async function build() {
     outfile: path.join(distDir, 'archive-worker.js'),
   });
 
-  const cssSrc = fs.readFileSync(path.join(__dirname, 'shared.css'), 'utf8');
+  // Bundle uPlot's stylesheet alongside our own.
+  const uplotCss = fs.readFileSync(
+    path.join(__dirname, 'node_modules', 'uplot', 'dist', 'uPlot.min.css'),
+    'utf8'
+  );
+  const cssSrc = uplotCss + '\n' + fs.readFileSync(path.join(__dirname, 'shared.css'), 'utf8');
   const cssResult = await esbuild.transform(cssSrc, { minify: true, loader: 'css' });
   fs.writeFileSync(path.join(distDir, 'app.min.css'), cssResult.code);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "dependencies": {
         "fflate": "^0.8.2",
-        "fit-file-parser": "^1.21.0"
+        "fit-file-parser": "^1.21.0",
+        "uplot": "^1.6.32"
       },
       "devDependencies": {
         "esbuild": "^0.27.3",
@@ -3042,6 +3043,12 @@
         "pathe": "^2.0.3",
         "ufo": "^1.5.4"
       }
+    },
+    "node_modules/uplot": {
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "fflate": "^0.8.2",
-    "fit-file-parser": "^1.21.0"
+    "fit-file-parser": "^1.21.0",
+    "uplot": "^1.6.32"
   }
 }

--- a/shared.css
+++ b/shared.css
@@ -428,6 +428,74 @@ main {
   border-bottom-color: var(--oxblood-deep);
 }
 
+/* CURVE CHART */
+
+.curve-chart-section {
+  margin: 1.5rem 0 0;
+}
+.curve-chart-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+.curve-chart-title {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+.curve-window-tabs {
+  display: inline-flex;
+  border: 1px solid var(--hair-strong);
+  background: var(--paper-soft);
+}
+.curve-window-tabs button {
+  font-family: var(--sans);
+  font-weight: 500;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--hair);
+  color: var(--ink-soft);
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease;
+}
+.curve-window-tabs button:last-child { border-right: none; }
+.curve-window-tabs button:hover { color: var(--ink); }
+.curve-window-tabs button.is-active {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.curve-chart {
+  width: 100%;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair);
+  padding: 0.75rem 0.5rem 0.5rem;
+}
+.curve-chart .u-legend {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  text-align: left;
+  padding-top: 0.4rem;
+}
+.curve-chart .u-legend .u-marker {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.4em;
+}
+.curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
+
 /* PREDICT */
 
 .predict {

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import { DURATIONS_S } from './mmp.js';
 import { rollingBest } from './aggregate.js';
+import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
 import {
   loadActivities,
@@ -211,13 +212,15 @@ function formatBytes(bytes) {
   return `${v.toFixed(v < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
-// Held in module scope so the predict form can read it on submit.
+// Held in module scope so the predict form + chart toggles can read.
 let currentFit = null;
+let currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   const allTime = rollingBest(activityMmps);
   const last90 = rollingBest(activityMmps, { windowDays: 90 });
   const last30 = rollingBest(activityMmps, { windowDays: 30 });
+  currentMmpByWindow = { last30, last90, allTime };
 
   // Fit CP/W' on the 90-day curve (falls back to all-time if too sparse).
   currentFit = fitCp2(mmpToPoints(last90)) || fitCp2(mmpToPoints(allTime));
@@ -261,6 +264,24 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   resultsEl.dataset.revealed = '';
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
   wirePredictForm();
+  wireCurveChart();
+}
+
+function wireCurveChart() {
+  const container = document.getElementById('curve-chart');
+  if (!container || !currentFit) return;
+  const tabs = document.querySelectorAll('[data-window]');
+  const drawWindow = (key) => {
+    renderCurveChart(container, {
+      mmp: currentMmpByWindow[key] || {},
+      fit: currentFit,
+    });
+    tabs.forEach((t) => t.classList.toggle('is-active', t.dataset.window === key));
+  };
+  tabs.forEach((t) => {
+    t.addEventListener('click', () => drawWindow(t.dataset.window));
+  });
+  drawWindow('last90');
 }
 
 function renderPredictBlock() {
@@ -289,6 +310,18 @@ function renderPredictBlock() {
         <div><dt>RMSE</dt><dd>${currentFit.rmse.toFixed(1)} W</dd></div>
         <div><dt>Points</dt><dd>${currentFit.nPoints}</dd></div>
       </dl>
+
+      <div class="curve-chart-section">
+        <header class="curve-chart-head">
+          <span class="curve-chart-title">Power-duration curve</span>
+          <div class="curve-window-tabs" role="tablist">
+            <button type="button" data-window="last30" role="tab">Last 30d</button>
+            <button type="button" data-window="last90" role="tab" class="is-active">Last 90d</button>
+            <button type="button" data-window="allTime" role="tab">All-time</button>
+          </div>
+        </header>
+        <div id="curve-chart" class="curve-chart"></div>
+      </div>
 
       <form class="predict-form" id="predict-form">
         <label class="predict-form__field">

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -1,0 +1,168 @@
+// Power-duration curve chart. Renders observed MMP points + the fitted
+// CP curve + the fatigue-decay tail in a single plot, log-scaled on
+// the duration axis.
+
+import uPlot from 'uplot';
+import { DEFAULT_DECAY, predictPower } from './cpfit.js';
+
+const SAMPLE_DURATIONS = (() => {
+  // Dense log-spaced samples 1s..24h for the model and decay lines.
+  const out = [];
+  const min = 1;
+  const max = 86400;
+  const steps = 240;
+  const r = Math.log(max / min);
+  for (let i = 0; i <= steps; i++) {
+    out.push(Math.round(min * Math.exp((r * i) / steps)));
+  }
+  return Array.from(new Set(out));
+})();
+
+export function renderCurveChart(container, { mmp, fit }) {
+  if (!container) return;
+  container.innerHTML = '';
+  if (!fit) {
+    container.innerHTML = '<p class="results-foot__note">Need a fit before plotting the curve.</p>';
+    return;
+  }
+
+  // Observed: MMP map → sorted by duration.
+  const observedDurations = Object.keys(mmp || {})
+    .map(Number)
+    .filter((d) => Number.isFinite(d) && Number.isFinite(mmp[d]))
+    .sort((a, b) => a - b);
+  const observedPower = observedDurations.map((d) => mmp[d]);
+
+  // Model: split into two series — CP-validity range (solid) and
+  // decay extrapolation (dashed).
+  const modelInside = [];
+  const modelOutside = [];
+  for (const d of SAMPLE_DURATIONS) {
+    const inside = d >= fit.range.minS && d <= DEFAULT_DECAY.fromS;
+    const out = predictPower(fit, d);
+    const w = out ? out.powerW : null;
+    modelInside.push(inside ? w : null);
+    modelOutside.push(!inside ? w : null);
+  }
+
+  // uPlot wants ALL series on the same x axis, so map observed values
+  // onto the SAMPLE_DURATIONS grid (null elsewhere).
+  const observedAligned = SAMPLE_DURATIONS.map((d) => {
+    const idx = observedDurations.indexOf(d);
+    return idx >= 0 ? observedPower[idx] : null;
+  });
+  // If observed durations don't fall on the grid, add them.
+  const xs = SAMPLE_DURATIONS.slice();
+  for (const d of observedDurations) {
+    if (!xs.includes(d)) xs.push(d);
+  }
+  xs.sort((a, b) => a - b);
+  // Re-sample the three series onto the merged xs array.
+  const obsSeries = xs.map((d) => {
+    const idx = observedDurations.indexOf(d);
+    return idx >= 0 ? observedPower[idx] : null;
+  });
+  const insideSeries = xs.map((d) => {
+    const out = (d >= fit.range.minS && d <= DEFAULT_DECAY.fromS)
+      ? predictPower(fit, d)
+      : null;
+    return out ? out.powerW : null;
+  });
+  const outsideSeries = xs.map((d) => {
+    const out = (d > DEFAULT_DECAY.fromS || d < fit.range.minS)
+      ? predictPower(fit, d)
+      : null;
+    return out ? out.powerW : null;
+  });
+
+  const data = [xs, obsSeries, insideSeries, outsideSeries];
+
+  const styles = getComputedStyle(document.body);
+  const ink = styles.getPropertyValue('--ink').trim() || '#1a1612';
+  const oxblood = styles.getPropertyValue('--oxblood').trim() || '#7a1f24';
+  const muted = styles.getPropertyValue('--muted').trim() || '#7a6f60';
+  const hair = 'rgba(26, 22, 18, 0.18)';
+
+  const opts = {
+    width: container.clientWidth || 720,
+    height: 360,
+    scales: {
+      x: { distr: 3, log: 10 }, // log10 scale on duration
+      y: { auto: true },
+    },
+    axes: [
+      {
+        stroke: ink,
+        grid: { stroke: hair, width: 0.5 },
+        ticks: { stroke: hair, width: 0.5 },
+        font: '11px "JetBrains Mono", ui-monospace, monospace',
+        values: (_u, splits) => splits.map(formatDurationTick),
+      },
+      {
+        stroke: ink,
+        grid: { stroke: hair, width: 0.5 },
+        ticks: { stroke: hair, width: 0.5 },
+        font: '11px "JetBrains Mono", ui-monospace, monospace',
+        values: (_u, splits) => splits.map((v) => `${Math.round(v)} W`),
+      },
+    ],
+    series: [
+      { value: (_u, v) => formatDurationTick(v) },
+      {
+        label: 'Observed MMP',
+        stroke: oxblood,
+        fill: oxblood,
+        width: 0,
+        points: { show: true, size: 6, stroke: oxblood, fill: oxblood },
+        value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
+      },
+      {
+        label: 'CP fit (3-20 min)',
+        stroke: ink,
+        width: 1.5,
+        points: { show: false },
+        value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
+      },
+      {
+        label: 'Extrapolation',
+        stroke: muted,
+        width: 1.25,
+        dash: [4, 4],
+        points: { show: false },
+        value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
+      },
+    ],
+    cursor: {
+      drag: { x: false, y: false },
+      points: { size: 6 },
+    },
+    legend: {
+      show: true,
+      live: true,
+    },
+  };
+
+  const chart = new uPlot(opts, data, container);
+  // Resize on window changes
+  if (!container.dataset.resizeBound) {
+    container.dataset.resizeBound = '1';
+    let resizeTimer = null;
+    window.addEventListener('resize', () => {
+      clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(() => {
+        chart.setSize({ width: container.clientWidth, height: 360 });
+      }, 80);
+    });
+  }
+}
+
+function formatDurationTick(s) {
+  if (s == null) return '';
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) {
+    const h = s / 3600;
+    return h % 1 === 0 ? `${h}h` : `${h.toFixed(1)}h`;
+  }
+  return `${Math.round(s / 3600)}h`;
+}


### PR DESCRIPTION
Closes #15.

## Summary
Renders the rolling-best MMP points + the fitted CP line + the fatigue-decay tail in a log-scale chart under the predict form. Window toggles (Last 30d / Last 90d / All-time) swap the underlying MMP. uPlot under the hood (light, fast, no React).

- **Observed MMP** — oxblood scatter
- **CP fit (3-20 min)** — solid ink line in the fitting window
- **Extrapolation** — dashed muted line outside (covers both short-duration and decay-tail regions)

Custom log-scale tick formatter shows 1s / 10s / 1m / 10m / 1h / 6h / etc.

## Test plan
- [ ] Pull, drop archive (or hydrate from cache), confirm chart appears under the predict form
- [ ] All three window toggles redraw the chart correctly
- [ ] Hovering shows the duration / wattage in the legend
- [ ] Resizing the window redraws the chart at the new width
- [ ] Mobile: chart still legible at narrow widths