### PR TITLE
Fix duplicate startTime + zero-padded "has power" detection

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,7 +54,11 @@ async function hydrateFromCache() {
 async function handleArchive(file) {
   setProgressPhase('Reading', { bytesRead: 0, totalBytes: file.size });
 
-  const newActivities = [];
+  // Dedupe by startTime (the IDB primary key) within this run. Two
+  // FIT files that share a start instant would otherwise both count
+  // as "with power" while only one survives in IDB.
+  const newActivities = new Map();
+  const seenStartTimes = new Set();
   let withPower = 0;
   let skipped = 0;
   let lastActivitiesSeen = 0;
@@ -68,8 +72,7 @@ async function handleArchive(file) {
         const msg = e.data;
         if (msg.type === 'progress') {
           lastActivitiesSeen = msg.activitiesSeen;
-          const phase = msg.phase === 'parsing' ? 'Parsing'
-            : msg.activitiesSeen > 0 ? 'Reading' : 'Reading';
+          const phase = msg.phase === 'parsing' ? 'Parsing' : 'Reading';
           setProgressPhase(phase, {
             bytesRead: msg.bytesRead,
             totalBytes: msg.totalBytes,
@@ -79,11 +82,13 @@ async function handleArchive(file) {
             skipped,
           });
         } else if (msg.type === 'activity') {
+          if (seenStartTimes.has(msg.startTime)) return;
+          seenStartTimes.add(msg.startTime);
           try {
             if (await hasActivity(msg.startTime)) {
               skipped++;
             } else {
-              newActivities.push({
+              newActivities.set(msg.startTime, {
                 startTime: msg.startTime,
                 durationS: msg.durationS,
                 distanceM: msg.distanceM,
@@ -110,9 +115,10 @@ async function handleArchive(file) {
   }
   worker.terminate();
 
-  if (newActivities.length > 0) {
-    setProgress(`Saving ${newActivities.length} new activities to local cache…`);
-    await saveActivities(newActivities);
+  const newList = Array.from(newActivities.values());
+  if (newList.length > 0) {
+    setProgress(`Saving ${newList.length} new activities to local cache…`);
+    await saveActivities(newList);
   }
 
   const all = await loadActivities();
@@ -124,7 +130,7 @@ async function handleArchive(file) {
   }
 
   setProgress(
-    `Done. ${all.length} activities cached locally (${newActivities.length} new this run, ${skipped} already cached, ${withPower} with power).`
+    `Done. ${all.length} activities cached locally (${newList.length} new this run, ${skipped} already cached, ${withPower} with power out of ${lastActivitiesSeen} activity files).`
   );
   renderCurves(all);
 }

--- a/src/fit.js
+++ b/src/fit.js
@@ -31,15 +31,24 @@ function toActivity(data) {
   const tEnd = +new Date(records[records.length - 1].timestamp);
   const durationS = Math.max(1, Math.round((tEnd - t0) / 1000) + 1);
 
+  // Build a 1Hz power stream and count how many samples actually
+  // carry positive power. Some FIT files written by non-power devices
+  // include power=0 in every record, which `typeof === 'number'` would
+  // count as "has power". Require enough non-zero samples to call it
+  // a real power-meter recording — at least 60 seconds' worth, and at
+  // least 5% of the activity's duration. Otherwise treat as no power.
   const powerStream = new Float32Array(durationS);
-  let hasPower = false;
+  let nonZeroSamples = 0;
   for (const r of records) {
     if (typeof r.power !== 'number') continue;
-    hasPower = true;
     const idx = Math.round((+new Date(r.timestamp) - t0) / 1000);
     if (idx >= 0 && idx < durationS) powerStream[idx] = r.power;
+    if (r.power > 0) nonZeroSamples++;
   }
-  if (!hasPower) return { startTime: t0, durationS, distanceM: lastDistance(records), powerStream: null };
+  const minSamples = Math.max(60, Math.floor(durationS * 0.05));
+  if (nonZeroSamples < minSamples) {
+    return { startTime: t0, durationS, distanceM: lastDistance(records), powerStream: null };
+  }
 
   return {
     startTime: t0,


### PR DESCRIPTION
Reported in testing: \`Done. 3017 activities cached locally (3022 new this run, 0 already cached, 3022 with power)\` — but the user has many non-power rides, so 3022 with-power was way too high, and the 3022/3017 mismatch is a counter bug.

## 1. Counter dedupe
Two FIT files sharing a start_time both incremented \`withPower\`, only one survived in IDB (last write wins on the keyPath). Switched newActivities to a \`Map\` keyed on startTime and added a \`seenStartTimes\` Set to skip duplicates at message receive time.

## 2. Real has-power detection
fit-file-parser emits \`power: 0\` records on activities recorded by non-power devices. The old check accepted any numeric power. Now require \`max(60s, 5% of duration)\` samples with \`power > 0\`. Removes the false positives.

## Test plan
- [ ] Drop archive, confirm \`with power\` count is now realistic (matches your power-meter ride history)
- [ ] \`X activities cached\` matches \`X new this run\` (assuming an empty cache)
- [ ] Re-drop the same archive, all entries report as already cached, withPower count stays consistent