### PR TITLE
Curve chart: drop fill on observed-MMP series

### DIFF
--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -131,8 +131,8 @@ export function renderCurveChart(container, { mmp, fit }) {
       {
         label: 'Observed MMP',
         stroke: oxblood,
-        fill: oxblood,
         width: 0,
+        spanGaps: false,
         points: { show: true, size: 6, stroke: oxblood, fill: oxblood },
         value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
       },


### PR DESCRIPTION
Series was meant to be points-only. The leftover `fill: oxblood` was filling the area to baseline between consecutive non-null observations, producing a big red rectangle at the left edge.