### PR TITLE
Has-power: add mean-power floor (≥30W)

### DIFF
--- a/src/fit.js
+++ b/src/fit.js
@@ -31,22 +31,32 @@ function toActivity(data) {
   const tEnd = +new Date(records[records.length - 1].timestamp);
   const durationS = Math.max(1, Math.round((tEnd - t0) / 1000) + 1);
 
-  // Build a 1Hz power stream and count how many samples actually
-  // carry positive power. Some FIT files written by non-power devices
-  // include power=0 in every record, which `typeof === 'number'` would
-  // count as "has power". Require enough non-zero samples to call it
-  // a real power-meter recording — at least 60 seconds' worth, and at
-  // least 5% of the activity's duration. Otherwise treat as no power.
+  // Build a 1Hz power stream and decide whether this is a real
+  // power-meter recording. Three failure modes to filter out:
+  //   1. No power field at all (typical for non-power devices).
+  //   2. Power field present but always 0 (some FIT writers do this).
+  //   3. Power field with sparse low non-zero values from
+  //      speed-or-HR-derived "estimated power" — looks numeric but
+  //      isn't a power meter. Filtered by requiring a non-trivial
+  //      mean across the whole activity.
   const powerStream = new Float32Array(durationS);
+  let totalPower = 0;
+  let powerSamples = 0;
   let nonZeroSamples = 0;
   for (const r of records) {
     if (typeof r.power !== 'number') continue;
     const idx = Math.round((+new Date(r.timestamp) - t0) / 1000);
     if (idx >= 0 && idx < durationS) powerStream[idx] = r.power;
+    powerSamples++;
+    totalPower += r.power;
     if (r.power > 0) nonZeroSamples++;
   }
-  const minSamples = Math.max(60, Math.floor(durationS * 0.05));
-  if (nonZeroSamples < minSamples) {
+  const minNonZero = Math.max(60, Math.floor(durationS * 0.05));
+  const meanPower = powerSamples ? totalPower / powerSamples : 0;
+  // Real rides easily exceed 30 W mean (Z1 spinning is ≥ 100 W for
+  // most riders); estimated-power activities hover near zero.
+  const MEAN_POWER_FLOOR_W = 30;
+  if (nonZeroSamples < minNonZero || meanPower < MEAN_POWER_FLOOR_W) {
     return { startTime: t0, durationS, distanceM: lastDistance(records), powerStream: null };
   }
 


### PR DESCRIPTION
Still seeing too many false positives — 6683 activity files were resolving to ~3000 with-power, vs. expected ~300. The non-zero-sample-count check accepted devices that emit estimated-power readings (low non-zero values from speed/HR). Adding a 30 W mean floor across the activity. Real rides clear it easily; estimated-power recordings don't.