### PR TITLE
Recency-weighted MMP for the CP fit; clarify metric semantics

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -48,6 +48,16 @@
 
     <p>Power Predict fits the model on Last 90 days by default and falls back to All time if 90 days has too few points in the fitting window.</p>
 
+    <h3>What "best" means</h3>
+
+    <p>Each value in the table is <strong>mean maximal power</strong>: the best rolling <em>average</em> power held for that duration in any activity in the window. It is not normalized power. A 20-minute MMP of 280 W means there is a 20-minute slice of one ride that averaged 280 W &mdash; nothing more.</p>
+
+    <h3>Recency weighting (for the fit, not the table)</h3>
+
+    <p>The display table shows the raw rolling-best across the window. The CP fit is different: each effort is weighted by an exponential decay on age, half-life 42 days. A modest 5-minute power from last week can outrank a peak 5-minute power from 8 weeks ago, because we trust recent data more as a signal of current form.</p>
+
+    <p>The fit returns the <em>raw</em> power of whichever effort wins this weighted contest, so predictions are still calibrated against actual achieved watts. The weighting only changes which efforts the fit listens to.</p>
+
     <h2>3. The Critical Power model</h2>
 
     <p>For durations from roughly 3 minutes to 20 minutes, sustainable power is well-described by the <strong>2-parameter Critical Power model</strong>:</p>

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -18,6 +18,46 @@ export function rollingBest(activityMmps, { windowDays = null, now = Date.now() 
   return best;
 }
 
+// Recency-weighted best. For each duration, every activity's MMP is
+// scaled by an exponential weight based on age — half-life
+// configurable, default 42 days (6 weeks). The activity with the
+// highest WEIGHTED power "wins" the duration; we return its RAW power.
+//
+// Why not return the weighted value? The fit needs realistic watts.
+// Weighting selects which effort to trust (a moderate recent ride can
+// outrank an old peak), but the prediction should still calibrate
+// against actual achieved power.
+//
+// Inside `windowDays`, this gives the CP fit a curve that responds to
+// current form: a 6-week-old super-effort no longer dominates if more
+// recent rides tell a different story.
+export function recencyWeightedBest(activityMmps, {
+  windowDays = null,
+  halfLifeDays = 42,
+  now = Date.now(),
+} = {}) {
+  const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
+  const halfLifeMs = halfLifeDays * 86400_000;
+  const ln2 = Math.log(2);
+  const winner = {}; // { [duration]: { raw, weighted } }
+  for (const { startTime, mmp } of activityMmps) {
+    if (startTime < cutoff) continue;
+    const ageMs = Math.max(0, now - startTime);
+    const weight = Math.exp((-ln2 * ageMs) / halfLifeMs);
+    for (const d of DURATIONS_S) {
+      const v = mmp[d];
+      if (typeof v !== 'number') continue;
+      const weighted = v * weight;
+      if (winner[d] === undefined || weighted > winner[d].weighted) {
+        winner[d] = { raw: v, weighted };
+      }
+    }
+  }
+  const out = {};
+  for (const d of Object.keys(winner)) out[d] = winner[d].raw;
+  return out;
+}
+
 // Average power for a stream segment (used for normalized power below).
 function rollingAverage(stream, windowSize) {
   if (stream.length < windowSize) return new Float32Array();

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { DURATIONS_S } from './mmp.js';
-import { rollingBest } from './aggregate.js';
+import { rollingBest, recencyWeightedBest } from './aggregate.js';
 import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
 import {
@@ -204,8 +204,12 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const last30 = rollingBest(activityMmps, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
-  // Fit CP/W' on the 90-day curve (falls back to all-time if too sparse).
-  currentFit = fitCp2(mmpToPoints(last90)) || fitCp2(mmpToPoints(allTime));
+  // The fit uses a recency-weighted aggregation of the 90-day window
+  // so a 6-week-old peak doesn't outweigh more recent (and possibly
+  // more representative) rides. Falls back to all-time if too sparse.
+  const last90Weighted = recencyWeightedBest(activityMmps, { windowDays: 90 });
+  const allTimeWeighted = recencyWeightedBest(activityMmps);
+  currentFit = fitCp2(mmpToPoints(last90Weighted)) || fitCp2(mmpToPoints(allTimeWeighted));
 
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)
@@ -221,7 +225,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   resultsEl.innerHTML = `
     <header class="results-head">
       <h2>Mean Maximal Power</h2>
-      <span class="results-head__meta">Watts · by duration</span>
+      <span class="results-head__meta">Best avg watts held · raw, not normalized</span>
     </header>
     <table class="mmp-table">
       <thead>
@@ -283,7 +287,7 @@ function renderPredictBlock() {
     <section class="predict">
       <header class="results-head">
         <h2>Predict</h2>
-        <span class="results-head__meta">Critical-power model · last 90 days</span>
+        <span class="results-head__meta">CP model · 90d window, recency-weighted (42d half-life)</span>
       </header>
 
       <dl class="fit-stats">

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { rollingBest, normalizedPower, avgPower } from '../src/aggregate.js';
+import { rollingBest, recencyWeightedBest, normalizedPower, avgPower } from '../src/aggregate.js';
 
 describe('rollingBest', () => {
   it('takes the max across activities at each duration', () => {
@@ -20,6 +20,43 @@ describe('rollingBest', () => {
   });
 });
 
+describe('recencyWeightedBest', () => {
+  const now = 100 * 86400_000;
+
+  it('returns the raw power of the highest-weighted effort', () => {
+    const acts = [
+      { startTime: now - 60 * 86400_000, mmp: { 60: 350 } }, // 60d old, weight ≈ 0.37
+      { startTime: now - 5  * 86400_000, mmp: { 60: 280 } }, // 5d old, weight ≈ 0.92
+    ];
+    // 350 × 0.37 ≈ 130 vs 280 × 0.92 ≈ 258 → recent wins; raw value is 280.
+    expect(recencyWeightedBest(acts, { halfLifeDays: 42, now })).toEqual({ 60: 280 });
+  });
+
+  it('lets an old peak win when the recent value is much lower', () => {
+    const acts = [
+      { startTime: now - 60 * 86400_000, mmp: { 60: 400 } }, // weight 0.37 → 148
+      { startTime: now - 5  * 86400_000, mmp: { 60: 100 } }, // weight 0.92 → 92
+    ];
+    expect(recencyWeightedBest(acts, { halfLifeDays: 42, now })).toEqual({ 60: 400 });
+  });
+
+  it('respects windowDays cutoff', () => {
+    const acts = [
+      { startTime: now - 200 * 86400_000, mmp: { 60: 999 } },
+      { startTime: now - 10  * 86400_000, mmp: { 60: 250 } },
+    ];
+    expect(recencyWeightedBest(acts, { windowDays: 90, halfLifeDays: 42, now })).toEqual({ 60: 250 });
+  });
+
+  it('handles a missing duration gracefully', () => {
+    const acts = [
+      { startTime: now - 5 * 86400_000, mmp: { 60: 300 } },
+      { startTime: now - 5 * 86400_000, mmp: { 300: 250 } },
+    ];
+    expect(recencyWeightedBest(acts, { halfLifeDays: 42, now })).toEqual({ 60: 300, 300: 250 });
+  });
+});
+
 describe('normalizedPower', () => {
   it('equals avg power for a flat stream', () => {
     const stream = new Array(120).fill(200);
@@ -27,7 +64,6 @@ describe('normalizedPower', () => {
   });
 
   it('exceeds avg power for a variable stream', () => {
-    // 60s @ 100W / 60s @ 300W blocks — variability above the 30s smoothing window
     const stream = [];
     for (let block = 0; block < 6; block++) {
       const w = block % 2 === 0 ? 100 : 300;


### PR DESCRIPTION
Closes #16.

## Recency weighting
The fit previously used a flat max across the 90-day window — a peak from week 1 anchored the curve through week 12. Now `recencyWeightedBest` scales each effort by an exponential decay on age (42-day half-life), and the fit listens to whichever effort has the highest *weighted* power. The fit still consumes raw watts so predictions remain calibrated, but the *choice* of which effort to trust now favors recent data.

The display table is unchanged — still raw rolling-best across the window.

## Clarify metric semantics
Made it clear in the UI and methodology doc that these are mean maximal power (best rolling-average watts), not normalized.

## Test plan
- [ ] Reload, check that 'Last 90d' table values are unchanged from before (still raw rolling-best)
- [ ] Predict numbers should shift slightly toward recent form — likely most visible if you have an old peak that the fit now de-emphasizes
- [ ] Table header reads 'Best avg watts held · raw, not normalized'
- [ ] Predict header notes the 42d half-life
- [ ] Methodology doc: new sections on what "best" means and how recency weighting works