### PR TITLE
Predict: scan all observed MMPs for the best decay anchor

### DIFF
--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -57,14 +57,14 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
   }
   const rmse = Math.sqrt(sse / n);
 
-  // Track the longest-duration MMP across the *full* input (not just
-  // the fitting window) so predictions for endurance durations can
-  // anchor to real data instead of extrapolating from the CP model.
-  let longest = null;
-  for (const p of points) {
-    if (!Number.isFinite(p.durationS) || !Number.isFinite(p.powerW)) continue;
-    if (!longest || p.durationS > longest.durationS) longest = p;
-  }
+  // Keep the full input on the fit so predictPower can anchor decay
+  // on whichever observed point is most relevant for the target
+  // duration — not just the single longest point.
+  const allPoints = points
+    .filter((p) => Number.isFinite(p.durationS) && Number.isFinite(p.powerW))
+    .map((p) => ({ durationS: p.durationS, powerW: p.powerW }))
+    .sort((a, b) => a.durationS - b.durationS);
+  const longest = allPoints[allPoints.length - 1] || null;
 
   return {
     cpW,
@@ -76,6 +76,7 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
     maxObservedS: filtered.reduce((m, p) => Math.max(m, p.durationS), -Infinity),
     longestS: longest?.durationS ?? null,
     longestW: longest?.powerW ?? null,
+    points: allPoints,
   };
 }
 
@@ -119,28 +120,37 @@ export function predictPower(fit, durationS, opts = {}) {
   let powerW = fit.cpW + fit.wPrimeJ / durationS;
   let decayed = false;
   if (decay && durationS > decay.fromS) {
-    // Default: anchor at the decay threshold using the model's
-    // extrapolated power at that duration.
+    // Walk every observed point in the extrapolation range and pick
+    // the best decay anchor: the one closest to (and not beyond) the
+    // target duration whose observed power exceeds what the CP model
+    // would predict there. Anchoring closer to the target gives a
+    // tighter prediction; requiring "above model" filters out
+    // low-effort base rides that would drag the prediction down.
     let anchorS = decay.fromS;
     let anchorPower = fit.cpW + fit.wPrimeJ / decay.fromS;
 
-    // Only override with the longest observed MMP when that real
-    // effort *exceeds* what the model would predict at that
-    // duration. Otherwise the observation reflects a low-effort
-    // base ride rather than a true ceiling, and using it as anchor
-    // would propagate the under-effort to all longer predictions.
-    if (
-      fit.longestS && fit.longestW &&
-      fit.longestS > decay.fromS &&
-      fit.longestS <= durationS
-    ) {
-      const modelAtLongest = fit.cpW + fit.wPrimeJ / fit.longestS;
-      if (fit.longestW > modelAtLongest) {
-        anchorS = fit.longestS;
-        anchorPower = fit.longestW;
+    if (Array.isArray(fit.points)) {
+      for (const p of fit.points) {
+        if (p.durationS <= decay.fromS) continue;
+        if (p.durationS > durationS) break; // points are sorted by durationS
+        const modelAtP = fit.cpW + fit.wPrimeJ / p.durationS;
+        if (p.powerW > modelAtP && p.durationS > anchorS) {
+          anchorS = p.durationS;
+          anchorPower = p.powerW;
+        }
       }
     }
-    powerW = anchorPower * (anchorS / durationS) ** decay.k;
+
+    // If we have an observed point AT the target duration, use it
+    // directly — never predict below an actual recorded value.
+    const exact = Array.isArray(fit.points)
+      ? fit.points.find((p) => p.durationS === durationS)
+      : null;
+    if (exact && exact.powerW > anchorPower * (anchorS / durationS) ** decay.k) {
+      powerW = exact.powerW;
+    } else {
+      powerW = anchorPower * (anchorS / durationS) ** decay.k;
+    }
     decayed = true;
   }
 

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -65,24 +65,49 @@ describe('predictPower', () => {
     expect(out.powerW).toBeLessThan(fit.cpW);
   });
 
-  it('only uses longest-observed MMP as anchor when it exceeds the model', () => {
+  it('only uses an observed-MMP anchor when it exceeds the model', () => {
     // Case A: long observed MMP is BELOW model — use threshold anchor.
     const fitLowLong = fitCp2([
       ...synth(280, 22000, [180, 300, 600, 900, 1200]),
       { durationS: 3600, powerW: 200 }, // low-effort 1h base ride
     ]);
     const lowOut = predictPower(fitLowLong, 7200);
-    // Should ignore the 200W observation and anchor at threshold.
     const expectedThresholdAnchored = (280 + 22000 / 1200) * (1200 / 7200) ** 0.10;
     expect(lowOut.powerW).toBeCloseTo(expectedThresholdAnchored, 2);
 
-    // Case B: long observed MMP EXCEEDS model — use it as anchor.
+    // Case B: long observed MMP EXCEEDS model — anchor on it.
     const fitHighLong = fitCp2([
       ...synth(280, 22000, [180, 300, 600, 900, 1200]),
       { durationS: 3600, powerW: 290 }, // genuinely strong 1h
     ]);
     const highOut = predictPower(fitHighLong, 7200);
     expect(highOut.powerW).toBeCloseTo(290 * (3600 / 7200) ** 0.10, 2);
+  });
+
+  it('never predicts below a real observation at the same duration', () => {
+    // 45-min observed of 242 W in a fit whose 90d CP came out lowish.
+    // Even with decay, the prediction should not undercut a real ride
+    // at the exact target duration.
+    const lowFit = fitCp2([
+      ...synth(220, 14000, [180, 300, 600, 900, 1200]),
+      { durationS: 2700, powerW: 242 },
+      { durationS: 14400, powerW: 150 }, // long low-effort ride
+    ]);
+    const out = predictPower(lowFit, 2700);
+    expect(out.powerW).toBeGreaterThanOrEqual(242);
+  });
+
+  it('anchors closer to target when intermediate observations exceed model', () => {
+    // Same low fit, but predict 60 min — should anchor on the 45-min
+    // observation rather than the threshold or the 4h ride.
+    const lowFit = fitCp2([
+      ...synth(220, 14000, [180, 300, 600, 900, 1200]),
+      { durationS: 2700, powerW: 242 },   // 45 min above model
+      { durationS: 14400, powerW: 150 },  // 4h below model — ignored
+    ]);
+    const out = predictPower(lowFit, 3600);
+    // Should anchor at (2700, 242) and decay to 3600.
+    expect(out.powerW).toBeCloseTo(242 * (2700 / 3600) ** 0.10, 1);
   });
 
   it('respects an explicit decay override', () => {


### PR DESCRIPTION
Reported: 45-min predict (216 W) read below the user's actual 45-min ride (242 W) because the anchor logic only considered the *single longest* observed point. Now predictPower walks every observed point in the extrapolation range, picks the closest one ≤ target whose power exceeds the model, and anchors decay there. Plus a final "never below an observed value at the exact target duration" guard.

37 tests passing (2 new for this case).