### PR TITLE
Anchor decay on raw rolling-best, not recency-weighted points

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -204,12 +204,17 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const last30 = rollingBest(activityMmps, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
-  // The fit uses a recency-weighted aggregation of the 90-day window
-  // so a 6-week-old peak doesn't outweigh more recent (and possibly
-  // more representative) rides. Falls back to all-time if too sparse.
+  // The fit's regression uses a recency-weighted aggregation of the
+  // 90-day window so a 6-week-old peak doesn't outweigh more recent
+  // rides. The observed-point set (used to anchor decay on real
+  // efforts) stays as the raw rolling-best — a real ride at 45 min
+  // months ago still proves capability and keeps long-duration
+  // predictions honest.
   const last90Weighted = recencyWeightedBest(activityMmps, { windowDays: 90 });
   const allTimeWeighted = recencyWeightedBest(activityMmps);
-  currentFit = fitCp2(mmpToPoints(last90Weighted)) || fitCp2(mmpToPoints(allTimeWeighted));
+  currentFit =
+    fitCp2(mmpToPoints(last90Weighted), undefined, { observedPoints: mmpToPoints(last90) })
+    || fitCp2(mmpToPoints(allTimeWeighted), undefined, { observedPoints: mmpToPoints(allTime) });
 
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -30,7 +30,12 @@ export function mmpToPoints(mmp) {
 
 // Linear-regression fit. Returns null if there aren't at least 2
 // points within the fitting window.
-export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
+// `points` drives the regression. `opts.observedPoints` (defaults to
+// `points`) is what predictPower scans when anchoring decay on real
+// efforts — pass the raw rolling-best here when the regression input
+// is recency-weighted, so a real ride from 50 days ago can still
+// keep predictions honest at long durations.
+export function fitCp2(points, range = DEFAULT_FIT_RANGE, opts = {}) {
   const filtered = points.filter(
     (p) => p.durationS >= range.minS && p.durationS <= range.maxS
   );
@@ -57,14 +62,16 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
   }
   const rmse = Math.sqrt(sse / n);
 
-  // Keep the full input on the fit so predictPower can anchor decay
-  // on whichever observed point is most relevant for the target
-  // duration — not just the single longest point.
-  const allPoints = points
+  // Keep the observed-point set on the fit so predictPower can
+  // anchor decay on whichever real effort is most relevant for the
+  // target duration. Defaults to the regression points but can be
+  // supplied separately so the regression can use recency-weighted
+  // values while anchoring still trusts raw rolling-best efforts.
+  const observed = (opts.observedPoints || points)
     .filter((p) => Number.isFinite(p.durationS) && Number.isFinite(p.powerW))
     .map((p) => ({ durationS: p.durationS, powerW: p.powerW }))
     .sort((a, b) => a.durationS - b.durationS);
-  const longest = allPoints[allPoints.length - 1] || null;
+  const longest = observed[observed.length - 1] || null;
 
   return {
     cpW,
@@ -76,7 +83,7 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE) {
     maxObservedS: filtered.reduce((m, p) => Math.max(m, p.durationS), -Infinity),
     longestS: longest?.durationS ?? null,
     longestW: longest?.powerW ?? null,
-    points: allPoints,
+    points: observed,
   };
 }
 


### PR DESCRIPTION
Reported in testing: predict at 45m read 216 W while the chart showed an observed 265 W at the same duration. Root cause: I was using the recency-weighted set both for the regression *and* for the "observed-effort exceeds model?" anchor scan. A 50-day-old peak got de-weighted out of consideration even though the user actually rode it.

Fix: `fitCp2` now takes a separate `observedPoints` array (defaulting to the regression set, so existing tests still pass) used only for decay anchoring. `renderCurves` passes the recency-weighted set for regression and the raw rolling-best for anchoring. CP/W' still respond to recent form; predictions can't read below a real ride at the same duration.

37 tests passing.