### PR TITLE
Manual fit override (CP + date range)

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -121,7 +121,7 @@
       <li><strong>Recency weighting</strong> &mdash; weight recent efforts more heavily within the window so a peak ride from week 1 doesn't outweigh week 12.</li>
       <li><strong>Effort-quality flagging</strong> &mdash; only count an MMP as a "true" point if the activity's overall intensity suggests you were going hard; treat tempo-pace bests as soft data points.</li>
       <li><strong>Fitness drift normalization</strong> &mdash; rescale older efforts by the ratio of estimated FTP then vs. now, so a year-old peak doesn't dominate.</li>
-      <li><strong>Manual fitness override</strong> &mdash; a way to tell Power Predict "ignore my zone-2 base block, I'm actually fitter than that suggests" via a CP override or a custom date range.</li>
+      <li><strong>Manual fitness override</strong> &mdash; CP override and custom date range are now available under "Adjust the fit" on the predict panel. CP override replaces the model's CP while keeping the data-derived W'. Date range filters which activities feed the fit, useful for "my best 90 days from earlier this year".</li>
     </ul>
 
     <p>Track these on the <a href="https://github.com/iammike/power-predict/milestones" target="_blank" rel="noopener">project milestones</a>.</p>

--- a/shared.css
+++ b/shared.css
@@ -496,6 +496,120 @@ main {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
+/* OVERRIDE PANEL */
+
+.override-panel {
+  margin: 1.25rem 0 0;
+  border: 1px solid var(--hair);
+  background: var(--paper-soft);
+  padding: 0;
+}
+.override-panel > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.6rem 0.9rem;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-soft);
+  border-bottom: 1px solid transparent;
+  transition: border-color 160ms ease, background 160ms ease;
+}
+.override-panel > summary::-webkit-details-marker { display: none; }
+.override-panel > summary::before {
+  content: '+';
+  display: inline-block;
+  width: 1em;
+  font-family: var(--mono);
+  color: var(--oxblood);
+  margin-right: 0.4rem;
+}
+.override-panel[open] > summary::before { content: '−'; }
+.override-panel[open] > summary {
+  border-bottom-color: var(--hair);
+  background: var(--paper);
+}
+
+.override-form {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 1rem 0.9rem 0.5rem;
+  align-items: end;
+}
+.override-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.override-form__field span {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
+.override-form input {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  background: transparent;
+  color: var(--ink);
+  border: none;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.3rem 0;
+  outline: none;
+}
+.override-form input:focus { border-bottom-color: var(--oxblood); }
+
+.override-form__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.5rem 0 0;
+  border-top: 1px solid var(--hair);
+  margin-top: 0.4rem;
+}
+.override-form button[type="submit"] {
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--paper);
+  background: var(--oxblood);
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+.override-form button[type="submit"]:hover { background: var(--oxblood-deep); }
+.override-panel .results-foot__note {
+  padding: 0 0.9rem 0.9rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.override-badge {
+  font-family: var(--mono);
+  font-size: 0.6em;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  color: var(--paper);
+  background: var(--oxblood);
+  padding: 0.15em 0.5em;
+  margin-left: 0.5em;
+  vertical-align: middle;
+  border-radius: 2px;
+}
+
+@media (max-width: 720px) {
+  .override-form { grid-template-columns: 1fr; }
+}
+
 /* PREDICT */
 
 .predict {

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,8 @@ import {
   hasActivity,
   clearActivities,
   activityCount,
+  loadSettings,
+  saveSettings,
 } from './storage.js';
 import { fitCp2, predictPower, mmpToPoints } from './cpfit.js';
 import { parseDuration } from './duration.js';
@@ -36,13 +38,19 @@ if (dropZone && fileInput) {
   });
 }
 
+// User-settable fit overrides, persisted to IDB.
+let currentSettings = {};
+let currentActivities = [];
+
 // Hydrate from IndexedDB on page load — returning visitors see their
 // curve instantly without re-uploading.
 hydrateFromCache();
 
 async function hydrateFromCache() {
   try {
-    const cached = await loadActivities();
+    const [cached, settings] = await Promise.all([loadActivities(), loadSettings()]);
+    currentSettings = settings || {};
+    currentActivities = cached;
     if (cached.length > 0) {
       renderCurves(cached, { fromCache: true });
     }
@@ -199,9 +207,21 @@ let currentFit = null;
 let currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
-  const allTime = rollingBest(activityMmps);
-  const last90 = rollingBest(activityMmps, { windowDays: 90 });
-  const last30 = rollingBest(activityMmps, { windowDays: 30 });
+  currentActivities = activityMmps;
+  // Filter activities by the user's date range, if set.
+  const dateFromMs = currentSettings.dateFrom ? Date.parse(currentSettings.dateFrom) : null;
+  const dateToMs = currentSettings.dateTo
+    ? Date.parse(currentSettings.dateTo) + 86400_000 - 1
+    : null;
+  const filtered = (dateFromMs || dateToMs)
+    ? activityMmps.filter((a) =>
+        (!dateFromMs || a.startTime >= dateFromMs) &&
+        (!dateToMs   || a.startTime <= dateToMs))
+    : activityMmps;
+
+  const allTime = rollingBest(filtered);
+  const last90 = rollingBest(filtered, { windowDays: 90 });
+  const last30 = rollingBest(filtered, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
   // The fit's regression uses a recency-weighted aggregation of the
@@ -210,11 +230,22 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // efforts) stays as the raw rolling-best — a real ride at 45 min
   // months ago still proves capability and keeps long-duration
   // predictions honest.
-  const last90Weighted = recencyWeightedBest(activityMmps, { windowDays: 90 });
-  const allTimeWeighted = recencyWeightedBest(activityMmps);
+  //
+  // If the user supplied a custom date range, we let the rolling-90d
+  // logic still apply on top of the filtered set. If they prefer the
+  // entire range, they can set a wider window.
+  const fitWindow = (dateFromMs || dateToMs) ? null : 90;
+  const last90Weighted = recencyWeightedBest(filtered, { windowDays: fitWindow });
+  const allTimeWeighted = recencyWeightedBest(filtered);
   currentFit =
     fitCp2(mmpToPoints(last90Weighted), undefined, { observedPoints: mmpToPoints(last90) })
     || fitCp2(mmpToPoints(allTimeWeighted), undefined, { observedPoints: mmpToPoints(allTime) });
+
+  // Apply CP override on top of the fit (W' stays from the underlying
+  // fit so the curve shape is data-derived, not a hand-set hyperbola).
+  if (currentFit && Number.isFinite(currentSettings.cpOverrideW)) {
+    currentFit = { ...currentFit, cpW: currentSettings.cpOverrideW, overridden: true };
+  }
 
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)
@@ -256,6 +287,67 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
   wirePredictForm();
   wireCurveChart();
+  wireOverrideForm();
+}
+
+function renderOverrideForm() {
+  const cp = currentSettings.cpOverrideW ?? '';
+  const from = currentSettings.dateFrom || '';
+  const to = currentSettings.dateTo || '';
+  return `
+    <details class="override-panel" ${
+      currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo ? 'open' : ''
+    }>
+      <summary>Adjust the fit</summary>
+      <form class="override-form" id="override-form">
+        <label class="override-form__field">
+          <span>CP override (W)</span>
+          <input type="number" id="cp-override" min="50" max="600" step="1" value="${cp}" placeholder="e.g. 280">
+        </label>
+        <label class="override-form__field">
+          <span>From</span>
+          <input type="date" id="date-from" value="${from}">
+        </label>
+        <label class="override-form__field">
+          <span>To</span>
+          <input type="date" id="date-to" value="${to}">
+        </label>
+        <div class="override-form__actions">
+          <button type="submit">Apply</button>
+          <button type="button" class="link-button" id="reset-override">Reset</button>
+        </div>
+      </form>
+      <p class="results-foot__note">
+        Use a CP override when recent rides don't reflect your real fitness (e.g. base block).
+        Use a date range to fit only a specific period — the recency window is dropped while a date range is active.
+      </p>
+    </details>
+  `;
+}
+
+function wireOverrideForm() {
+  const form = document.getElementById('override-form');
+  if (!form) return;
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const cpStr = document.getElementById('cp-override').value.trim();
+    const from = document.getElementById('date-from').value;
+    const to = document.getElementById('date-to').value;
+    const cp = cpStr ? Number(cpStr) : null;
+    currentSettings = {
+      ...currentSettings,
+      cpOverrideW: Number.isFinite(cp) ? cp : null,
+      dateFrom: from || null,
+      dateTo: to || null,
+    };
+    await saveSettings(currentSettings);
+    renderCurves(currentActivities, { fromCache: true });
+  });
+  document.getElementById('reset-override').addEventListener('click', async () => {
+    currentSettings = {};
+    await saveSettings({});
+    renderCurves(currentActivities, { fromCache: true });
+  });
 }
 
 function wireCurveChart() {
@@ -288,19 +380,26 @@ function renderPredictBlock() {
     `;
   }
 
+  const overrideActive = !!(currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo);
+  const headerMeta = overrideActive
+    ? `CP model · custom override`
+    : `CP model · 90d window, recency-weighted (42d half-life)`;
+
   return `
     <section class="predict">
       <header class="results-head">
-        <h2>Predict</h2>
-        <span class="results-head__meta">CP model · 90d window, recency-weighted (42d half-life)</span>
+        <h2>Predict ${overrideActive ? '<span class="override-badge">OVERRIDE</span>' : ''}</h2>
+        <span class="results-head__meta">${headerMeta}</span>
       </header>
 
       <dl class="fit-stats">
-        <div><dt>CP</dt><dd>${formatPower(currentFit.cpW)}</dd></div>
+        <div><dt>CP${currentFit.overridden ? ' *' : ''}</dt><dd>${formatPower(currentFit.cpW)}</dd></div>
         <div><dt>W'</dt><dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd></div>
         <div><dt>RMSE</dt><dd>${currentFit.rmse.toFixed(1)} W</dd></div>
         <div><dt>Points</dt><dd>${currentFit.nPoints}</dd></div>
       </dl>
+
+      ${renderOverrideForm()}
 
       <div class="curve-chart-section">
         <header class="curve-chart-head">

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,19 +1,26 @@
-// IndexedDB cache for parsed activity records. Keeps returning visits
-// instant: we never re-parse the zip if the user has been here before.
-// startTime (unix ms) is the natural key — two rides can't start in the
-// same millisecond.
+// IndexedDB cache for parsed activity records and user settings.
+//
+// `activities` keeps the per-ride MMP arrays so returning visits hydrate
+// instantly. `settings` stores the manual fit override so a user-defined
+// CP / date range survives reloads. startTime (unix ms) is the
+// activities key — two rides can't start in the same millisecond.
 
 const DB_NAME = 'power-predict';
-const DB_VERSION = 1;
-const STORE = 'activities';
+const DB_VERSION = 2;
+const ACTIVITIES_STORE = 'activities';
+const SETTINGS_STORE = 'settings';
+const SETTINGS_KEY = 'current';
 
 function openDb() {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
-      if (!db.objectStoreNames.contains(STORE)) {
-        db.createObjectStore(STORE, { keyPath: 'startTime' });
+      if (!db.objectStoreNames.contains(ACTIVITIES_STORE)) {
+        db.createObjectStore(ACTIVITIES_STORE, { keyPath: 'startTime' });
+      }
+      if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
+        db.createObjectStore(SETTINGS_STORE);
       }
     };
     req.onsuccess = () => resolve(req.result);
@@ -21,11 +28,11 @@ function openDb() {
   });
 }
 
-async function withStore(mode, fn) {
+async function withStore(name, mode, fn) {
   const db = await openDb();
   return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE, mode);
-    const store = tx.objectStore(STORE);
+    const tx = db.transaction(name, mode);
+    const store = tx.objectStore(name);
     let result;
     Promise.resolve(fn(store))
       .then((r) => { result = r; })
@@ -37,7 +44,7 @@ async function withStore(mode, fn) {
 }
 
 export async function loadActivities() {
-  return withStore('readonly', (store) =>
+  return withStore(ACTIVITIES_STORE, 'readonly', (store) =>
     new Promise((resolve, reject) => {
       const req = store.getAll();
       req.onsuccess = () => resolve(req.result || []);
@@ -48,13 +55,13 @@ export async function loadActivities() {
 
 export async function saveActivities(activities) {
   if (activities.length === 0) return;
-  return withStore('readwrite', (store) => {
+  return withStore(ACTIVITIES_STORE, 'readwrite', (store) => {
     for (const a of activities) store.put(a);
   });
 }
 
 export async function hasActivity(startTime) {
-  return withStore('readonly', (store) =>
+  return withStore(ACTIVITIES_STORE, 'readonly', (store) =>
     new Promise((resolve, reject) => {
       const req = store.getKey(startTime);
       req.onsuccess = () => resolve(req.result !== undefined);
@@ -64,15 +71,37 @@ export async function hasActivity(startTime) {
 }
 
 export async function clearActivities() {
-  return withStore('readwrite', (store) => store.clear());
+  return withStore(ACTIVITIES_STORE, 'readwrite', (store) => store.clear());
 }
 
 export async function activityCount() {
-  return withStore('readonly', (store) =>
+  return withStore(ACTIVITIES_STORE, 'readonly', (store) =>
     new Promise((resolve, reject) => {
       const req = store.count();
       req.onsuccess = () => resolve(req.result || 0);
       req.onerror = () => reject(req.error);
     })
   );
+}
+
+// ───── Settings ─────
+
+export async function loadSettings() {
+  return withStore(SETTINGS_STORE, 'readonly', (store) =>
+    new Promise((resolve, reject) => {
+      const req = store.get(SETTINGS_KEY);
+      req.onsuccess = () => resolve(req.result || {});
+      req.onerror = () => reject(req.error);
+    })
+  );
+}
+
+export async function saveSettings(settings) {
+  return withStore(SETTINGS_STORE, 'readwrite', (store) => {
+    store.put(settings, SETTINGS_KEY);
+  });
+}
+
+export async function clearSettings() {
+  return withStore(SETTINGS_STORE, 'readwrite', (store) => store.clear());
 }


### PR DESCRIPTION
Closes #35.

Adds an "Adjust the fit" disclosure under the predict header with:
- **CP override (W)** — replaces the model's asymptote. W' stays data-derived.
- **From / To date inputs** — restrict which activities feed the fit.
- **Reset** — back to defaults in one click.
- Visual: \`OVERRIDE\` badge in the header + asterisk on CP stat when active.

Settings persist via a new \`settings\` object store in IDB (DB v2 upgrade, idempotent).

## Test plan
- [ ] Reload, check footer SHA past current main
- [ ] Set CP override = 280 W, click Apply — predict + chart re-render with CP=280, OVERRIDE badge shows
- [ ] Set date range From = 2025-09-01, To = 2025-12-01, Apply — fit re-runs against just those activities
- [ ] Reload page — settings persist; values pre-populated; OVERRIDE badge still shown
- [ ] Click Reset — defaults restored, badge disappears
- [ ] Existing IDB activities still load (DB upgrade is non-destructive)