### PR TITLE
Continuous fit-to-extrapolation; hide tabs when date range set; README + methodology refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,78 @@
 # power-predict
 
-Predict the power output you can sustain for a target race duration, based on your Strava history.
+Predict the wattage you can sustain for a target race duration, based on your Strava history.
 
-**Live target:** [power.iammike.org](https://power.iammike.org/) (not yet deployed)
+**Live:** [power.iammike.org](https://power.iammike.org/)
 
-Patterned after [`sports-card-checklists`](https://github.com/iammike/sports-card-checklists): static SPA on GitHub Pages, Cloudflare Worker for OAuth + API proxy, Cloudflare D1 for storage.
+A static SPA on GitHub Pages with a Web Worker that parses your Strava archive in-browser. No upload — your power streams never leave your machine. Cloudflare Worker + D1 are scaffolded for the (planned) OAuth + webhook sync path; they're not required for the archive-upload onboarding that ships today.
 
-## How users import data
+## How it works
 
-The primary onboarding flow is the **Strava account archive** &mdash; see [`docs/strava-archive-guide.md`](docs/strava-archive-guide.md) for the user-facing walkthrough.
+1. Request your Strava archive (Settings → My Account → Download Request — full guide at `docs/strava-archive-guide.md`).
+2. Drop the zip on the page. A Web Worker unzips it, parses every FIT file, and computes mean-maximal-power arrays per activity.
+3. Derived data is cached in IndexedDB so returning visits are instant. Only the per-activity MMP arrays persist; raw streams are discarded after parsing.
+4. The fit + predict + chart all run client-side from that cache.
 
-## Why archive upload, not API-only
+## Modeling
 
-Strava's free-tier API is shared 200 req / 15 min and 2000 / day across **all users of the app**, plus a single-user cap until you apply for an upgrade. Pulling a power stream costs one request per activity, so onboarding a single user with 500 rides exhausts the daily budget for everyone. Power Predict bulk-onboards from the user's downloaded Strava archive (parsed in the browser) and reserves the API for incremental updates via webhook.
+- **MMP per activity** — best rolling-average power for every duration (1 s up to 4 h).
+- **Rolling-best aggregation** — Last 30d / Last 90d / All-time. The display table shows raw rolling-best across the window.
+- **Recency-weighted regression** — the CP fit consumes a 42-day half-life weighted aggregation, so a 60-day-old peak counts ≈ 37% of a recent ride. Keeps the fit responsive to current form.
+- **2-parameter Critical Power model** — `P(t) = CP + W'/t`, fitted in the standard 3–20 minute window by ordinary least squares.
+- **Riegel-style fatigue decay** beyond the fit window with k = 0.10. Anchored on whichever observed effort closest to the target exceeds the model — predictions are grounded in real data, not just the regression's asymptote.
+- **Manual override** — set a custom CP or restrict the fit to a date range. Persists in IndexedDB.
 
-See `~/Documents/claude/power-predict-plan.md` for the full plan.
+Full methodology + references at `docs/methodology.html` (Skiba, Allen & Coggan, Riegel 1981, Pinot & Grappe, Monod & Scherrer 1965).
 
 ## Layout
 
 | File | Purpose |
 |------|---------|
 | `index.html` | Landing + onboarding UI |
-| `src/app.js` | Frontend entry — drop-zone wiring, predict form |
-| `src/mmp.js` | Mean-maximal-power extraction from a 1Hz power stream |
-| `worker.js` | Cloudflare Worker — OAuth, webhook ingest, MMP ingest endpoint |
-| `wrangler.toml` | Worker + D1 + R2 + KV bindings |
-| `migrations/0001_init.sql` | D1 schema |
-| `build.js` | esbuild bundling to `dist/` |
-| `tests/` | vitest specs |
+| `src/app.js` | Drop-zone wiring, render loop, predict + override forms |
+| `src/archive-worker.js` | Web Worker entry — file slicing, fflate Unzip, FIT parse, MMP extraction |
+| `src/mmp.js` | Mean-maximal-power extraction from a 1 Hz power stream |
+| `src/aggregate.js` | Rolling-best + recency-weighted MMP aggregation |
+| `src/cpfit.js` | 2-parameter CP regression + Riegel decay extrapolation |
+| `src/curve-chart.js` | uPlot-based power-duration curve |
+| `src/storage.js` | IndexedDB cache (activities + settings) |
+| `worker.js` | Cloudflare Worker — OAuth, webhook ingest (Phase 4, not yet wired) |
+| `migrations/0001_init.sql` | D1 schema (Phase 4) |
 
 ## Develop
 
 ```bash
 npm install
-npm run build
-npm run serve     # http://localhost:8000
-npm test
+npm run build       # bundle app, worker, css
+npm run serve       # http://localhost:8000
+npm test            # vitest, ~37 unit tests
 ```
 
 ## Deploy
 
+GitHub Pages serves `index.html` + `dist/` from `main`. The deploy workflow runs tests, builds, and publishes on every push.
+
+The Cloudflare Worker is wired but unused until Phase 4 ships:
+
 ```bash
-# one-time
-wrangler d1 create power-predict           # then paste id into wrangler.toml
+wrangler d1 create power-predict
 wrangler kv:namespace create RATE_LIMIT
 wrangler r2 bucket create power-predict-archives
 wrangler d1 execute power-predict --file=migrations/0001_init.sql
 wrangler secret put STRAVA_CLIENT_SECRET
 wrangler secret put STRAVA_WEBHOOK_VERIFY_TOKEN
-
-# routine
-npm run deploy:worker
 ```
 
-GitHub Pages picks up `index.html` + `dist/` from `main`.
+## Roadmap
 
-## Strava setup
+Open issues are grouped by phase: see [milestones](https://github.com/iammike/power-predict/milestones). Highlights still queued:
+
+- **Phase 3** — effort-quality flagging (#18), training-load nudge (#42), eFTP normalization (#17), distance/speed helper (#14)
+- **Phase 4** — Strava OAuth + webhook ingest (#20, #21), 180-day API backfill (#39), rate-limit budget (#22), connect UI (#26)
+- **Phase 5** — privacy / accessibility / account deletion polish
+
+## Strava setup (for Phase 4)
 
 1. Register an app at https://www.strava.com/settings/api
 2. Authorization callback domain: `power.iammike.org`
-3. Copy `client_id` into `wrangler.toml` (public) and `client_secret` via `wrangler secret put`
+3. Copy `client_id` into `wrangler.toml` (public), `client_secret` via `wrangler secret put`

--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -73,6 +73,17 @@
 
     <p>With <em>x</em> = 1 / <em>t</em>, the formula becomes a line, and we fit it by ordinary least squares. <em>W&prime;</em> falls out as the slope, CP as the intercept. Power Predict reports the fit's RMSE alongside CP and W&prime; so you can see how well your data matches the model.</p>
 
+    <h3>Why the fit line doesn't pass through every dot</h3>
+
+    <p>The CP fit is a 2-parameter hyperbola &mdash; it has only two knobs (CP and W&prime;) to fit your whole power-duration profile. It approximates your data with a smooth curve; it can't connect every observed dot exactly. Add the recency weighting on top (older observations count less in the regression) and the fit can sit visibly below your raw rolling-best, especially during base blocks where recent rides are softer than older peaks.</p>
+
+    <p>The dots are <em>history</em> &mdash; what you actually rode. The line is the <em>model</em>'s smooth forecast of what you can sustain. If the line reads conservatively, you have two levers:</p>
+
+    <ul>
+      <li><strong>CP override</strong> &mdash; pin CP at a value you trust (e.g. your last hard FTP test). The line shifts to match while W&prime; stays data-derived.</li>
+      <li><strong>Date range</strong> &mdash; restrict the fit to a stretch where you know you were going hard. The recency weighting is dropped while a range is active.</li>
+    </ul>
+
     <h3>Why 3-20 minutes</h3>
 
     <p>Below about 3 minutes, anaerobic / neuromuscular contributions distort the simple two-parameter relationship. Above 20 minutes, fatigue and substrate-depletion effects pull power below the model's prediction. Fits done outside this window are unreliable.</p>

--- a/shared.css
+++ b/shared.css
@@ -449,6 +449,13 @@ main {
   letter-spacing: 0.16em;
   color: var(--muted);
 }
+.curve-range-label {
+  font-family: var(--mono);
+  font-size: 0.74rem;
+  color: var(--oxblood);
+  letter-spacing: 0.04em;
+}
+
 .curve-window-tabs {
   display: inline-flex;
   border: 1px solid var(--hair-strong);

--- a/src/app.js
+++ b/src/app.js
@@ -354,17 +354,22 @@ function wireCurveChart() {
   const container = document.getElementById('curve-chart');
   if (!container || !currentFit) return;
   const tabs = document.querySelectorAll('[data-window]');
-  const drawWindow = (key) => {
+  const draw = (key) => {
     renderCurveChart(container, {
       mmp: currentMmpByWindow[key] || {},
       fit: currentFit,
     });
     tabs.forEach((t) => t.classList.toggle('is-active', t.dataset.window === key));
   };
+  if (tabs.length === 0) {
+    // Date range is active — no tabs, just draw the (pre-filtered) 90d set.
+    draw('last90');
+    return;
+  }
   tabs.forEach((t) => {
-    t.addEventListener('click', () => drawWindow(t.dataset.window));
+    t.addEventListener('click', () => draw(t.dataset.window));
   });
-  drawWindow('last90');
+  draw('last90');
 }
 
 function renderPredictBlock() {
@@ -404,11 +409,14 @@ function renderPredictBlock() {
       <div class="curve-chart-section">
         <header class="curve-chart-head">
           <span class="curve-chart-title">Power-duration curve</span>
-          <div class="curve-window-tabs" role="tablist">
-            <button type="button" data-window="last30" role="tab">Last 30d</button>
-            <button type="button" data-window="last90" role="tab" class="is-active">Last 90d</button>
-            <button type="button" data-window="allTime" role="tab">All-time</button>
-          </div>
+          ${(currentSettings.dateFrom || currentSettings.dateTo)
+            ? `<span class="curve-range-label">Range: ${currentSettings.dateFrom || '…'} → ${currentSettings.dateTo || '…'}</span>`
+            : `<div class="curve-window-tabs" role="tablist">
+                <button type="button" data-window="last30" role="tab">Last 30d</button>
+                <button type="button" data-window="last90" role="tab" class="is-active">Last 90d</button>
+                <button type="button" data-window="allTime" role="tab">All-time</button>
+              </div>`
+          }
         </header>
         <div id="curve-chart" class="curve-chart"></div>
       </div>

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -126,14 +126,19 @@ export function predictPower(fit, durationS, opts = {}) {
 
   let powerW = fit.cpW + fit.wPrimeJ / durationS;
   let decayed = false;
-  if (decay && durationS > decay.fromS) {
-    // Take the upper envelope of the threshold-anchored decay and
-    // decay curves originating at every observed point that beats
-    // the model. Each underlying curve is monotonically decreasing,
-    // so their max is continuous — no jumps where one anchor takes
-    // over from another.
+  // Apply the observed-anchor envelope at *all* durations so the
+  // chart line is continuous across the fit-window boundary. Inside
+  // the fit window the baseline is the regression model itself; the
+  // envelope only lifts it where a longer-duration observed effort
+  // implies you can do at least as much for the shorter duration.
+  if (decay) {
+    // Inside the fit window the baseline is the model itself.
+    // Outside, the threshold-anchored decay takes over (model at the
+    // top of the fit window, then Riegel from there).
     const thresholdAnchorPower = fit.cpW + fit.wPrimeJ / decay.fromS;
-    let best = thresholdAnchorPower * (decay.fromS / durationS) ** decay.k;
+    let best = durationS > decay.fromS
+      ? thresholdAnchorPower * (decay.fromS / durationS) ** decay.k
+      : powerW;
 
     if (Array.isArray(fit.points)) {
       // Every observed point above the model contributes a Riegel
@@ -144,6 +149,10 @@ export function predictPower(fit, durationS, opts = {}) {
       // the formula gives a slightly higher power, which matches the
       // physical intuition: if you held P for 30 min, you held ≥ P
       // for any shorter duration of the same effort.)
+      // Anchor candidates are observations beyond the fit window
+      // whose power exceeds what the regression predicts at their
+      // duration. (Anchors inside the fit window are already encoded
+      // in CP/W'.)
       for (const p of fit.points) {
         if (p.durationS <= decay.fromS) continue;
         const modelAtP = fit.cpW + fit.wPrimeJ / p.durationS;
@@ -159,7 +168,7 @@ export function predictPower(fit, durationS, opts = {}) {
     }
 
     powerW = best;
-    decayed = true;
+    decayed = durationS > decay.fromS;
   }
 
   let extrapolated = false;

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -70,13 +70,17 @@ export function renderCurveChart(container, { mmp, fit }) {
     const idx = observedDurations.indexOf(d);
     return idx >= 0 ? observedPower[idx] : null;
   });
+  // Solid inside the fit window, dashed outside. We deliberately
+  // overlap both series at d == DEFAULT_DECAY.fromS so the two lines
+  // share that point — predictPower returns the same value across
+  // the boundary, so the visual transition is seamless.
   const insideSeries = xs.map((d) => {
     if (d < fit.range.minS || d > DEFAULT_DECAY.fromS) return null;
     const out = predictPower(fit, d);
     return out ? out.powerW : null;
   });
   const outsideSeries = xs.map((d) => {
-    if (d <= DEFAULT_DECAY.fromS) return null;
+    if (d < DEFAULT_DECAY.fromS) return null;
     const out = predictPower(fit, d);
     return out ? out.powerW : null;
   });


### PR DESCRIPTION
## 1. Continuous chart line
The remaining visible jump in the curve was at d=20m where the solid CP-fit line met the dashed extrapolation — two different models with different values at the boundary. \`predictPower\` now applies the observed-anchor envelope at every duration, not just past the fit window. Inside the fit window the baseline is the regression model; the envelope only lifts it where a longer-duration observation implies you can do at least as much for the shorter duration (Riegel evaluated below the anchor). The two chart series now share the boundary point — visually seamless.

## 2. Tabs hidden when a date range is active
30d/90d/All-time tabs further-filtered an already-filtered set when a custom date range was set. Confusing. Now the tab row collapses to a \"Range: A → B\" label when override dates are present.

## 3. README + methodology refresh
- Methodology gains a *Why the fit line doesn't pass through every dot* subsection answering today's user question: 2-param hyperbolas can't match every dot, recency weighting pulls the regression input down, and pointing at the manual-override controls.
- README rewritten to reflect what actually ships in 2026: Web Worker archive ingest, recency-weighted CP fit, Riegel decay, manual override, IDB persistence. Roadmap section points at current open issues / milestones.

## Test plan
- [ ] Drop archive (or hydrate from cache) — chart line goes from solid (3-20m) to dashed (>20m) without any visible step at the boundary
- [ ] Set a date range in the override panel — Last 30d / 90d / All-time tabs disappear, replaced with a range label
- [ ] Visit `/docs/methodology.html` — new "Why the fit line doesn't pass through every dot" subsection is there
- [ ] README on GitHub reflects current behavior (Web Worker, override, etc.)