### PR TITLE
Smooth chart line; keep observed anchors in predict-form output

### DIFF
--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -114,15 +114,18 @@ export const DEFAULT_DECAY = {
 // Predict sustainable power for a target duration.
 // Returns { powerW, low, high, extrapolated, fit, decayed } or null.
 //
-// Pass `opts.decay = false` to disable fatigue decay (raw 2-param CP);
-// pass `opts.decay = { fromS, k }` to override.
-//
-// The confidence band is the fit RMSE plus an extrapolation penalty
-// that grows logarithmically with how far the target sits outside
-// the observed MMP range.
+// Options:
+//   `decay`              - false to disable fatigue decay; `{ fromS, k }` to override
+//   `useObservedAnchors` - default true. When false, predictions follow the
+//                          regression + threshold-anchored Riegel decay only,
+//                          without lifting the line to match observations.
+//                          The chart uses this for a smooth visualization;
+//                          the predict form keeps the default so single-
+//                          duration predictions never undercut a real ride.
 export function predictPower(fit, durationS, opts = {}) {
   if (!fit || !Number.isFinite(durationS) || durationS <= 0) return null;
   const decay = opts.decay === false ? null : { ...DEFAULT_DECAY, ...(opts.decay || {}) };
+  const useObservedAnchors = opts.useObservedAnchors !== false;
 
   let powerW = fit.cpW + fit.wPrimeJ / durationS;
   let decayed = false;
@@ -140,7 +143,7 @@ export function predictPower(fit, durationS, opts = {}) {
       ? thresholdAnchorPower * (decay.fromS / durationS) ** decay.k
       : powerW;
 
-    if (Array.isArray(fit.points)) {
+    if (useObservedAnchors && Array.isArray(fit.points)) {
       // Every observed point above the model contributes a Riegel
       // decay curve valid at *all* extrapolation durations. We take
       // the upper envelope, regardless of whether the anchor sits

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -70,18 +70,22 @@ export function renderCurveChart(container, { mmp, fit }) {
     const idx = observedDurations.indexOf(d);
     return idx >= 0 ? observedPower[idx] : null;
   });
-  // Solid inside the fit window, dashed outside. We deliberately
-  // overlap both series at d == DEFAULT_DECAY.fromS so the two lines
-  // share that point — predictPower returns the same value across
-  // the boundary, so the visual transition is seamless.
+  // The chart line is the smooth regression + threshold-anchored
+  // decay (no observed-anchor envelope) so it reads as a clean
+  // power-duration curve, not a sawtooth that spikes at every
+  // observed dot. The predict form still uses the envelope, so
+  // single-duration predictions remain anchored to real rides.
+  // Solid inside the fit window, dashed outside; both series share
+  // d == DEFAULT_DECAY.fromS so the visual transition is seamless.
+  const lineOpts = { useObservedAnchors: false };
   const insideSeries = xs.map((d) => {
     if (d < fit.range.minS || d > DEFAULT_DECAY.fromS) return null;
-    const out = predictPower(fit, d);
+    const out = predictPower(fit, d, lineOpts);
     return out ? out.powerW : null;
   });
   const outsideSeries = xs.map((d) => {
     if (d < DEFAULT_DECAY.fromS) return null;
-    const out = predictPower(fit, d);
+    const out = predictPower(fit, d, lineOpts);
     return out ? out.powerW : null;
   });
 


### PR DESCRIPTION
Reported: the chart line was spiking to each observed dot inside the fit window (sawtooth pattern) after the last continuity fix. Root cause: applying the upper envelope at every duration in the chart makes the line follow each observation peak.

Split the two: predictPower now takes `useObservedAnchors` (default true), the chart passes false so its line is smooth (regression + threshold-anchored Riegel decay only), and the predict form keeps the default so single-duration predictions still respect observed efforts.