### PR TITLE
Effort-quality filter (#18)

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -52,6 +52,14 @@
 
     <p>Each value in the table is <strong>mean maximal power</strong>: the best rolling <em>average</em> power held for that duration in any activity in the window. It is not normalized power. A 20-minute MMP of 280 W means there is a 20-minute slice of one ride that averaged 280 W &mdash; nothing more.</p>
 
+    <h3>Effort-quality filter</h3>
+
+    <p>Recency weighting on its own can underread your fitness when recent rides have been low intensity &mdash; a 30-day base block of zone-2 spinning gets weighted heavily even though those rides don't reflect what you can do at threshold.</p>
+
+    <p>Power Predict estimates your FTP from your all-time best 20-minute mean maximal power (Coggan: FTP &approx; 0.95 &times; MMP<sub>20m</sub>) and computes an <strong>intensity factor</strong> (IF = average power / FTP) for each activity. Activities with IF below 0.70 (roughly tempo or harder) are dropped from the recency-weighted regression input. Hard rides anchor the fit; easy rides don't.</p>
+
+    <p>The filter is on by default and visible in the "Adjust the fit" panel. The note there reports how many activities were included, dropped, or marked as unknown (missing average-power data, e.g., legacy IDB cache &mdash; re-parse the archive to classify).</p>
+
     <h3>Recency weighting (for the fit, not the table)</h3>
 
     <p>The display table shows the raw rolling-best across the window. The CP fit is different: each effort is weighted by an exponential decay on age, half-life 42 days. A modest 5-minute power from last week can outrank a peak 5-minute power from 8 weeks ago, because we trust recent data more as a signal of current form.</p>

--- a/shared.css
+++ b/shared.css
@@ -571,6 +571,20 @@ main {
 }
 .override-form input:focus { border-bottom-color: var(--oxblood); }
 
+.override-form__check {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  color: var(--ink-soft);
+  padding: 0.4rem 0;
+  border-top: 1px solid var(--hair);
+  margin-top: 0.4rem;
+}
+.override-form__check input { margin: 0; }
+
 .override-form__actions {
   grid-column: 1 / -1;
   display: flex;

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -28,20 +28,30 @@ export function rollingBest(activityMmps, { windowDays = null, now = Date.now() 
 // outrank an old peak), but the prediction should still calibrate
 // against actual achieved power.
 //
-// Inside `windowDays`, this gives the CP fit a curve that responds to
-// current form: a 6-week-old super-effort no longer dominates if more
-// recent rides tell a different story.
+// Effort-quality filter: when `minIF` and `ftp` are supplied, any
+// activity whose `avgPower / ftp` ratio falls below `minIF` is
+// dropped. This prevents low-effort base rides (zone 2 spinning)
+// from anchoring the regression even when they're recent. Activities
+// without `avgPower` are included unconditionally (legacy cache,
+// re-parse archive to enable filtering on them).
 export function recencyWeightedBest(activityMmps, {
   windowDays = null,
   halfLifeDays = 42,
   now = Date.now(),
+  minIF = null,
+  ftp = null,
 } = {}) {
   const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
   const halfLifeMs = halfLifeDays * 86400_000;
   const ln2 = Math.log(2);
+  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
   const winner = {}; // { [duration]: { raw, weighted } }
-  for (const { startTime, mmp } of activityMmps) {
+  for (const { startTime, mmp, avgPower } of activityMmps) {
     if (startTime < cutoff) continue;
+    if (filterEnabled && Number.isFinite(avgPower)) {
+      const intensity = avgPower / ftp;
+      if (intensity < minIF) continue;
+    }
     const ageMs = Math.max(0, now - startTime);
     const weight = Math.exp((-ln2 * ageMs) / halfLifeMs);
     for (const d of DURATIONS_S) {
@@ -56,6 +66,40 @@ export function recencyWeightedBest(activityMmps, {
   const out = {};
   for (const d of Object.keys(winner)) out[d] = winner[d].raw;
   return out;
+}
+
+// Estimate FTP from the all-time best 20-min MMP (Coggan): FTP ≈
+// 0.95 × MMP_20min. Falls back to MMP_15min × 0.93 or null if no
+// long-duration data is available. Used to compute IF for the
+// effort-quality filter.
+export function estimateFtp(activityMmps) {
+  const best = {};
+  for (const { mmp } of activityMmps) {
+    for (const d of [1200, 900]) {
+      const v = mmp?.[d];
+      if (typeof v !== 'number') continue;
+      if (best[d] === undefined || v > best[d]) best[d] = v;
+    }
+  }
+  if (best[1200]) return best[1200] * 0.95;
+  if (best[900])  return best[900]  * 0.93;
+  return null;
+}
+
+// Count activities that pass the effort-quality filter, plus those
+// excluded vs unknown — for surfacing in the UI so the user knows
+// how much data the filter is acting on.
+export function effortQualityStats(activityMmps, { minIF, ftp }) {
+  let included = 0, excluded = 0, unknown = 0;
+  if (!Number.isFinite(minIF) || !Number.isFinite(ftp) || ftp <= 0) {
+    return { included: activityMmps.length, excluded: 0, unknown: 0 };
+  }
+  for (const a of activityMmps) {
+    if (!Number.isFinite(a.avgPower)) { unknown++; continue; }
+    if (a.avgPower / ftp < minIF) excluded++;
+    else included++;
+  }
+  return { included, excluded, unknown };
 }
 
 // Average power for a stream segment (used for normalized power below).

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { DURATIONS_S } from './mmp.js';
-import { rollingBest, recencyWeightedBest } from './aggregate.js';
+import { rollingBest, recencyWeightedBest, estimateFtp, effortQualityStats } from './aggregate.js';
 import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
 import {
@@ -41,6 +41,7 @@ if (dropZone && fileInput) {
 // User-settable fit overrides, persisted to IDB.
 let currentSettings = {};
 let currentActivities = [];
+let currentEffortStats = { included: 0, excluded: 0, unknown: 0 };
 
 // Hydrate from IndexedDB on page load — returning visitors see their
 // curve instantly without re-uploading.
@@ -100,6 +101,7 @@ async function handleArchive(file) {
                 startTime: msg.startTime,
                 durationS: msg.durationS,
                 distanceM: msg.distanceM,
+                avgPower: msg.avgPower,
                 mmp: msg.mmp,
               });
             }
@@ -224,6 +226,18 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const last30 = rollingBest(filtered, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
+  // Effort-quality filter: drop activities whose IF (avg / FTP)
+  // falls below the threshold so low-effort base rides don't anchor
+  // the regression. Default ON. FTP is estimated from all-time best
+  // 20-min MMP via Coggan's 0.95 factor.
+  const effortFilterOn = currentSettings.effortFilterOff !== true;
+  const ftp = estimateFtp(filtered);
+  const minIF = currentSettings.minIF ?? 0.70;
+  const effortOpts = effortFilterOn && ftp ? { minIF, ftp } : {};
+  currentEffortStats = effortFilterOn
+    ? effortQualityStats(filtered, { minIF, ftp })
+    : { included: filtered.length, excluded: 0, unknown: 0 };
+
   // The fit's regression uses a recency-weighted aggregation of the
   // 90-day window so a 6-week-old peak doesn't outweigh more recent
   // rides. The observed-point set (used to anchor decay on real
@@ -235,8 +249,8 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // logic still apply on top of the filtered set. If they prefer the
   // entire range, they can set a wider window.
   const fitWindow = (dateFromMs || dateToMs) ? null : 90;
-  const last90Weighted = recencyWeightedBest(filtered, { windowDays: fitWindow });
-  const allTimeWeighted = recencyWeightedBest(filtered);
+  const last90Weighted = recencyWeightedBest(filtered, { windowDays: fitWindow, ...effortOpts });
+  const allTimeWeighted = recencyWeightedBest(filtered, effortOpts);
   currentFit =
     fitCp2(mmpToPoints(last90Weighted), undefined, { observedPoints: mmpToPoints(last90) })
     || fitCp2(mmpToPoints(allTimeWeighted), undefined, { observedPoints: mmpToPoints(allTime) });
@@ -294,9 +308,15 @@ function renderOverrideForm() {
   const cp = currentSettings.cpOverrideW ?? '';
   const from = currentSettings.dateFrom || '';
   const to = currentSettings.dateTo || '';
+  const effortOff = currentSettings.effortFilterOff === true;
+  const stats = currentEffortStats;
+  const effortNote = effortOff
+    ? 'Effort filter off — all activities feed the fit.'
+    : `Effort filter on: ${stats.included} included, ${stats.excluded} dropped as low-effort${stats.unknown ? `, ${stats.unknown} unknown (re-parse archive to classify)` : ''}.`;
   return `
     <details class="override-panel" ${
-      currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo ? 'open' : ''
+      currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo || effortOff
+        ? 'open' : ''
     }>
       <summary>Adjust the fit</summary>
       <form class="override-form" id="override-form">
@@ -312,14 +332,19 @@ function renderOverrideForm() {
           <span>To</span>
           <input type="date" id="date-to" value="${to}">
         </label>
+        <label class="override-form__check">
+          <input type="checkbox" id="effort-off" ${effortOff ? 'checked' : ''}>
+          <span>Disable effort-quality filter (include all activities)</span>
+        </label>
         <div class="override-form__actions">
           <button type="submit">Apply</button>
           <button type="button" class="link-button" id="reset-override">Reset</button>
         </div>
       </form>
       <p class="results-foot__note">
-        Use a CP override when recent rides don't reflect your real fitness (e.g. base block).
-        Use a date range to fit only a specific period — the recency window is dropped while a date range is active.
+        ${effortNote} The filter drops activities whose average power is below 70% of estimated FTP
+        (≈ 0.95 × all-time best 20-min MMP), so base rides don't drag the regression down.
+        Use a CP override or date range when even the filter doesn't capture your real fitness.
       </p>
     </details>
   `;
@@ -334,11 +359,13 @@ function wireOverrideForm() {
     const from = document.getElementById('date-from').value;
     const to = document.getElementById('date-to').value;
     const cp = cpStr ? Number(cpStr) : null;
+    const effortOff = document.getElementById('effort-off').checked;
     currentSettings = {
       ...currentSettings,
       cpOverrideW: Number.isFinite(cp) ? cp : null,
       dateFrom: from || null,
       dateTo: to || null,
+      effortFilterOff: effortOff,
     };
     await saveSettings(currentSettings);
     renderCurves(currentActivities, { fromCache: true });
@@ -385,7 +412,12 @@ function renderPredictBlock() {
     `;
   }
 
-  const overrideActive = !!(currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo);
+  const overrideActive = !!(
+    currentSettings.cpOverrideW ||
+    currentSettings.dateFrom ||
+    currentSettings.dateTo ||
+    currentSettings.effortFilterOff
+  );
   const headerMeta = overrideActive
     ? `CP model · custom override`
     : `CP model · 90d window, recency-weighted (42d half-life)`;

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -105,11 +105,23 @@ async function parseArchive(file) {
       const activity = await parseFit(b);
       if (activity?.powerStream) {
         const mmp = extractMmp(activity.powerStream);
+        // Average power across the activity's full power stream
+        // (including zero / coasting samples) is a coarse proxy for
+        // overall intensity. Used to flag low-effort rides that
+        // shouldn't anchor the recency-weighted CP fit.
+        let totalPower = 0;
+        for (let i = 0; i < activity.powerStream.length; i++) {
+          totalPower += activity.powerStream[i] || 0;
+        }
+        const avgPower = activity.powerStream.length
+          ? totalPower / activity.powerStream.length
+          : 0;
         self.postMessage({
           type: 'activity',
           startTime: activity.startTime,
           durationS: activity.durationS,
           distanceM: activity.distanceM,
+          avgPower,
           mmp,
         });
         withPower++;

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { rollingBest, recencyWeightedBest, normalizedPower, avgPower } from '../src/aggregate.js';
+import {
+  rollingBest,
+  recencyWeightedBest,
+  estimateFtp,
+  effortQualityStats,
+  normalizedPower,
+  avgPower,
+} from '../src/aggregate.js';
 
 describe('rollingBest', () => {
   it('takes the max across activities at each duration', () => {
@@ -17,6 +24,68 @@ describe('rollingBest', () => {
       { startTime: now - 10 * 86400_000, mmp: { 60: 250 } },
     ];
     expect(rollingBest(acts, { windowDays: 90, now })).toEqual({ 60: 250 });
+  });
+});
+
+describe('recencyWeightedBest with effort filter', () => {
+  const now = 100 * 86400_000;
+
+  it('drops activities whose IF falls below the threshold', () => {
+    const acts = [
+      // 5d old, IF = 280/300 = 0.93 → kept
+      { startTime: now - 5 * 86400_000, mmp: { 60: 320 }, avgPower: 280 },
+      // 5d old, IF = 150/300 = 0.50 → dropped
+      { startTime: now - 5 * 86400_000, mmp: { 60: 350 }, avgPower: 150 },
+    ];
+    const out = recencyWeightedBest(acts, { halfLifeDays: 42, now, minIF: 0.70, ftp: 300 });
+    expect(out).toEqual({ 60: 320 });
+  });
+
+  it('includes activities with missing avgPower regardless of filter', () => {
+    const acts = [
+      { startTime: now - 5 * 86400_000, mmp: { 60: 300 } /* no avgPower */ },
+    ];
+    const out = recencyWeightedBest(acts, { halfLifeDays: 42, now, minIF: 0.70, ftp: 300 });
+    expect(out).toEqual({ 60: 300 });
+  });
+
+  it('disables filter when minIF or ftp is missing', () => {
+    const acts = [
+      { startTime: now - 5 * 86400_000, mmp: { 60: 200 }, avgPower: 100 }, // would be IF=0.33
+    ];
+    expect(recencyWeightedBest(acts, { halfLifeDays: 42, now })).toEqual({ 60: 200 });
+  });
+});
+
+describe('estimateFtp', () => {
+  it('uses 95% of all-time best 20-min MMP', () => {
+    const acts = [
+      { mmp: { 1200: 280 } },
+      { mmp: { 1200: 295 } },
+      { mmp: { 1200: 250 } },
+    ];
+    expect(estimateFtp(acts)).toBeCloseTo(295 * 0.95, 4);
+  });
+
+  it('falls back to 15-min × 0.93 when no 20-min data', () => {
+    const acts = [{ mmp: { 900: 300 } }];
+    expect(estimateFtp(acts)).toBeCloseTo(300 * 0.93, 4);
+  });
+
+  it('returns null when neither is available', () => {
+    expect(estimateFtp([{ mmp: { 60: 350 } }])).toBeNull();
+  });
+});
+
+describe('effortQualityStats', () => {
+  it('counts included / excluded / unknown', () => {
+    const acts = [
+      { avgPower: 220 },           // IF 0.78 → included
+      { avgPower: 150 },           // IF 0.53 → excluded
+      { /* no avgPower */ },       // → unknown
+    ];
+    expect(effortQualityStats(acts, { minIF: 0.70, ftp: 281 }))
+      .toEqual({ included: 1, excluded: 1, unknown: 1 });
   });
 });
 


### PR DESCRIPTION
Closes #18.

Recency weighting alone can't tell low-effort base from real threshold work. Adds an intensity-factor filter:

- Worker reports mean power per activity (alongside MMP).
- FTP estimated from all-time best 20-min × 0.95 (Coggan).
- IF = avgPower / FTP. Activities below `minIF` (default 0.70) are dropped from the recency-weighted regression.
- Toggle in the override panel disables it. Stats line shows included / dropped / unknown counts.
- Activities without avgPower (legacy cache) included by default — re-parse archive to classify.

44 tests passing.

## Test plan
- [ ] Re-drop archive (so new activities have avgPower)
- [ ] Override panel: "Effort filter on: X included, Y dropped, Z unknown"
- [ ] CP should rise vs current 228 W if your dropped rides include a recent base block
- [ ] Tick "Disable effort-quality filter" → CP returns to old value
- [ ] Verify methodology page mentions the filter