### PR TITLE
Lengthen recency half-life: 42d → 180d

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -62,7 +62,7 @@
 
     <h3>Recency weighting (for the fit, not the table)</h3>
 
-    <p>The display table shows the raw rolling-best across the window. The CP fit is different: each effort is weighted by an exponential decay on age, half-life 42 days. A modest 5-minute power from last week can outrank a peak 5-minute power from 8 weeks ago, because we trust recent data more as a signal of current form.</p>
+    <p>The display table shows the raw rolling-best across the window. The CP fit is different: each effort is weighted by an exponential decay on age, half-life 180 days (≈ 6 months) &mdash; chosen to roughly match physiological detraining (a trained rider loses about 5&ndash;10% of capacity per month with no training, putting half-life at the 6-month order). Shorter half-lives over-penalize older efforts and underread real fitness during easy training blocks.</p>
 
     <p>The fit returns the <em>raw</em> power of whichever effort wins this weighted contest, so predictions are still calibrated against actual achieved watts. The weighting only changes which efforts the fit listens to.</p>
 

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -20,8 +20,13 @@ export function rollingBest(activityMmps, { windowDays = null, now = Date.now() 
 
 // Recency-weighted best. For each duration, every activity's MMP is
 // scaled by an exponential weight based on age — half-life
-// configurable, default 42 days (6 weeks). The activity with the
-// highest WEIGHTED power "wins" the duration; we return its RAW power.
+// configurable, default 180 days (≈ 6 months) to roughly match
+// physiological detraining (5-10% loss per month for trained
+// athletes). Shorter half-lives over-penalize older efforts: a
+// 60-day-old peak weighted at 42d half-life lands at 37%, but in
+// reality a rider's capacity drops only ~20% over 60 days even
+// with no training. The activity with the highest WEIGHTED power
+// "wins" the duration; we return its RAW power.
 //
 // Why not return the weighted value? The fit needs realistic watts.
 // Weighting selects which effort to trust (a moderate recent ride can
@@ -36,7 +41,7 @@ export function rollingBest(activityMmps, { windowDays = null, now = Date.now() 
 // re-parse archive to enable filtering on them).
 export function recencyWeightedBest(activityMmps, {
   windowDays = null,
-  halfLifeDays = 42,
+  halfLifeDays = 180,
   now = Date.now(),
   minIF = null,
   ftp = null,

--- a/src/app.js
+++ b/src/app.js
@@ -445,7 +445,7 @@ function renderPredictBlock() {
   );
   const headerMeta = overrideActive
     ? `CP model · custom override`
-    : `CP model · 90d window, recency-weighted (42d half-life)`;
+    : `CP model · 90d window, recency-weighted (180d half-life)`;
 
   return `
     <section class="predict">


### PR DESCRIPTION
Reported in testing: the 42-day half-life is too aggressive — physiologically a trained rider loses only ~5-10%/month with no training, putting half-life around 6 months. The previous default was effectively saying "a 60-day-old peak counts as 37% of itself" which is way too pessimistic.

180d default matches detraining curves and lets historical peaks still anchor the fit while remaining sensitive to genuinely improved or detrained recent rides.