### PR TITLE
Drop recency weighting; use effort-filtered raw rolling-best

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -60,11 +60,11 @@
 
     <p>The filter is on by default and visible in the "Adjust the fit" panel. The note there reports how many activities were included, dropped, or marked as unknown (missing average-power data, e.g., legacy IDB cache &mdash; re-parse the archive to classify).</p>
 
-    <h3>Recency weighting (for the fit, not the table)</h3>
+    <h3>Why no recency weighting</h3>
 
-    <p>The display table shows the raw rolling-best across the window. The CP fit is different: each effort is weighted by an exponential decay on age, half-life 180 days (≈ 6 months) &mdash; chosen to roughly match physiological detraining (a trained rider loses about 5&ndash;10% of capacity per month with no training, putting half-life at the 6-month order). Shorter half-lives over-penalize older efforts and underread real fitness during easy training blocks.</p>
+    <p>Earlier versions of Power Predict applied an exponential recency weight on top of the 90-day window. After testing, that turned out to over-penalize older efforts: physiologically, a trained rider's capacity changes only a few percent over weeks, not the dramatic decay implied by a half-life shorter than a couple of months. Within a 90-day window, peak power is peak power &mdash; if you hit it once, you can almost certainly hit it again.</p>
 
-    <p>The fit returns the <em>raw</em> power of whichever effort wins this weighted contest, so predictions are still calibrated against actual achieved watts. The weighting only changes which efforts the fit listens to.</p>
+    <p>The "soft training block" case &mdash; recent zone-2 rides making the rider <em>look</em> less fit than they are &mdash; is handled by the effort-quality filter rather than time-weighting. Easy rides are excluded from the regression input; the rider's real efforts within the window anchor the fit.</p>
 
     <h2>3. The Critical Power model</h2>
 

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -4,11 +4,18 @@
 
 import { DURATIONS_S } from './mmp.js';
 
-export function rollingBest(activityMmps, { windowDays = null, now = Date.now() } = {}) {
+export function rollingBest(activityMmps, {
+  windowDays = null,
+  now = Date.now(),
+  minIF = null,
+  ftp = null,
+} = {}) {
   const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
+  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
   const best = {};
-  for (const { startTime, mmp } of activityMmps) {
+  for (const { startTime, mmp, avgPower } of activityMmps) {
     if (startTime < cutoff) continue;
+    if (filterEnabled && Number.isFinite(avgPower) && avgPower / ftp < minIF) continue;
     for (const d of DURATIONS_S) {
       const v = mmp[d];
       if (typeof v !== 'number') continue;

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { DURATIONS_S } from './mmp.js';
-import { rollingBest, recencyWeightedBest, estimateFtp, effortQualityStats } from './aggregate.js';
+import { rollingBest, estimateFtp, effortQualityStats } from './aggregate.js';
 import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
 import {
@@ -263,22 +263,18 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     ? effortQualityStats(filtered, { minIF, ftp })
     : { included: filtered.length, excluded: 0, unknown: 0 };
 
-  // The fit's regression uses a recency-weighted aggregation of the
-  // 90-day window so a 6-week-old peak doesn't outweigh more recent
-  // rides. The observed-point set (used to anchor decay on real
-  // efforts) stays as the raw rolling-best — a real ride at 45 min
-  // months ago still proves capability and keeps long-duration
-  // predictions honest.
-  //
-  // If the user supplied a custom date range, we let the rolling-90d
-  // logic still apply on top of the filtered set. If they prefer the
-  // entire range, they can set a wider window.
+  // The fit's regression uses raw rolling-best from the same window
+  // the table displays — within 90 days, peak power IS what the
+  // rider has demonstrated they can do. Recency weighting on top of
+  // the window is over-engineering; physiology doesn't decay over
+  // weeks the way the model implied. The effort filter handles the
+  // "tons of zone-2 base" case by excluding low-IF rides outright.
   const fitWindow = (dateFromMs || dateToMs) ? null : 90;
-  const last90Weighted = recencyWeightedBest(filtered, { windowDays: fitWindow, ...effortOpts });
-  const allTimeWeighted = recencyWeightedBest(filtered, effortOpts);
+  const last90Fit = rollingBest(filtered, { windowDays: fitWindow, ...effortOpts });
+  const allTimeFit = rollingBest(filtered, effortOpts);
   currentFit =
-    fitCp2(mmpToPoints(last90Weighted), undefined, { observedPoints: mmpToPoints(last90) })
-    || fitCp2(mmpToPoints(allTimeWeighted), undefined, { observedPoints: mmpToPoints(allTime) });
+    fitCp2(mmpToPoints(last90Fit), undefined, { observedPoints: mmpToPoints(last90) })
+    || fitCp2(mmpToPoints(allTimeFit), undefined, { observedPoints: mmpToPoints(allTime) });
 
   // Apply CP override on top of the fit (W' stays from the underlying
   // fit so the curve shape is data-derived, not a hand-set hyperbola).
@@ -445,7 +441,7 @@ function renderPredictBlock() {
   );
   const headerMeta = overrideActive
     ? `CP model · custom override`
-    : `CP model · 90d window, recency-weighted (180d half-life)`;
+    : `CP model · last 90 days, effort-filtered`;
 
   return `
     <section class="predict">


### PR DESCRIPTION
Reported: even 180-day half-life implies a baseline decay that doesn't match physiology — within 90 days, peak power is peak power.

Regression input switches to raw rollingBest (with the existing effort filter applied). The 'soft training block' case is solved by the filter dropping low-IF rides, not by time-weighting. The rider's real efforts within the window anchor the fit; CP no longer collapses during base periods just because the model time-discounted the user's threshold work.