### PR TITLE
Tooltips on CP / W' / RMSE / Points

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -649,6 +649,41 @@ main {
 .fit-stats > div {
   padding: 0.85rem 1rem;
   border-right: var(--rule-soft);
+  position: relative;
+}
+.fit-stats > div[data-tooltip] { cursor: help; }
+.fit-stats > div[data-tooltip]:hover::after,
+.fit-stats > div[data-tooltip]:focus-within::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0.75rem;
+  right: 0.75rem;
+  z-index: 10;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-style: normal;
+  font-weight: 400;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--ink);
+  box-shadow: 0 6px 16px rgba(26, 22, 18, 0.18);
+  white-space: normal;
+  pointer-events: none;
+}
+.fit-stats > div[data-tooltip]:hover::before,
+.fit-stats > div[data-tooltip]:focus-within::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 1.1rem;
+  border: 5px solid transparent;
+  border-top-color: var(--ink);
+  z-index: 11;
 }
 .fit-stats > div:last-child { border-right: none; }
 .fit-stats dt {

--- a/src/app.js
+++ b/src/app.js
@@ -451,10 +451,22 @@ function renderPredictBlock() {
       </header>
 
       <dl class="fit-stats">
-        <div><dt>CP${currentFit.overridden ? ' *' : ''}</dt><dd>${formatPower(currentFit.cpW)}</dd></div>
-        <div><dt>W'</dt><dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd></div>
-        <div><dt>RMSE</dt><dd>${currentFit.rmse.toFixed(1)} W</dd></div>
-        <div><dt>Points</dt><dd>${currentFit.nPoints}</dd></div>
+        <div data-tooltip="Critical Power — the asymptote of your power-duration curve. The wattage you could theoretically hold indefinitely if no other system failed first.">
+          <dt>CP${currentFit.overridden ? ' *' : ''}</dt>
+          <dd>${formatPower(currentFit.cpW)}</dd>
+        </div>
+        <div data-tooltip="Anaerobic work capacity (W-prime) — the finite work above CP you can do before exhausting that reserve. Slope of the regression in joules.">
+          <dt>W'</dt>
+          <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd>
+        </div>
+        <div data-tooltip="Root-mean-squared error of the regression. How closely the CP/W' hyperbola tracks your 3-20 minute MMPs. Lower = tighter fit.">
+          <dt>RMSE</dt>
+          <dd>${currentFit.rmse.toFixed(1)} W</dd>
+        </div>
+        <div data-tooltip="Number of MMP points (durations between 3 and 20 minutes) the regression fitted on.">
+          <dt>Points</dt>
+          <dd>${currentFit.nPoints}</dd>
+        </div>
       </dl>
 
       ${renderOverrideForm()}


### PR DESCRIPTION
Hover any of the fit stats to see a plain-language description. CSS-only via `data-tooltip` attribute. Keyboard-accessible via :focus-within.