### PR TITLE
Remove effort-filter toggle (filter stays always on)

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -58,7 +58,7 @@
 
     <p>Power Predict estimates your FTP from your all-time best 20-minute mean maximal power (Coggan: FTP &approx; 0.95 &times; MMP<sub>20m</sub>) and computes an <strong>intensity factor</strong> (IF = average power / FTP) for each activity. Activities with IF below 0.70 (roughly tempo or harder) are dropped from the recency-weighted regression input. Hard rides anchor the fit; easy rides don't.</p>
 
-    <p>The filter is on by default and visible in the "Adjust the fit" panel. The note there reports how many activities were included, dropped, or marked as unknown (missing average-power data, e.g., legacy IDB cache &mdash; re-parse the archive to classify).</p>
+    <p>The filter is always on. The "Adjust the fit" panel reports how many activities were included, dropped, or marked as unknown (missing average-power data, e.g., legacy IDB cache &mdash; re-parse the archive to classify).</p>
 
     <h3>Why no recency weighting</h3>
 

--- a/src/app.js
+++ b/src/app.js
@@ -255,11 +255,10 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // falls below the threshold so low-effort base rides don't anchor
   // the regression. Default ON. FTP is estimated from all-time best
   // 20-min MMP via Coggan's 0.95 factor.
-  const effortFilterOn = currentSettings.effortFilterOff !== true;
   const ftp = estimateFtp(filtered);
   const minIF = currentSettings.minIF ?? 0.70;
-  const effortOpts = effortFilterOn && ftp ? { minIF, ftp } : {};
-  currentEffortStats = effortFilterOn
+  const effortOpts = ftp ? { minIF, ftp } : {};
+  currentEffortStats = ftp
     ? effortQualityStats(filtered, { minIF, ftp })
     : { included: filtered.length, excluded: 0, unknown: 0 };
 
@@ -379,14 +378,11 @@ function renderOverrideForm() {
   const cp = currentSettings.cpOverrideW ?? '';
   const from = currentSettings.dateFrom || '';
   const to = currentSettings.dateTo || '';
-  const effortOff = currentSettings.effortFilterOff === true;
   const stats = currentEffortStats;
-  const effortNote = effortOff
-    ? 'Effort filter off — all activities feed the fit.'
-    : `Effort filter on: ${stats.included} included, ${stats.excluded} dropped as low-effort${stats.unknown ? `, ${stats.unknown} unknown (re-parse archive to classify)` : ''}.`;
+  const effortNote = `Effort filter: ${stats.included} included, ${stats.excluded} dropped as low-effort${stats.unknown ? `, ${stats.unknown} unknown (re-parse archive to classify)` : ''}.`;
   return `
     <details class="override-panel" ${
-      currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo || effortOff
+      currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo
         ? 'open' : ''
     }>
       <summary>Adjust the fit</summary>
@@ -403,19 +399,15 @@ function renderOverrideForm() {
           <span>To</span>
           <input type="date" id="date-to" value="${to}">
         </label>
-        <label class="override-form__check">
-          <input type="checkbox" id="effort-off" ${effortOff ? 'checked' : ''}>
-          <span>Disable effort-quality filter (include all activities)</span>
-        </label>
         <div class="override-form__actions">
           <button type="submit">Apply</button>
           <button type="button" class="link-button" id="reset-override">Reset</button>
         </div>
       </form>
       <p class="results-foot__note">
-        ${effortNote} The filter drops activities whose average power is below 70% of estimated FTP
-        (≈ 0.95 × all-time best 20-min MMP), so base rides don't drag the regression down.
-        Use a CP override or date range when even the filter doesn't capture your real fitness.
+        ${effortNote} Activities below 70% of estimated FTP (≈ 0.95 × all-time best 20-min MMP)
+        are dropped from the regression so base rides don't drag the fit down. Use a CP override
+        or date range when even the filter doesn't capture your real fitness.
       </p>
     </details>
   `;
@@ -430,13 +422,11 @@ function wireOverrideForm() {
     const from = document.getElementById('date-from').value;
     const to = document.getElementById('date-to').value;
     const cp = cpStr ? Number(cpStr) : null;
-    const effortOff = document.getElementById('effort-off').checked;
     currentSettings = {
       ...currentSettings,
       cpOverrideW: Number.isFinite(cp) ? cp : null,
       dateFrom: from || null,
       dateTo: to || null,
-      effortFilterOff: effortOff,
     };
     await saveSettings(currentSettings);
     renderCurves(currentActivities, { fromCache: true });
@@ -486,8 +476,7 @@ function renderPredictBlock() {
   const overrideActive = !!(
     currentSettings.cpOverrideW ||
     currentSettings.dateFrom ||
-    currentSettings.dateTo ||
-    currentSettings.effortFilterOff
+    currentSettings.dateTo
   );
   const headerMeta = overrideActive
     ? `CP model · custom override`


### PR DESCRIPTION
## Summary
- Drops the "Disable effort-quality filter" checkbox from the Adjust-the-fit panel.
- Filter logic stays — it still excludes rides with IF < 0.70 from the regression and reports included/dropped/unknown counts.
- Updates methodology page wording from "on by default" to "always on".

The toggle never carried its weight: rolling-best already self-selects hard rides at the 3-20 min fit window, so flipping the filter off rarely moved CP/W' meaningfully. Less UI surface, same behavior in practice.

## Test plan
- [ ] Adjust-the-fit panel renders without the checkbox.
- [ ] Effort-filter note still shows the included/dropped/unknown counts.
- [ ] CP override and date range continue to work.
- [ ] Existing users with `effortFilterOff: true` in IDB settings see no errors (the field is just ignored now).