### PR TITLE
Distance × speed mode for the predict form

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -715,12 +715,16 @@ main {
 .fit-stats__quality.is-mid  { color: var(--burnt); }
 .fit-stats__quality.is-bad  { color: var(--oxblood); }
 
+.predict-mode-tabs {
+  margin-bottom: 1rem;
+}
 .predict-form {
   display: flex;
   align-items: flex-end;
   gap: 1rem;
   flex-wrap: wrap;
 }
+.predict-form__field[hidden] { display: none; }
 .predict-form__field {
   flex: 1 1 16rem;
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -518,10 +518,23 @@ function renderPredictBlock() {
         <div id="curve-chart" class="curve-chart"></div>
       </div>
 
-      <form class="predict-form" id="predict-form">
-        <label class="predict-form__field">
+      <div class="predict-mode-tabs curve-window-tabs" role="tablist">
+        <button type="button" data-mode="duration" role="tab" class="is-active">Duration</button>
+        <button type="button" data-mode="distance" role="tab">Distance × speed</button>
+      </div>
+
+      <form class="predict-form" id="predict-form" data-mode="duration">
+        <label class="predict-form__field" data-mode-field="duration">
           <span>Target duration</span>
-          <input type="text" id="predict-input" placeholder="45m or 2h30m" autocomplete="off" spellcheck="false" required>
+          <input type="text" id="predict-input" placeholder="45m or 2h30m" autocomplete="off" spellcheck="false">
+        </label>
+        <label class="predict-form__field" data-mode-field="distance" hidden>
+          <span>Distance (km)</span>
+          <input type="number" id="predict-distance" min="0.1" max="500" step="0.1" placeholder="40" autocomplete="off">
+        </label>
+        <label class="predict-form__field" data-mode-field="distance" hidden>
+          <span>Avg speed (km/h)</span>
+          <input type="number" id="predict-speed" min="1" max="80" step="0.1" placeholder="35" autocomplete="off">
         </label>
         <button type="submit">Predict</button>
       </form>
@@ -533,14 +546,44 @@ function renderPredictBlock() {
 function wirePredictForm() {
   const form = document.getElementById('predict-form');
   if (!form) return;
+  const tabs = document.querySelectorAll('.predict-mode-tabs button');
+  tabs.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const mode = btn.dataset.mode;
+      tabs.forEach((b) => b.classList.toggle('is-active', b === btn));
+      form.dataset.mode = mode;
+      form.querySelectorAll('[data-mode-field]').forEach((field) => {
+        field.hidden = field.dataset.modeField !== mode;
+      });
+      const focusEl = mode === 'duration'
+        ? document.getElementById('predict-input')
+        : document.getElementById('predict-distance');
+      focusEl?.focus();
+    });
+  });
+
   form.addEventListener('submit', (e) => {
     e.preventDefault();
-    const input = document.getElementById('predict-input');
     const out = document.getElementById('predict-output');
-    const seconds = parseDuration(input.value);
-    if (!seconds) {
+    let seconds;
+    let parseError = null;
+
+    if (form.dataset.mode === 'distance') {
+      const km = Number(document.getElementById('predict-distance').value);
+      const kmh = Number(document.getElementById('predict-speed').value);
+      if (!Number.isFinite(km) || km <= 0 || !Number.isFinite(kmh) || kmh <= 0) {
+        parseError = 'Enter a positive distance and speed.';
+      } else {
+        seconds = Math.round((km / kmh) * 3600);
+      }
+    } else {
+      seconds = parseDuration(document.getElementById('predict-input').value);
+      if (!seconds) parseError = 'Couldn\'t parse that. Try "45m", "1h30m", or "90s".';
+    }
+
+    if (parseError) {
       out.hidden = false;
-      out.innerHTML = `<p class="predict-output__error">Couldn't parse that. Try "45m", "1h30m", or "90s".</p>`;
+      out.innerHTML = `<p class="predict-output__error">${parseError}</p>`;
       return;
     }
     const result = predictPower(currentFit, seconds);
@@ -549,9 +592,12 @@ function wirePredictForm() {
       out.innerHTML = `<p class="predict-output__error">Prediction failed.</p>`;
       return;
     }
+    const labelExtra = form.dataset.mode === 'distance'
+      ? ` · ${Number(document.getElementById('predict-distance').value)} km @ ${Number(document.getElementById('predict-speed').value)} km/h`
+      : '';
     out.hidden = false;
     out.innerHTML = `
-      <p class="predict-output__label">Predicted for ${formatDuration(seconds)}</p>
+      <p class="predict-output__label">Predicted for ${formatDuration(seconds)}${labelExtra}</p>
       <p class="predict-output__value">${Math.round(result.powerW)}<span class="predict-output__unit">W</span></p>
       <p class="predict-output__band">
         Range ${Math.round(result.low)}–${Math.round(result.high)} W


### PR DESCRIPTION
## Summary
- New tab strip above the predict form: **Duration** | **Distance × speed**.
- Distance mode takes km + km/h, computes the implied duration in seconds, and runs the same CP-model prediction.
- Output label includes both the derived duration and the original distance/speed so the user can sanity-check.

Closes #14.

## Test plan
- [ ] Default mode is Duration; existing "45m" / "2h30m" parsing still works.
- [ ] Switching to Distance × speed swaps the inputs in place and focuses the distance field.
- [ ] 40 km @ 35 km/h → predicted for 1h08m, with the trailing label showing `40 km @ 35 km/h`.
- [ ] Empty or zero values trigger the inline error rather than a NaN duration.
- [ ] Extrapolated flag still appears for far-out durations.