### PR TITLE
Fitness-drift normalization for the all-time fit fallback

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -132,15 +132,21 @@
       <li>Hill, A.V. <em>The physiological basis of athletic records</em>. 1925. Earliest hyperbolic power-duration model.</li>
     </ul>
 
+    <h3>Fitness drift on the all-time fallback</h3>
+
+    <p>When the last-90-days window has too few MMP points to fit a model, Power Predict falls back to your all-time data. The all-time set is dominated by peak efforts that may be years old, when the rider was demonstrably fitter (or less fit) than today &mdash; an unmodified fallback would anchor the fit to a stranger.</p>
+
+    <p>To correct for this we estimate eFTP at each activity's date as 0.95 × best 20-min MMP across the surrounding 90 days, then anchor eFTP<sub>now</sub> from the same window ending today. Each activity's MMP values are scaled by <em>eFTP<sub>now</sub> / eFTP<sub>then</sub></em> before merging into the all-time rolling-best, with the ratio clamped to [0.7, 1.3] so a sparse historical window can't produce wild adjustments. Activities whose window has no 20-min effort pass through unchanged.</p>
+
+    <p>Drift normalization only feeds the fit's fallback path. The displayed all-time table column stays raw history &mdash; the dots are still what you actually rode. eFTP<sub>now</sub> is reported as a stat on the predict panel.</p>
+
     <h2>Limitations and planned improvements</h2>
 
     <p>Today's predictions assume your last 90 days of data accurately reflect your current fitness. Issues planned for upcoming releases:</p>
 
     <ul>
-      <li><strong>Recency weighting</strong> &mdash; weight recent efforts more heavily within the window so a peak ride from week 1 doesn't outweigh week 12.</li>
-      <li><strong>Effort-quality flagging</strong> &mdash; only count an MMP as a "true" point if the activity's overall intensity suggests you were going hard; treat tempo-pace bests as soft data points.</li>
-      <li><strong>Fitness drift normalization</strong> &mdash; rescale older efforts by the ratio of estimated FTP then vs. now, so a year-old peak doesn't dominate.</li>
-      <li><strong>Manual fitness override</strong> &mdash; CP override and custom date range are now available under "Adjust the fit" on the predict panel. CP override replaces the model's CP while keeping the data-derived W'. Date range filters which activities feed the fit, useful for "my best 90 days from earlier this year".</li>
+      <li><strong>3-parameter CP fit</strong> &mdash; add a P<sub>max</sub> term so the model behaves on the &lt;3 minute end. Today the regression window starts at 3 min because the 2-parameter form distorts below that.</li>
+      <li><strong>Training-load adjustment</strong> &mdash; modulate predictions by recent CTL/ATL/TSB so a rider mid-taper doesn't get the same forecast as a rider mid-build.</li>
     </ul>
 
     <p>Track these on the <a href="https://github.com/iammike/power-predict/milestones" target="_blank" rel="noopener">project milestones</a>.</p>

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import { DURATIONS_S } from './mmp.js';
 import { rollingBest, estimateFtp } from './aggregate.js';
+import { normalizeForDrift } from './drift.js';
 import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
 import {
@@ -230,6 +231,7 @@ function formatBytes(bytes) {
 
 // Held in module scope so the predict form + chart toggles can read.
 let currentFit = null;
+let currentEftpNow = null;
 let currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
@@ -266,9 +268,17 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // "tons of zone-2 base" case by excluding low-IF rides outright.
   const fitWindow = (dateFromMs || dateToMs) ? null : 90;
   const last90Fit = rollingBest(filtered, { windowDays: fitWindow, ...effortOpts });
-  const allTimeFit = rollingBest(filtered, effortOpts);
+
+  // Drift-normalize for the all-time fallback so an old peak ridden
+  // when the rider was demonstrably fitter doesn't anchor today's
+  // prediction. Only the fallback path uses normalized data — the
+  // displayed all-time table stays raw history.
+  const drift = normalizeForDrift(filtered);
+  const allTimeFitNorm = rollingBest(drift.activities, effortOpts);
+  currentEftpNow = drift.eftpNow;
+
   const primaryFit = fitCp2(mmpToPoints(last90Fit), undefined, { observedPoints: mmpToPoints(last90) });
-  const fallbackFit = fitCp2(mmpToPoints(allTimeFit), undefined, { observedPoints: mmpToPoints(allTime) });
+  const fallbackFit = fitCp2(mmpToPoints(allTimeFitNorm), undefined, { observedPoints: mmpToPoints(allTime) });
   currentFit = primaryFit
     ? { ...primaryFit, fallback: false }
     : (fallbackFit ? { ...fallbackFit, fallback: true } : null);
@@ -499,6 +509,12 @@ function renderPredictBlock() {
           <dd>${currentFit.nPoints}</dd>
           <span class="fit-stats__quality ${pointsQuality(currentFit.nPoints).cls}">${pointsQuality(currentFit.nPoints).label}</span>
         </div>
+        ${currentEftpNow ? `
+        <div data-tooltip="Estimated FTP from your most recent 90 days: 0.95 × best 20-min MMP. Used to drift-normalize older efforts when the fit falls back to all-time data.">
+          <dt>eFTP</dt>
+          <dd>${formatPower(currentEftpNow)}</dd>
+          <span class="fit-stats__quality is-good">last 90d</span>
+        </div>` : ''}
       </dl>
 
       ${renderOverrideForm()}

--- a/src/drift.js
+++ b/src/drift.js
@@ -1,0 +1,69 @@
+// Fitness-drift normalization. The all-time curve is dominated by
+// peak efforts that may be years old, when the rider was demonstrably
+// fitter (or less fit) than today. Without correction, the fit's
+// fallback to all-time data anchors on a stranger.
+//
+// Approach: estimate eFTP at each point in time from a backward
+// 90-day window's best 20-min MMP (Coggan 0.95). Anchor eFTP_now from
+// the same window ending today. For any older activity with a
+// computable eFTP_then, scale its MMP values by `eFTP_now / eFTP_then`
+// before merging into rolling-best. Activities whose window is too
+// sparse to compute eFTP_then pass through unchanged.
+
+const DAY_MS = 86400_000;
+const WINDOW_DAYS = 90;
+const SCALE_MIN = 0.7;
+const SCALE_MAX = 1.3;
+
+// eFTP for a given timestamp = 0.95 × max 20-min MMP across activities
+// in [t - windowDays, t]. Returns null if no activity in the window
+// has a 20-min MMP. Falls back to 15-min × 0.93 when no 20-min data
+// is available — same hierarchy as estimateFtp().
+function eftpAt(activities, t, windowDays = WINDOW_DAYS) {
+  const cutoff = t - windowDays * DAY_MS;
+  let best20 = 0;
+  let best15 = 0;
+  for (const a of activities) {
+    if (a.startTime > t || a.startTime < cutoff) continue;
+    const v20 = a.mmp?.[1200];
+    const v15 = a.mmp?.[900];
+    if (typeof v20 === 'number' && v20 > best20) best20 = v20;
+    if (typeof v15 === 'number' && v15 > best15) best15 = v15;
+  }
+  if (best20 > 0) return best20 * 0.95;
+  if (best15 > 0) return best15 * 0.93;
+  return null;
+}
+
+// Returns a new activity list with each activity's MMP scaled by
+// `eFTP_now / eFTP_then`. Scale clamped to [0.7, 1.3] so a sparse
+// historical window can't produce wild adjustments. Activities with
+// no computable eFTP_then pass through unchanged.
+//
+// `now` defaults to the latest activity's startTime, not Date.now() —
+// this keeps tests deterministic and handles archives that haven't
+// been re-uploaded recently (eFTP_now is anchored to "the freshest
+// data we have," not wall-clock time).
+export function normalizeForDrift(activities, opts = {}) {
+  if (!activities.length) return { activities, eftpNow: null };
+  const now = opts.now ?? Math.max(...activities.map((a) => a.startTime));
+  const windowDays = opts.windowDays ?? WINDOW_DAYS;
+  const eftpNow = eftpAt(activities, now, windowDays);
+  if (!eftpNow) return { activities, eftpNow: null };
+
+  const out = activities.map((a) => {
+    const eftpThen = eftpAt(activities, a.startTime, windowDays);
+    if (!eftpThen) return a;
+    const rawScale = eftpNow / eftpThen;
+    const scale = Math.max(SCALE_MIN, Math.min(SCALE_MAX, rawScale));
+    if (Math.abs(scale - 1) < 0.005) return a;
+    const scaledMmp = {};
+    for (const d of Object.keys(a.mmp || {})) {
+      scaledMmp[d] = a.mmp[d] * scale;
+    }
+    return { ...a, mmp: scaledMmp, _driftScale: scale };
+  });
+  return { activities: out, eftpNow };
+}
+
+export { eftpAt };

--- a/tests/drift.test.js
+++ b/tests/drift.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { eftpAt, normalizeForDrift } from '../src/drift.js';
+
+const day = 86400_000;
+
+describe('eftpAt', () => {
+  it('returns 0.95 × best 20-min MMP in the backward window', () => {
+    const acts = [
+      { startTime: 0,        mmp: { 1200: 280 } },
+      { startTime: 30 * day, mmp: { 1200: 300 } },
+      { startTime: 60 * day, mmp: { 1200: 250 } },
+    ];
+    expect(eftpAt(acts, 60 * day)).toBeCloseTo(300 * 0.95, 4);
+  });
+
+  it('excludes activities outside the window', () => {
+    const acts = [
+      { startTime: 0,         mmp: { 1200: 999 } }, // 200d old, out
+      { startTime: 150 * day, mmp: { 1200: 250 } },
+    ];
+    expect(eftpAt(acts, 200 * day)).toBeCloseTo(250 * 0.95, 4);
+  });
+
+  it('falls back to 15-min × 0.93 when no 20-min data', () => {
+    const acts = [{ startTime: 10 * day, mmp: { 900: 290 } }];
+    expect(eftpAt(acts, 10 * day)).toBeCloseTo(290 * 0.93, 4);
+  });
+
+  it('returns null when neither 20m nor 15m exist', () => {
+    expect(eftpAt([{ startTime: 0, mmp: { 60: 350 } }], 0)).toBeNull();
+  });
+});
+
+describe('normalizeForDrift', () => {
+  it('scales an old activity up when current fitness is higher', () => {
+    const acts = [
+      { startTime: 0,         mmp: { 1200: 200, 300: 240 } }, // eFTP_then ≈ 190
+      { startTime: 200 * day, mmp: { 1200: 250 } },           // eFTP_now  ≈ 237.5
+    ];
+    const { activities, eftpNow } = normalizeForDrift(acts);
+    expect(eftpNow).toBeCloseTo(250 * 0.95, 4);
+    // First activity scales by 250/200 = 1.25 (within clamp)
+    expect(activities[0].mmp[1200]).toBeCloseTo(200 * 1.25, 2);
+    expect(activities[0].mmp[300]).toBeCloseTo(240 * 1.25, 2);
+    expect(activities[0]._driftScale).toBeCloseTo(1.25, 4);
+    // Most recent activity is the eftp_now anchor — scale ≈ 1, passes through
+    expect(activities[1].mmp[1200]).toBe(250);
+  });
+
+  it('clamps scale to [0.7, 1.3]', () => {
+    const acts = [
+      { startTime: 0,         mmp: { 1200: 100 } }, // eFTP 95
+      { startTime: 200 * day, mmp: { 1200: 400 } }, // eFTP 380, ratio 4.0 → clamp 1.3
+    ];
+    const { activities } = normalizeForDrift(acts);
+    expect(activities[0]._driftScale).toBeCloseTo(1.3, 4);
+    expect(activities[0].mmp[1200]).toBeCloseTo(130, 2);
+  });
+
+  it('passes activities through unchanged when no eFTP_now is available', () => {
+    const acts = [{ startTime: 0, mmp: { 60: 350 } }]; // no 20m/15m
+    const { activities, eftpNow } = normalizeForDrift(acts);
+    expect(eftpNow).toBeNull();
+    expect(activities).toBe(acts);
+  });
+
+  it('passes individual activities through when their window has no eFTP', () => {
+    const acts = [
+      { startTime: 0,         mmp: { 60: 280 } }, // no 20m in window — pass through
+      { startTime: 200 * day, mmp: { 1200: 300 } },
+    ];
+    const { activities } = normalizeForDrift(acts);
+    expect(activities[0]).toBe(acts[0]);
+    expect(activities[0]._driftScale).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/drift.js` computes per-activity eFTP from a backward 90-day window (0.95 × best 20-min MMP, fallback 0.93 × 15-min). `normalizeForDrift(activities)` returns activities with MMP scaled by `eFTP_now / eFTP_then`, ratio clamped to [0.7, 1.3].
- Wired into the fit pipeline so the all-time fallback uses drift-normalized data. The 90-day primary path and the displayed all-time table stay raw history.
- New **eFTP** stat in the predict panel (last-90d estimate).
- Methodology page gets a "Fitness drift on the all-time fallback" section. Updated the planned-improvements list (eFTP/drift now lives, 3-param CP and CTL/ATL/TSB remain).
- 8 new unit tests covering the eFTP window, fallback hierarchy, scale clamp, and pass-through cases.

Closes #17.

## Test plan
- [ ] Predict panel shows the new **eFTP** stat (~0.95 × your best recent 20-min MMP).
- [ ] CP/W'/RMSE/Points unchanged when the 90d primary fit succeeds.
- [ ] Force a fallback (set a tight date range with sparse 3-20 min coverage); resulting CP looks reasonable rather than anchored to ancient peaks.
- [ ] All-time table column values unchanged (drift doesn't touch the displayed data).
- [ ] No console errors. `npm test` is 52 green.