### PR TITLE
Move RMSE and Points behind a disclosure

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -715,6 +715,36 @@ main {
 .fit-stats__quality.is-mid  { color: var(--burnt); }
 .fit-stats__quality.is-bad  { color: var(--oxblood); }
 
+.fit-details {
+  margin: 0.75rem 0 0;
+}
+.fit-details > summary {
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  padding: 0.25rem 0;
+}
+.fit-details > summary::-webkit-details-marker { display: none; }
+.fit-details > summary::before {
+  content: '+';
+  display: inline-block;
+  width: 1em;
+  font-family: var(--mono);
+  color: var(--oxblood);
+  margin-right: 0.4rem;
+}
+.fit-details[open] > summary::before { content: '−'; }
+.fit-details[open] > summary { color: var(--ink-soft); }
+.fit-stats--secondary {
+  margin-top: 0.5rem;
+}
+.fit-stats--secondary dd { font-size: 1.1rem; }
+
 .predict-form {
   display: flex;
   align-items: flex-end;

--- a/src/app.js
+++ b/src/app.js
@@ -499,16 +499,6 @@ function renderPredictBlock() {
           <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd>
           <span class="fit-stats__quality ${wPrimeQuality(currentFit.wPrimeJ).cls}">${wPrimeQuality(currentFit.wPrimeJ).label}</span>
         </div>
-        <div data-tooltip="${rmseTooltip(currentFit.rmse)}">
-          <dt>RMSE</dt>
-          <dd>${currentFit.rmse.toFixed(1)} W</dd>
-          <span class="fit-stats__quality ${rmseQuality(currentFit.rmse).cls}">${rmseQuality(currentFit.rmse).label}</span>
-        </div>
-        <div data-tooltip="${pointsTooltip(currentFit.nPoints)}">
-          <dt>Points</dt>
-          <dd>${currentFit.nPoints}</dd>
-          <span class="fit-stats__quality ${pointsQuality(currentFit.nPoints).cls}">${pointsQuality(currentFit.nPoints).label}</span>
-        </div>
         ${currentEftpNow ? `
         <div data-tooltip="Estimated FTP from your most recent 90 days: 0.95 × best 20-min MMP. Used to drift-normalize older efforts when the fit falls back to all-time data.">
           <dt>eFTP</dt>
@@ -516,6 +506,22 @@ function renderPredictBlock() {
           <span class="fit-stats__quality is-good">last 90d</span>
         </div>` : ''}
       </dl>
+
+      <details class="fit-details">
+        <summary>Fit diagnostics</summary>
+        <dl class="fit-stats fit-stats--secondary">
+          <div data-tooltip="${rmseTooltip(currentFit.rmse)}">
+            <dt>RMSE</dt>
+            <dd>${currentFit.rmse.toFixed(1)} W</dd>
+            <span class="fit-stats__quality ${rmseQuality(currentFit.rmse).cls}">${rmseQuality(currentFit.rmse).label}</span>
+          </div>
+          <div data-tooltip="${pointsTooltip(currentFit.nPoints)}">
+            <dt>Points</dt>
+            <dd>${currentFit.nPoints}</dd>
+            <span class="fit-stats__quality ${pointsQuality(currentFit.nPoints).cls}">${pointsQuality(currentFit.nPoints).label}</span>
+          </div>
+        </dl>
+      </details>
 
       ${renderOverrideForm()}
 


### PR DESCRIPTION
## Summary
- Top stats row stays on a single line: **CP / W' / eFTP**.
- New **Fit diagnostics** disclosure below holds RMSE and Points with smaller value sizing — same tooltips, same quality bands, just out of the headline.

## Test plan
- [ ] Top row never wraps; values render side-by-side.
- [ ] Fit diagnostics summary is closed by default; clicking expands to show RMSE and Points.
- [ ] Hover tooltips still work on all five stats.
- [ ] Quality color bands (green/burnt/oxblood) carry through.