### PR TITLE
Link MMP table cells to source Strava activities

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -390,6 +390,18 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
+.mmp-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--hair-strong);
+  transition: color 160ms ease, border-bottom-color 160ms ease;
+}
+.mmp-link:hover,
+.mmp-link:focus-visible {
+  color: var(--oxblood);
+  border-bottom-color: var(--oxblood);
+}
+
 .results-foot {
   display: flex;
   justify-content: space-between;

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -25,6 +25,32 @@ export function rollingBest(activityMmps, {
   return best;
 }
 
+// Same selection logic as rollingBest, but also tracks which
+// activity owns each per-duration max so the UI can deep-link cells
+// to the source ride. Returns { [duration]: { value, stravaId } }.
+export function rollingBestWithOwners(activityMmps, {
+  windowDays = null,
+  now = Date.now(),
+  minIF = null,
+  ftp = null,
+} = {}) {
+  const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
+  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
+  const best = {};
+  for (const a of activityMmps) {
+    if (a.startTime < cutoff) continue;
+    if (filterEnabled && Number.isFinite(a.avgPower) && a.avgPower / ftp < minIF) continue;
+    for (const d of DURATIONS_S) {
+      const v = a.mmp?.[d];
+      if (typeof v !== 'number') continue;
+      if (best[d] === undefined || v > best[d].value) {
+        best[d] = { value: v, stravaId: a.stravaId ?? null };
+      }
+    }
+  }
+  return best;
+}
+
 // Recency-weighted best. For each duration, every activity's MMP is
 // scaled by an exponential weight based on age — half-life
 // configurable, default 180 days (≈ 6 months) to roughly match

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { DURATIONS_S } from './mmp.js';
-import { rollingBest, estimateFtp } from './aggregate.js';
+import { rollingBest, rollingBestWithOwners, estimateFtp } from './aggregate.js';
 import { normalizeForDrift } from './drift.js';
 import { renderCurveChart } from './curve-chart.js';
 import { formatDuration, formatPower } from './format.js';
@@ -124,6 +124,7 @@ async function handleArchive(file) {
                 distanceM: msg.distanceM,
                 avgPower: msg.avgPower,
                 mmp: msg.mmp,
+                stravaId: msg.stravaId ?? null,
               });
             }
             withPower++;
@@ -250,6 +251,9 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const allTime = rollingBest(filtered);
   const last90 = rollingBest(filtered, { windowDays: 90 });
   const last30 = rollingBest(filtered, { windowDays: 30 });
+  const allTimeOwners = rollingBestWithOwners(filtered);
+  const last90Owners = rollingBestWithOwners(filtered, { windowDays: 90 });
+  const last30Owners = rollingBestWithOwners(filtered, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
   // Effort-quality filter: drop activities whose IF (avg / FTP)
@@ -294,9 +298,9 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     .map((d) => `
       <tr>
         <td>${formatDuration(d)}</td>
-        <td>${last30[d] !== undefined ? formatPower(last30[d]) : '—'}</td>
-        <td class="featured">${last90[d] !== undefined ? formatPower(last90[d]) : '—'}</td>
-        <td>${formatPower(allTime[d])}</td>
+        <td>${renderMmpCell(last30Owners[d])}</td>
+        <td class="featured">${renderMmpCell(last90Owners[d])}</td>
+        <td>${renderMmpCell(allTimeOwners[d])}</td>
       </tr>`)
     .join('');
 
@@ -374,6 +378,17 @@ function wPrimeTooltip(wPrimeJ) {
        + 'sprinters and track riders push higher. Very high values from a 2-param fit can also signal '
        + 'a steep short-duration MMP relative to the threshold end — sanity-check against your sprint efforts.';
 }
+// Render an MMP table cell. When the owning activity has a Strava
+// ID, link out to strava.com so the user can jump straight to the
+// source ride. Activities cached before this field was tracked render
+// as plain text — re-parse the archive to populate the link.
+function renderMmpCell(owner) {
+  if (!owner || typeof owner.value !== 'number') return '—';
+  const watts = formatPower(owner.value);
+  if (!owner.stravaId) return watts;
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>`;
+}
+
 // Combined fit-quality summary: pick whichever of RMSE / points is
 // the worse of the two so the headline label reflects the limiting
 // factor. Tooltip lists both numbers + the per-axis interpretation.

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -116,6 +116,10 @@ async function parseArchive(file) {
         const avgPower = activity.powerStream.length
           ? totalPower / activity.powerStream.length
           : 0;
+        // Strava archive paths look like "activities/14228334907.fit.gz".
+        // Capture the numeric ID so MMP cells can deep-link to the
+        // source ride on strava.com.
+        const stravaId = extractStravaId(name);
         self.postMessage({
           type: 'activity',
           startTime: activity.startTime,
@@ -123,6 +127,7 @@ async function parseArchive(file) {
           distanceM: activity.distanceM,
           avgPower,
           mmp,
+          stravaId,
         });
         withPower++;
       }
@@ -137,4 +142,13 @@ async function parseArchive(file) {
   pendingFits.length = 0;
 
   self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower });
+}
+
+function extractStravaId(name) {
+  // "activities/14228334907.fit.gz" → "14228334907"
+  // Tolerate paths without a leading directory and the .fit / .fit.gz
+  // / .tcx.gz / .gpx.gz variants. Returns null if no numeric ID found.
+  const base = name.split('/').pop() || name;
+  const m = base.match(/^(\d+)\./);
+  return m ? m[1] : null;
 }

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   rollingBest,
+  rollingBestWithOwners,
   recencyWeightedBest,
   estimateFtp,
   effortQualityStats,
@@ -24,6 +25,26 @@ describe('rollingBest', () => {
       { startTime: now - 10 * 86400_000, mmp: { 60: 250 } },
     ];
     expect(rollingBest(acts, { windowDays: 90, now })).toEqual({ 60: 250 });
+  });
+});
+
+describe('rollingBestWithOwners', () => {
+  it('attaches the winning activity\'s stravaId to each duration', () => {
+    const acts = [
+      { startTime: 1, stravaId: 'A', mmp: { 60: 250, 300: 220 } },
+      { startTime: 2, stravaId: 'B', mmp: { 60: 300, 300: 200 } },
+    ];
+    expect(rollingBestWithOwners(acts)).toEqual({
+      60: { value: 300, stravaId: 'B' },
+      300: { value: 220, stravaId: 'A' },
+    });
+  });
+
+  it('records null stravaId when activity has none', () => {
+    const acts = [{ startTime: 1, mmp: { 60: 200 } }];
+    expect(rollingBestWithOwners(acts)).toEqual({
+      60: { value: 200, stravaId: null },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Worker extracts the numeric Strava ID from each FIT path (`activities/<id>.fit.gz`) and posts it on the activity message.
- Cached activity records gain a `stravaId` field. New `rollingBestWithOwners` returns `{ value, stravaId }` per duration.
- MMP table cells render as `<a>` to `strava.com/activities/<id>` when the owner has an ID. Activities cached pre-this-PR render as plain text — re-parse to populate.
- Subtle dotted-underline link style; color shift on hover/focus.

Closes #71.

## Test plan
- [ ] Re-parse the Strava archive (or upload a fresh one).
- [ ] MMP table cells become links — clicking opens the right activity on strava.com.
- [ ] Cells whose owning activity has no ID (legacy cache) render as plain text without errors.
- [ ] Hover state shows oxblood color and a darker underline.
- [ ] All 54 unit tests still pass.