### PR TITLE
Disable Strava activity links (wrong IDs)

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -390,17 +390,6 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
-.mmp-link {
-  color: inherit;
-  text-decoration: none;
-  border-bottom: 1px dotted var(--hair-strong);
-  transition: color 160ms ease, border-bottom-color 160ms ease;
-}
-.mmp-link:hover,
-.mmp-link:focus-visible {
-  color: var(--oxblood);
-  border-bottom-color: var(--oxblood);
-}
 
 .results-foot {
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -416,15 +416,14 @@ function wPrimeTooltip(wPrimeJ) {
        + 'sprinters and track riders push higher. Very high values from a 2-param fit can also signal '
        + 'a steep short-duration MMP relative to the threshold end — sanity-check against your sprint efforts.';
 }
-// Render an MMP table cell. When the owning activity has a Strava
-// ID, link out to strava.com so the user can jump straight to the
-// source ride. Activities cached before this field was tracked render
-// as plain text — re-parse the archive to populate the link.
+// Render an MMP table cell. Linking to Strava is disabled — the ID
+// captured from the archive filename is the upload ID, not the public
+// activity ID, so the link lands on a different user's ride. Real
+// activity IDs live in activities.csv in the archive root; once we
+// parse that file the linking can come back. See issue #71.
 function renderMmpCell(owner) {
   if (!owner || typeof owner.value !== 'number') return '—';
-  const watts = formatPower(owner.value);
-  if (!owner.stravaId) return watts;
-  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>`;
+  return formatPower(owner.value);
 }
 
 // Combined fit-quality summary: pick whichever of RMSE / points is


### PR DESCRIPTION
## Summary
The links shipped in #72 used the number from each archive filename (`activities/<id>.fit.gz`), which is the **upload ID**, not the public activity ID. Activity IDs are globally unique, so linking with an upload ID lands on whichever ride happens to share that number — often another user's. Reverting the link rendering so we stop pointing at strangers' activities.

The data-capture (the `stravaId` field, `rollingBestWithOwners`) stays in place — they're harmless when not rendered, and we'll need them when the proper CSV-mapping fix lands.

## Test plan
- [ ] MMP cells render as plain text again, no underline.
- [ ] No console errors.