### PR TITLE
Resolve real Strava activity IDs via activities.csv

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -390,6 +390,18 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
+.mmp-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--hair-strong);
+  transition: color 160ms ease, border-bottom-color 160ms ease;
+}
+.mmp-link:hover,
+.mmp-link:focus-visible {
+  color: var(--oxblood);
+  border-bottom-color: var(--oxblood);
+}
+
 
 .results-foot {
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -416,14 +416,16 @@ function wPrimeTooltip(wPrimeJ) {
        + 'sprinters and track riders push higher. Very high values from a 2-param fit can also signal '
        + 'a steep short-duration MMP relative to the threshold end — sanity-check against your sprint efforts.';
 }
-// Render an MMP table cell. Linking to Strava is disabled — the ID
-// captured from the archive filename is the upload ID, not the public
-// activity ID, so the link lands on a different user's ride. Real
-// activity IDs live in activities.csv in the archive root; once we
-// parse that file the linking can come back. See issue #71.
+// Render an MMP table cell. Activity IDs are resolved through the
+// archive's activities.csv during parsing — never from the FIT
+// filename, which is Strava's upload ID and points to a different
+// public activity. Cells without a resolved ID (legacy cache or an
+// archive without activities.csv) render as plain text.
 function renderMmpCell(owner) {
   if (!owner || typeof owner.value !== 'number') return '—';
-  return formatPower(owner.value);
+  const watts = formatPower(owner.value);
+  if (!owner.stravaId) return watts;
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>`;
 }
 
 // Combined fit-quality summary: pick whichever of RMSE / points is

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -14,6 +14,7 @@ import { parseFit } from './fit.js';
 import { extractMmp } from './mmp.js';
 
 const ACTIVITY_PATH = /^activities\/[^/]+\.fit(\.gz)?$/i;
+const ACTIVITIES_CSV = /^activities\.csv$/i;
 const CHUNK_BYTES = 1 << 20; // 1 MB
 
 self.onmessage = async (e) => {
@@ -38,6 +39,10 @@ async function parseArchive(file) {
   // ondata because parseFit is synchronous and slow — instead we
   // collect bytes and process after the streaming read completes.
   const pendingFits = [];
+  // activities.csv (when present) maps each FIT filename to its
+  // public Strava activity ID. Buffered during the unzip stream and
+  // parsed once before the FIT loop walks the pending entries.
+  let csvBytes = null;
 
   const post = (extra = {}) =>
     self.postMessage({
@@ -53,6 +58,21 @@ async function parseArchive(file) {
   // ------- Read + decompress -------
   await new Promise((resolve, reject) => {
     const unzipper = new Unzip((entry) => {
+      if (ACTIVITIES_CSV.test(entry.name)) {
+        const chunks = [];
+        let totalSize = 0;
+        entry.ondata = (err, chunk, final) => {
+          if (err) { console.warn('csv entry error', err); return; }
+          if (chunk) { chunks.push(chunk); totalSize += chunk.length; }
+          if (final) {
+            csvBytes = new Uint8Array(totalSize);
+            let offset = 0;
+            for (const c of chunks) { csvBytes.set(c, offset); offset += c.length; }
+          }
+        };
+        entry.start();
+        return;
+      }
       if (!ACTIVITY_PATH.test(entry.name)) {
         entry.ondata = () => {};
         entry.start();
@@ -96,6 +116,12 @@ async function parseArchive(file) {
     })();
   });
 
+  // ------- Parse activities.csv → filename → Strava ID map -------
+  // The map keys are normalized: full path (`activities/X.fit.gz`)
+  // and basename (`X.fit.gz`). Looking up a FIT entry tries both, so
+  // small differences in CSV path formatting don't break linking.
+  const idByName = csvBytes ? buildIdMap(csvBytes) : null;
+
   // ------- Parse FIT files -------
   for (const { name, bytes } of pendingFits) {
     let p = name;
@@ -116,10 +142,12 @@ async function parseArchive(file) {
         const avgPower = activity.powerStream.length
           ? totalPower / activity.powerStream.length
           : 0;
-        // Strava archive paths look like "activities/14228334907.fit.gz".
-        // Capture the numeric ID so MMP cells can deep-link to the
-        // source ride on strava.com.
-        const stravaId = extractStravaId(name);
+        // Resolve the public Strava activity ID via activities.csv.
+        // The number in the FIT filename is the upload ID — globally
+        // unique but distinct from the activity ID a user URL uses,
+        // so we can't fall back to the filename here.
+        const base = name.split('/').pop() || name;
+        const stravaId = idByName?.get(name) ?? idByName?.get(base) ?? null;
         self.postMessage({
           type: 'activity',
           startTime: activity.startTime,
@@ -144,11 +172,62 @@ async function parseArchive(file) {
   self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower });
 }
 
-function extractStravaId(name) {
-  // "activities/14228334907.fit.gz" → "14228334907"
-  // Tolerate paths without a leading directory and the .fit / .fit.gz
-  // / .tcx.gz / .gpx.gz variants. Returns null if no numeric ID found.
-  const base = name.split('/').pop() || name;
-  const m = base.match(/^(\d+)\./);
-  return m ? m[1] : null;
+export { buildIdMap, parseCsv };
+
+// Build { fullPath, basename → activity_id } from activities.csv.
+// Strava export columns shift between versions, so we resolve them
+// by header name. We index by both the full Filename column value
+// and its basename so lookup tolerates path differences in the FIT
+// loop.
+function buildIdMap(csvBytes) {
+  const text = new TextDecoder().decode(csvBytes);
+  const rows = parseCsv(text);
+  if (!rows.length) return null;
+  const header = rows[0].map((s) => s.trim().toLowerCase());
+  const idIdx = header.indexOf('activity id');
+  const fnIdx = header.indexOf('filename');
+  if (idIdx < 0 || fnIdx < 0) return null;
+  const map = new Map();
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r];
+    const id = row[idIdx]?.trim();
+    const fn = row[fnIdx]?.trim();
+    if (!id || !fn) continue;
+    map.set(fn, id);
+    const base = fn.split('/').pop();
+    if (base && base !== fn) map.set(base, id);
+  }
+  return map;
+}
+
+// Tiny CSV parser: handles quoted fields, escaped quotes (""), and
+// CRLF or LF line endings. Strava CSVs are small (KBs), so a
+// straightforward state machine is fine.
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++; }
+        else inQuotes = false;
+      } else field += c;
+    } else if (c === '"') {
+      inQuotes = true;
+    } else if (c === ',') {
+      row.push(field); field = '';
+    } else if (c === '\n' || c === '\r') {
+      if (field !== '' || row.length) {
+        row.push(field); rows.push(row); row = []; field = '';
+      }
+      if (c === '\r' && text[i + 1] === '\n') i++;
+    } else {
+      field += c;
+    }
+  }
+  if (field !== '' || row.length) { row.push(field); rows.push(row); }
+  return rows;
 }

--- a/tests/archive-worker.test.js
+++ b/tests/archive-worker.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildIdMap, parseCsv } from '../src/archive-worker.js';
+
+const enc = (s) => new TextEncoder().encode(s);
+
+describe('parseCsv', () => {
+  it('parses a simple csv', () => {
+    expect(parseCsv('a,b,c\n1,2,3\n')).toEqual([['a', 'b', 'c'], ['1', '2', '3']]);
+  });
+
+  it('handles quoted fields with commas', () => {
+    expect(parseCsv('a,b\n"hello, world",2\n')).toEqual([
+      ['a', 'b'],
+      ['hello, world', '2'],
+    ]);
+  });
+
+  it('handles escaped double quotes', () => {
+    expect(parseCsv('a\n"she said ""hi"""\n')).toEqual([['a'], ['she said "hi"']]);
+  });
+
+  it('handles CRLF endings', () => {
+    expect(parseCsv('a,b\r\n1,2\r\n')).toEqual([['a', 'b'], ['1', '2']]);
+  });
+});
+
+describe('buildIdMap', () => {
+  it('maps full path and basename to activity ID', () => {
+    const csv = enc(
+      'Activity ID,Activity Date,Filename\n' +
+      '12345,"Jan 1, 2024",activities/9876.fit.gz\n'
+    );
+    const m = buildIdMap(csv);
+    expect(m.get('activities/9876.fit.gz')).toBe('12345');
+    expect(m.get('9876.fit.gz')).toBe('12345');
+  });
+
+  it('resolves columns by header name (order-independent)', () => {
+    const csv = enc(
+      'Filename,Activity Name,Activity ID\n' +
+      'activities/A.fit.gz,Morning ride,99\n'
+    );
+    expect(buildIdMap(csv).get('activities/A.fit.gz')).toBe('99');
+  });
+
+  it('returns null when required headers are missing', () => {
+    const csv = enc('Activity ID,Foo\n1,bar\n');
+    expect(buildIdMap(csv)).toBeNull();
+  });
+
+  it('skips rows missing an ID or filename', () => {
+    const csv = enc(
+      'Activity ID,Filename\n' +
+      ',activities/skipped.fit.gz\n' +
+      '42,\n' +
+      '7,activities/X.fit\n'
+    );
+    const m = buildIdMap(csv);
+    expect(m.size).toBe(2); // 7 → "activities/X.fit" + "X.fit"
+    expect(m.get('activities/X.fit')).toBe('7');
+  });
+});


### PR DESCRIPTION
## Summary
- Worker now buffers \`activities.csv\` during the streaming unzip and parses it before walking pendingFits. Resolves the \`Activity ID\` and \`Filename\` columns by header name so we tolerate Strava export version drift.
- Map keys cover both the full \`activities/X.fit.gz\` path and bare \`X.fit.gz\` basename, so lookups don't break on path-formatting differences between the CSV and the unzip entry.
- Each FIT entry pulls its real ID through the map; cells with a resolved ID render as Strava links again. Cells without an ID (legacy cache, archive missing CSV) stay plain text.
- New CSV parser (handles quoted fields, escaped quotes, CRLF) covered by 8 unit tests.

Closes #71.

## Test plan
- [ ] Re-parse a Strava archive — MMP cells become links.
- [ ] Click any link, land on the **correct** activity in your Strava (not a stranger's).
- [ ] Cells from any activity that didn't resolve (e.g. older legacy cache) render as plain text without errors.
- [ ] All 62 unit tests still pass.