### PR TITLE
Mirror parsing progress into document.title

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -154,11 +154,14 @@ async function handleArchive(file) {
     document.removeEventListener('visibilitychange', onVisibility);
     if (wakeLock) try { await wakeLock.release(); } catch {}
     audio?.stop();
+    resetTitle();
     return;
   }
   worker.terminate();
   document.removeEventListener('visibilitychange', onVisibility);
   if (wakeLock) try { await wakeLock.release(); } catch {}
+  audio?.stop();
+  resetTitle();
 
   const newList = Array.from(newActivities.values());
   if (newList.length > 0) {
@@ -257,6 +260,19 @@ function setProgressPhase(phase, payload) {
   const fillEl = progressEl.querySelector('.progress__bar-fill');
   if (textEl) textEl.textContent = phaseDetail;
   if (fillEl) fillEl.style.width = `${overall}%`;
+
+  // Mirror progress into document.title so the tab strip shows
+  // movement even when the tab is hidden — browsers don't paint
+  // hidden tabs, so the progress bar visually freezes for a tabbed-
+  // away user even though the worker keeps running.
+  document.title = isComplete
+    ? 'Power Predict'
+    : `${overall.toFixed(0)}% · ${phase} — Power Predict`;
+}
+
+const ORIGINAL_TITLE = typeof document !== 'undefined' ? document.title : 'Power Predict';
+function resetTitle() {
+  if (typeof document !== 'undefined') document.title = ORIGINAL_TITLE;
 }
 
 function formatBytes(bytes) {


### PR DESCRIPTION
## Summary
Hidden tabs don't paint, so the in-page progress bar appears stuck for users who switch away — even though the worker is still running (and thanks to #74 won't be throttled either). Tab strip titles update regardless of visibility.

This PR writes \`{NN}% · {Reading|Parsing} — Power Predict\` into \`document.title\` from the same throttled progress hook that drives the bar, and restores the original title on success/failure.

## Test plan
- [ ] Drop a large archive, switch to a different tab — the Power Predict tab's title now reads e.g. \`23% · Reading — Power Predict\` and ticks upward.
- [ ] Title returns to plain \`Power Predict\` once parsing completes.
- [ ] Same on the error path (worker fails / archive corrupt).