### PR TITLE
Drop anomalous short-duration MMP values from rolling-best

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -52,6 +52,12 @@
 
     <p>Each value in the table is <strong>mean maximal power</strong>: the best rolling <em>average</em> power held for that duration in any activity in the window. It is not normalized power. A 20-minute MMP of 280 W means there is a 20-minute slice of one ride that averaged 280 W &mdash; nothing more.</p>
 
+    <h3>Anomaly filter (power-meter glitches)</h3>
+
+    <p>Real cycling power kinetics bound how much shorter durations can exceed longer ones &mdash; even a world-class sprinter's 1-second peak sits roughly 1.5-1.8&times; their 5-second peak. A power-meter spike (e.g. a single 2000 W sample on a normal ride) or a flatline glitch (a 2-second plateau at 1367 W where the meter reported the same wattage twice in a row) produces ratios well above plausible.</p>
+
+    <p>Before merging each activity's MMP into the rolling-best, Power Predict checks adjacent-duration ratios against caps tuned to the upper edge of trained-cyclist data. Any short-duration value that breaches its cap relative to a longer reference is dropped from <em>that activity only</em> &mdash; the rest of the activity (longer durations, average power, etc.) still feeds the curve. Other rides' best efforts at the dropped duration carry the table.</p>
+
     <h3>Effort-quality filter</h3>
 
     <p>Recency weighting on its own can underread your fitness when recent rides have been low intensity &mdash; a 30-day base block of zone-2 spinning gets weighted heavily even though those rides don't reflect what you can do at threshold.</p>

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -2,7 +2,7 @@
 // Optionally filter by `windowDays` (e.g. 90) so we only consider recent
 // activities for the "current fitness" curve.
 
-import { DURATIONS_S } from './mmp.js';
+import { DURATIONS_S, dropAnomalies } from './mmp.js';
 
 export function rollingBest(activityMmps, {
   windowDays = null,
@@ -16,8 +16,9 @@ export function rollingBest(activityMmps, {
   for (const { startTime, mmp, avgPower } of activityMmps) {
     if (startTime < cutoff) continue;
     if (filterEnabled && Number.isFinite(avgPower) && avgPower / ftp < minIF) continue;
+    const cleaned = dropAnomalies(mmp);
     for (const d of DURATIONS_S) {
-      const v = mmp[d];
+      const v = cleaned[d];
       if (typeof v !== 'number') continue;
       if (best[d] === undefined || v > best[d]) best[d] = v;
     }
@@ -40,8 +41,9 @@ export function rollingBestWithOwners(activityMmps, {
   for (const a of activityMmps) {
     if (a.startTime < cutoff) continue;
     if (filterEnabled && Number.isFinite(a.avgPower) && a.avgPower / ftp < minIF) continue;
+    const cleaned = dropAnomalies(a.mmp);
     for (const d of DURATIONS_S) {
-      const v = a.mmp?.[d];
+      const v = cleaned?.[d];
       if (typeof v !== 'number') continue;
       if (best[d] === undefined || v > best[d].value) {
         best[d] = { value: v, stravaId: a.stravaId ?? null };

--- a/src/mmp.js
+++ b/src/mmp.js
@@ -10,6 +10,49 @@ export const DURATIONS_S = [
   4500, 5400, 7200, 10800, 14400,
 ];
 
+// Adjacent-duration ratio sanity checks. Real cycling power kinetics
+// bound how much shorter durations can exceed longer ones — even a
+// world-class sprinter's 1s peak sits roughly 1.5-1.8x their 5s peak.
+// A power-meter spike or flatline glitch (e.g. a 2s plateau at 1367W
+// in an otherwise normal ride, or a single 2000W sample) produces
+// ratios well above plausible. When the ratio is exceeded we drop the
+// shorter-duration MMP from this activity so it doesn't anchor the
+// rolling-best curve.
+//
+// Caps reflect the upper edge of trained-cyclist sprint data; the
+// goal is to catch glitches, not to clip real efforts. Each pair is
+// checked independently — fixing one row can leave another flagged,
+// so we iterate until no further changes (in practice 1-2 passes).
+const ANOMALY_CHECKS = [
+  [1, 5, 1.6],
+  [2, 5, 1.5],
+  [3, 5, 1.4],
+  [5, 30, 1.8],
+  [10, 30, 1.6],
+  [15, 60, 1.7],
+  [30, 300, 2.0],
+  [60, 300, 1.7],
+];
+
+export function dropAnomalies(mmp) {
+  if (!mmp) return mmp;
+  const out = { ...mmp };
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [shortD, longD, cap] of ANOMALY_CHECKS) {
+      const s = out[shortD];
+      const l = out[longD];
+      if (typeof s !== 'number' || typeof l !== 'number') continue;
+      if (s > l * cap) {
+        delete out[shortD];
+        changed = true;
+      }
+    }
+  }
+  return out;
+}
+
 export function extractMmp(powerStream) {
   if (!powerStream || powerStream.length === 0) return {};
 

--- a/tests/mmp.test.js
+++ b/tests/mmp.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractMmp, DURATIONS_S } from '../src/mmp.js';
+import { extractMmp, dropAnomalies, DURATIONS_S } from '../src/mmp.js';
 
 describe('extractMmp', () => {
   it('returns empty for empty stream', () => {
@@ -21,5 +21,46 @@ describe('extractMmp', () => {
     const mmp = extractMmp(stream);
     expect(mmp[15]).toBeCloseTo(400, 5);
     expect(mmp[60]).toBeCloseTo((150 * 40 + 400 * 20) / 60, 5);
+  });
+});
+
+describe('dropAnomalies', () => {
+  it('passes a realistic sprint profile through unchanged', () => {
+    const mmp = { 1: 900, 2: 870, 3: 830, 5: 780, 15: 600, 30: 500, 60: 380, 300: 280 };
+    expect(dropAnomalies(mmp)).toEqual(mmp);
+  });
+
+  it('drops a 1s spike that dwarfs the 5s value', () => {
+    const mmp = { 1: 2000, 2: 1250, 3: 950, 5: 800, 30: 500, 60: 400 };
+    const out = dropAnomalies(mmp);
+    expect(out[1]).toBeUndefined();
+    expect(out[5]).toBe(800);
+  });
+
+  it('drops short-duration values from a 2-second flatline glitch', () => {
+    // Simulate a real-feeling ride that also contains a 2s flatline
+    // glitch at 1367W. The 1s/2s/3s values are all corrupted by the
+    // flatline; longer durations reflect real efforts.
+    const mmp = { 1: 1367, 2: 1367, 3: 978, 5: 667, 30: 500, 60: 420, 300: 320 };
+    const out = dropAnomalies(mmp);
+    expect(out[1]).toBeUndefined();
+    expect(out[2]).toBeUndefined();
+    expect(out[3]).toBeUndefined();
+    expect(out[30]).toBe(500);
+    expect(out[60]).toBe(420);
+    expect(out[300]).toBe(320);
+  });
+
+  it('preserves longer durations even when shorter ones are flagged', () => {
+    const mmp = { 1: 2000, 5: 800, 60: 400, 300: 250, 1200: 220 };
+    const out = dropAnomalies(mmp);
+    expect(out[60]).toBe(400);
+    expect(out[300]).toBe(250);
+    expect(out[1200]).toBe(220);
+  });
+
+  it('handles missing pairs gracefully', () => {
+    expect(dropAnomalies({})).toEqual({});
+    expect(dropAnomalies({ 60: 250 })).toEqual({ 60: 250 });
   });
 });


### PR DESCRIPTION
## Summary
- New \`dropAnomalies(mmp)\` in \`src/mmp.js\` runs adjacent-duration ratio sanity checks on each activity's MMP. Any short-duration value whose ratio to its longer reference exceeds a calibrated cap is dropped from that activity. Iterates until stable so cascading glitches (e.g. 2s flatline → 1s, 2s, 3s all bad) all get caught.
- Wired into \`rollingBest\` and \`rollingBestWithOwners\` so cached data is filtered every render — no re-parse required to benefit.
- Caps tuned against realistic trained-cyclist sprint profiles; the included pass-through test exercises a clean profile to guard against false positives.
- Methodology page gets a new "Anomaly filter (power-meter glitches)" section.
- Six new unit tests covering realistic profiles, single-sample spikes, multi-second flatlines, and missing-pair edge cases.

User-reported cases this catches:
- Activity 576223926 — 2s flatline at 1367W contributing a phantom 1s/2s/3s peak.
- Activity 725733185 — 1s spike at 2000W well outside the rider's range.

## Test plan
- [ ] After Pages redeploys, the user's 1s and 5s rolling-best should drop from the previously-glitched values down to legitimate efforts.
- [ ] Mid- and long-duration cells (5min, 20min, 1h) unchanged from before.
- [ ] All 67 unit tests pass.