### PR TITLE
Manual mode: synthesize a CP curve from FTP (no archive)

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -146,6 +146,12 @@
 
     <p>Drift normalization only feeds the fit's fallback path. The displayed all-time table column stays raw history &mdash; the dots are still what you actually rode. eFTP<sub>now</sub> is reported as a stat on the predict panel.</p>
 
+    <h2>Manual mode (no archive)</h2>
+
+    <p>For users who haven't uploaded an archive but know their FTP, the landing page exposes a "no archive yet" panel that synthesizes a CP/W' fit on the fly: <strong>CP &approx; 0.95 &times; FTP</strong> (Coggan: FTP is roughly 1.05 &times; CP). When the rider also enters a 1-minute sprint number, <em>W&prime;</em> is solved from the 2-parameter hyperbola at <em>t</em> = 60 s. Otherwise <em>W&prime;</em> defaults to 18 kJ &mdash; the middle of the trained-cyclist range. Result is clamped to [5, 40] kJ so a wildly out-of-range sprint number can't produce an absurd hyperbola.</p>
+
+    <p>Manual mode is intentionally coarse. It can't anchor the long-duration end of the curve to real data, so 4-hour and 12-hour predictions fall back to the model's pure decay rather than observed history. Upload an archive when possible &mdash; the prediction quality improves materially.</p>
+
     <h2>Limitations and planned improvements</h2>
 
     <p>Today's predictions assume your last 90 days of data accurately reflect your current fitness. Issues planned for upcoming releases:</p>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,28 @@
       <span class="drop__label">Drop your archive</span>
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>
     </div>
+
+    <details id="manual-mode" class="manual-mode">
+      <summary>No archive yet? Estimate from FTP</summary>
+      <form id="manual-form" class="manual-form" novalidate>
+        <label class="manual-form__field">
+          <span>FTP (W)</span>
+          <input type="number" id="manual-ftp" min="50" max="600" step="1" placeholder="280" autocomplete="off" required>
+        </label>
+        <label class="manual-form__field">
+          <span>Best 1-min power (W) <em>optional</em></span>
+          <input type="number" id="manual-1min" min="50" max="2000" step="1" placeholder="450" autocomplete="off">
+        </label>
+        <div class="manual-form__actions">
+          <button type="submit">Use these numbers</button>
+        </div>
+      </form>
+      <p class="results-foot__note">
+        A coarse CP/W' synthesized from FTP. CP is set to 0.95 × FTP; W' comes from your 1-min sprint when given,
+        otherwise defaults to 18 kJ (middle of the trained-cyclist range). Upload your archive when you can —
+        the prediction tightens up considerably with real data.
+      </p>
+    </details>
     <p id="progress" class="progress" hidden></p>
 
     <section id="results" hidden></section>

--- a/shared.css
+++ b/shared.css
@@ -390,6 +390,99 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
+.manual-mode {
+  margin: 1.5rem auto 0;
+  max-width: 36rem;
+  border: 1px solid var(--hair);
+  background: var(--paper-soft);
+}
+.manual-mode > summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.7rem 1rem;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ink-soft);
+}
+.manual-mode > summary::-webkit-details-marker { display: none; }
+.manual-mode > summary::before {
+  content: '+';
+  display: inline-block;
+  width: 1em;
+  font-family: var(--mono);
+  color: var(--oxblood);
+  margin-right: 0.4rem;
+}
+.manual-mode[open] > summary::before { content: '−'; }
+.manual-mode[open] > summary {
+  border-bottom: 1px solid var(--hair);
+  background: var(--paper);
+}
+.manual-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  padding: 1rem;
+}
+.manual-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.manual-form__field span {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+.manual-form__field span em {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+.manual-form input {
+  font-family: var(--mono);
+  font-size: 1rem;
+  background: transparent;
+  color: var(--ink);
+  border: none;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.5rem 0;
+  outline: none;
+}
+.manual-form input:focus { border-bottom-color: var(--oxblood); }
+.manual-form__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+.manual-form button {
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--paper);
+  background: var(--oxblood);
+  border: none;
+  padding: 0.7rem 1.4rem;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+.manual-form button:hover { background: var(--oxblood-deep); }
+.manual-mode .results-foot__note {
+  padding: 0 1rem 1rem;
+  margin: 0;
+}
+
 .mmp-link {
   color: inherit;
   text-decoration: none;

--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ import {
 } from './storage.js';
 import { fitCp2, predictPower, mmpToPoints } from './cpfit.js';
 import { parseDuration } from './duration.js';
+import { synthesizeFit } from './manual.js';
 
 const dropZone = document.getElementById('archive-drop');
 const fileInput = document.getElementById('archive-input');
@@ -36,6 +37,22 @@ if (dropZone && fileInput) {
   fileInput.addEventListener('change', () => {
     const file = fileInput.files?.[0];
     if (file) handleArchive(file);
+  });
+}
+
+const manualForm = document.getElementById('manual-form');
+if (manualForm) {
+  manualForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const ftpW = Number(document.getElementById('manual-ftp').value);
+    const sprintRaw = document.getElementById('manual-1min').value.trim();
+    const sprint1minW = sprintRaw ? Number(sprintRaw) : null;
+    const fit = synthesizeFit({ ftpW, sprint1minW });
+    if (!fit) {
+      setProgress('Enter a positive FTP value (typical range 100-450 W).');
+      return;
+    }
+    renderManualMode(fit);
   });
 }
 
@@ -541,6 +558,58 @@ function wireCurveChart() {
     t.addEventListener('click', () => draw(t.dataset.window));
   });
   draw('last90');
+}
+
+// Manual mode: synthesize a CP/W' from the rider's FTP and render
+// just the predict block. No MMP table, no chart of history, no
+// override panel — there's nothing of theirs to override.
+function renderManualMode(fit) {
+  currentFit = fit;
+  currentEftpNow = null;
+  currentActivities = [];
+  currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
+  currentSettings = {};
+
+  resultsEl.innerHTML = `
+    <section class="predict predict--manual">
+      <header class="results-head">
+        <h2>Predict <span class="override-badge">MANUAL MODE</span></h2>
+        <span class="results-head__meta">Synthesized from FTP · no ride history</span>
+      </header>
+
+      <dl class="fit-stats">
+        <div data-tooltip="Critical Power synthesized from the FTP you entered. CP ≈ 0.95 × FTP.">
+          <dt>CP</dt>
+          <dd>${formatPower(fit.cpW)}</dd>
+          <span class="fit-stats__quality is-mid">manual</span>
+        </div>
+        <div data-tooltip="Anaerobic work capacity. Derived from your 1-minute sprint number when given, otherwise defaulted to 18 kJ.">
+          <dt>W'</dt>
+          <dd>${(fit.wPrimeJ / 1000).toFixed(1)} kJ</dd>
+          <span class="fit-stats__quality is-mid">manual</span>
+        </div>
+      </dl>
+
+      <p class="results-foot__note">
+        Predictions will be coarse compared to a real archive — the model has no information about your
+        sprint kinetics or your endurance fade. Upload your Strava archive when you can to anchor the
+        long-duration end of the curve.
+      </p>
+
+      <form class="predict-form" id="predict-form">
+        <label class="predict-form__field">
+          <span>Target duration</span>
+          <input type="text" id="predict-input" placeholder="45m or 2h30m" autocomplete="off" spellcheck="false" required>
+        </label>
+        <button type="submit">Predict</button>
+      </form>
+      <output class="predict-output" id="predict-output" hidden></output>
+    </section>
+  `;
+  resultsEl.hidden = false;
+  resultsEl.dataset.revealed = '';
+  wirePredictForm();
+  resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
 function renderPredictBlock() {

--- a/src/manual.js
+++ b/src/manual.js
@@ -1,0 +1,38 @@
+// Manual-mode CP/W' synthesis from a rider's FTP (and optional
+// 1-min sprint number). For users who haven't uploaded a Strava
+// archive but know their FTP — a coarse-but-real prediction beats
+// a no-data dead end.
+//
+// CP ≈ 0.95 × FTP (Coggan: FTP ≈ 60-min power ≈ ~1.05 × CP).
+// W' from 1-min sprint: solve the 2-param hyperbola P(60) = CP + W'/60
+//   → W' = (P_1min - CP) × 60.
+// Default W' = 18 kJ when no sprint number is given (middle of the
+// trained-cyclist range, ~15-25 kJ).
+//
+// Clamps: keep W' in [5 kJ, 40 kJ] so a wildly out-of-range sprint
+// number can't produce an absurd hyperbola.
+
+const W_PRIME_DEFAULT_J = 18_000;
+const W_PRIME_MIN_J = 5_000;
+const W_PRIME_MAX_J = 40_000;
+
+export function synthesizeFit({ ftpW, sprint1minW }) {
+  if (!Number.isFinite(ftpW) || ftpW <= 0) return null;
+  const cpW = ftpW * 0.95;
+
+  let wPrimeJ = W_PRIME_DEFAULT_J;
+  if (Number.isFinite(sprint1minW) && sprint1minW > cpW) {
+    const fromSprint = (sprint1minW - cpW) * 60;
+    wPrimeJ = Math.max(W_PRIME_MIN_J, Math.min(W_PRIME_MAX_J, fromSprint));
+  }
+
+  return {
+    cpW,
+    wPrimeJ,
+    rmse: 0,
+    nPoints: 0,
+    fallback: false,
+    overridden: false,
+    manual: true,
+  };
+}

--- a/tests/manual.test.js
+++ b/tests/manual.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { synthesizeFit } from '../src/manual.js';
+
+describe('synthesizeFit', () => {
+  it('returns null for missing or invalid FTP', () => {
+    expect(synthesizeFit({})).toBeNull();
+    expect(synthesizeFit({ ftpW: 0 })).toBeNull();
+    expect(synthesizeFit({ ftpW: -5 })).toBeNull();
+  });
+
+  it('CP is 0.95 × FTP and W\' falls back to 18 kJ without a sprint number', () => {
+    const fit = synthesizeFit({ ftpW: 250 });
+    expect(fit.cpW).toBeCloseTo(237.5, 4);
+    expect(fit.wPrimeJ).toBe(18_000);
+    expect(fit.manual).toBe(true);
+  });
+
+  it('derives W\' from a 1-min sprint via the 2-param hyperbola', () => {
+    // CP = 250 × 0.95 = 237.5. Sprint 400 W → W' = (400 - 237.5) × 60 = 9750
+    const fit = synthesizeFit({ ftpW: 250, sprint1minW: 400 });
+    expect(fit.wPrimeJ).toBeCloseTo(9750, 1);
+  });
+
+  it('clamps W\' to the [5 kJ, 40 kJ] envelope', () => {
+    // Sprint slightly above CP → tiny W' → clamp to 5 kJ.
+    expect(synthesizeFit({ ftpW: 250, sprint1minW: 240 }).wPrimeJ).toBe(5_000);
+    // Sprint way above CP → huge W' → clamp to 40 kJ.
+    expect(synthesizeFit({ ftpW: 250, sprint1minW: 1500 }).wPrimeJ).toBe(40_000);
+  });
+
+  it('falls back to default when sprint number is below CP (nonsense)', () => {
+    const fit = synthesizeFit({ ftpW: 300, sprint1minW: 200 });
+    expect(fit.wPrimeJ).toBe(18_000);
+  });
+});


### PR DESCRIPTION
## Summary
- New \`src/manual.js\` exports \`synthesizeFit({ ftpW, sprint1minW })\`. CP = 0.95 × FTP; W' from 1-min sprint via the 2-param hyperbola, else default 18 kJ. Result clamped to W' ∈ [5, 40] kJ.
- Landing-page panel "No archive yet? Estimate from FTP" with FTP (required) + optional best 1-min power. Submitting renders a stripped-down predict block with a "MANUAL MODE" badge.
- Manual mode skips the MMP table, history chart, and override panel — there's nothing to override and no history to chart.
- Methodology page gets a "Manual mode (no archive)" section documenting the synthesis and clamps.
- Five new unit tests cover the synthesis logic.

Closes #73.

## Test plan
- [ ] Landing page shows the new disclosure below the drop zone.
- [ ] Submitting with no FTP shows the inline "Enter a positive FTP" message.
- [ ] FTP 280 → CP ≈ 266 W, W' = 18 kJ (with no sprint number).
- [ ] FTP 280 + 1-min 450 → W' = (450 − 266) × 60 = 11.0 kJ.
- [ ] Predict form synthesizes wattage for any duration; the predict header reads "MANUAL MODE."
- [ ] Uploading an archive afterwards swaps out manual mode for the data-driven render.