### PR TITLE
Reword manual-mode summary when cached data is present

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     </div>
 
     <details id="manual-mode" class="manual-mode">
-      <summary>No archive yet? Estimate from FTP</summary>
+      <summary id="manual-mode-summary">No archive yet? Estimate from FTP</summary>
       <form id="manual-form" class="manual-form" novalidate>
         <label class="manual-form__field">
           <span>FTP (W)</span>

--- a/src/app.js
+++ b/src/app.js
@@ -308,10 +308,11 @@ let currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   currentActivities = activityMmps;
-  // The "no archive yet" disclosure is for users without data —
-  // collapse it once they have data showing so it doesn't look like
-  // a competing entry point. Users can still expand it if they want
-  // to compare against an FTP-only synthesis.
+  // The manual-mode disclosure is for users without data — collapse
+  // it once they have data showing, and reword the summary so the
+  // copy makes sense when they're already working from a real
+  // archive ("compare" rather than "no archive yet?").
+  updateManualSummary(activityMmps.length > 0);
   if (activityMmps.length > 0) {
     const manualPanel = document.getElementById('manual-mode');
     if (manualPanel) manualPanel.open = false;
@@ -647,6 +648,14 @@ function renderManualMode(fit, inputs = {}) {
     });
   }
   resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function updateManualSummary(hasData) {
+  const el = document.getElementById('manual-mode-summary');
+  if (!el) return;
+  el.textContent = hasData
+    ? 'Compare against an FTP-only estimate'
+    : 'No archive yet? Estimate from FTP';
 }
 
 function wireManualInline() {


### PR DESCRIPTION
## Summary
- Manual-mode disclosure summary now switches between "No archive yet? Estimate from FTP" (no cache) and "Compare against an FTP-only estimate" (cache present).
- Driven from \`renderCurves\` so the wording reflects the user's current state on every render — fresh load, post-upload, or after "Back to my data".

## Test plan
- [ ] Fresh browser (no cache) → summary reads "No archive yet?".
- [ ] Cached visitor → summary reads "Compare against an FTP-only estimate".
- [ ] Upload an archive in a fresh browser → summary updates after parsing without a reload.