### PR TITLE
Hide landing disclosure while in manual mode

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -639,11 +639,18 @@ function renderManualMode(fit, inputs = {}) {
   resultsEl.dataset.revealed = '';
   wirePredictForm();
   wireManualInline();
+  // Hide the landing-page disclosure while we're in manual mode —
+  // the inline inputs in the predict block are now the source of
+  // truth and the duplicate above looks like a competing UI.
+  const manualPanel = document.getElementById('manual-mode');
+  if (manualPanel) manualPanel.hidden = true;
   if (hasPriorData) {
     document.getElementById('manual-back').addEventListener('click', () => {
       currentSettings = priorSettings;
-      const manualPanel = document.getElementById('manual-mode');
-      if (manualPanel) manualPanel.open = false;
+      if (manualPanel) {
+        manualPanel.hidden = false;
+        manualPanel.open = false;
+      }
       renderCurves(priorActivities, { fromCache: true });
     });
   }


### PR DESCRIPTION
## Summary
With the inline FTP/sprint inputs now living inside the manual-mode predict block, the original disclosure form on the landing page becomes redundant — you'd see the same fields twice. Hide the disclosure on entry to manual mode; restore it when the user clicks "Back to my data".

## Test plan
- [ ] Submit manual mode → landing disclosure disappears entirely. Only the inline inputs in the predict block remain.
- [ ] Click "Back to my data" → disclosure reappears (collapsed).
- [ ] Fresh visitor with no cache → disclosure visible by default; submitting hides it as expected.