### PR TITLE
Restructure layout around three explicit app states

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -390,6 +390,19 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
+/* App-state-driven layout. The body's data-app-state attribute
+   ("onboarding" | "data" | "manual") controls which top-level
+   sections are visible so each state shows only what's relevant. */
+body[data-app-state="data"] .lede,
+body[data-app-state="data"] .steps,
+body[data-app-state="data"] #archive-drop,
+body[data-app-state="data"] #manual-mode,
+body[data-app-state="manual"] .steps,
+body[data-app-state="manual"] #archive-drop,
+body[data-app-state="manual"] #manual-mode {
+  display: none;
+}
+
 .manual-mode {
   margin: 1.5rem auto 0;
   max-width: 36rem;

--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,7 @@ let currentActivities = [];
 hydrateFromCache();
 
 async function hydrateFromCache() {
+  setAppState('onboarding');
   try {
     const [cached, settings] = await Promise.all([loadActivities(), loadSettings()]);
     currentSettings = settings || {};
@@ -308,22 +309,7 @@ let currentMmpByWindow = { last30: {}, last90: {}, allTime: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   currentActivities = activityMmps;
-  // The manual-mode disclosure is for users without data — collapse
-  // it once they have data showing, and reword the summary so the
-  // copy makes sense when they're already working from a real
-  // archive ("compare" rather than "no archive yet?").
-  updateManualSummary(activityMmps.length > 0);
-  if (activityMmps.length > 0) {
-    const manualPanel = document.getElementById('manual-mode');
-    if (manualPanel) {
-      manualPanel.hidden = false;
-      manualPanel.open = false;
-    }
-    // Hide the giant drop zone now that we're showing real results.
-    // A compact "Upload another archive" link in the results foot
-    // covers re-uploads.
-    if (dropZone) dropZone.hidden = true;
-  }
+  setAppState(activityMmps.length > 0 ? 'data' : 'onboarding');
   // Filter activities by the user's date range, if set.
   const dateFromMs = currentSettings.dateFrom ? Date.parse(currentSettings.dateFrom) : null;
   const dateToMs = currentSettings.dateTo
@@ -631,12 +617,17 @@ function renderManualMode(fit, inputs = {}) {
         </div>
       </dl>
 
-      <p class="results-foot__note">
-        Predictions will be coarse compared to a real archive — the model has no information about your
-        sprint kinetics or your endurance fade. Upload your Strava archive when you can to anchor the
-        long-duration end of the curve.
-        ${hasPriorData ? `<button type="button" class="link-button" id="manual-back">← Back to my data (${priorActivities.length} cached activities)</button>` : ''}
-      </p>
+      <div class="results-foot">
+        <p class="results-foot__note">
+          Predictions will be coarse compared to a real archive — the model has no information about your
+          sprint kinetics or your endurance fade. Upload your Strava archive when you can to anchor the
+          long-duration end of the curve.
+        </p>
+        <div class="results-foot__actions">
+          ${hasPriorData ? `<button type="button" class="link-button" id="manual-back">← Back to my data (${priorActivities.length})</button>` : ''}
+          <button type="button" class="link-button" id="manual-upload">Upload an archive</button>
+        </div>
+      </div>
 
       <form class="predict-form" id="predict-form">
         <label class="predict-form__field">
@@ -652,37 +643,25 @@ function renderManualMode(fit, inputs = {}) {
   resultsEl.dataset.revealed = '';
   wirePredictForm();
   wireManualInline();
-  // Hide the landing-page disclosure while we're in manual mode —
-  // the inline inputs in the predict block are now the source of
-  // truth and the duplicate above looks like a competing UI. Same
-  // for the giant drop zone: the user has explicitly opted out of
-  // uploading right now, so leaving it visible just adds noise.
-  const manualPanel = document.getElementById('manual-mode');
-  if (manualPanel) manualPanel.hidden = true;
-  if (dropZone) dropZone.hidden = true;
+  setAppState('manual');
   if (hasPriorData) {
     document.getElementById('manual-back').addEventListener('click', () => {
       currentSettings = priorSettings;
-      if (manualPanel) {
-        manualPanel.hidden = false;
-        manualPanel.open = false;
-      }
-      // renderCurves re-hides the drop zone via its own logic, but
-      // restoring it here covers the brief flicker between "Back"
-      // and the next render pass.
-      if (dropZone) dropZone.hidden = false;
       renderCurves(priorActivities, { fromCache: true });
     });
   }
+  document.getElementById('manual-upload')?.addEventListener('click', () => {
+    fileInput?.click();
+  });
   resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
-function updateManualSummary(hasData) {
-  const el = document.getElementById('manual-mode-summary');
-  if (!el) return;
-  el.textContent = hasData
-    ? 'Compare against an FTP-only estimate'
-    : 'No archive yet? Estimate from FTP';
+// App states drive top-level layout visibility via CSS:
+//   onboarding — fresh visitor, drop zone + steps + manual disclosure shown
+//   data       — archive loaded, only results visible
+//   manual     — FTP-only synthesis, only manual predict block visible
+function setAppState(state) {
+  document.body.dataset.appState = state;
 }
 
 function wireManualInline() {
@@ -829,8 +808,7 @@ async function handleClearCache() {
   resultsEl.hidden = true;
   resultsEl.innerHTML = '';
   currentActivities = [];
-  if (dropZone) dropZone.hidden = false;
-  updateManualSummary(false);
+  setAppState('onboarding');
   setProgress(`Cache cleared. ${await activityCount()} activities remaining.`);
 }
 


### PR DESCRIPTION
## Summary
Replaces the per-element \`hidden\` juggling with a single \`body[data-app-state]\` attribute (\`onboarding\` / \`data\` / \`manual\`). CSS uses the attribute to hide the sections that don't belong in each state.

| State | Drop zone | Onboarding steps | Lede | Manual disclosure | Results |
|-------|-----------|------------------|------|--------------------|---------|
| onboarding | shown | shown | shown | shown | hidden |
| data | hidden | hidden | hidden | hidden | shown |
| manual | hidden | hidden | shown | hidden | shown |

Manual mode now also gets an explicit "Upload an archive" foot link alongside "Back to my data" so re-entering data mode doesn't require expanding any panel.

## Test plan
- [ ] Fresh visitor (no cache): unchanged from today — lede + steps + drop zone + manual disclosure all visible, no results.
- [ ] Cached visitor: lede / steps / drop zone / manual disclosure all gone; results sit cleanly at the top of the page below the site header. Foot row still has Upload another / Clear cached.
- [ ] Manual mode: drop zone + steps + disclosure gone; predict block visible; foot row offers "Back to my data" (when applicable) and "Upload an archive".
- [ ] Clear cached data → returns to onboarding state with everything visible.