### PR TITLE
Restore lede; rename override entry points

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -64,7 +64,7 @@
 
     <p>Power Predict estimates your FTP from your all-time best 20-minute mean maximal power (Coggan: FTP &approx; 0.95 &times; MMP<sub>20m</sub>) and computes an <strong>intensity factor</strong> (IF = average power / FTP) for each activity. Activities with IF below 0.70 (roughly tempo or harder) are dropped from the recency-weighted regression input. Hard rides anchor the fit; easy rides don't.</p>
 
-    <p>The filter is always on. The "Adjust the fit" panel reports how many activities were included, dropped, or marked as unknown (missing average-power data, e.g., legacy IDB cache &mdash; re-parse the archive to classify).</p>
+    <p>The filter is always on. Activities are dropped per-render with no user toggle &mdash; the goal is honest data, not knobs.</p>
 
     <h3>Why no recency weighting</h3>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     </div>
 
     <details id="manual-mode" class="manual-mode">
-      <summary id="manual-mode-summary">No archive yet? Estimate from FTP</summary>
+      <summary id="manual-mode-summary">Synthesize CP / W' from FTP</summary>
       <form id="manual-form" class="manual-form" novalidate>
         <label class="manual-form__field">
           <span>FTP (W)</span>

--- a/shared.css
+++ b/shared.css
@@ -392,14 +392,28 @@ main {
 
 /* App-state-driven layout. The body's data-app-state attribute
    ("onboarding" | "data" | "manual") controls which top-level
-   sections are visible so each state shows only what's relevant. */
-body[data-app-state="data"] .lede,
+   sections are visible so each state shows only what's relevant.
+   The lede stays visible in every state (it's the page header).
+   The manual-override disclosure is available in onboarding and
+   data states; it's only hidden in manual state because the
+   predict block already has the inline editors. */
 body[data-app-state="data"] .steps,
 body[data-app-state="data"] #archive-drop,
-body[data-app-state="data"] #manual-mode,
 body[data-app-state="manual"] .steps,
 body[data-app-state="manual"] #archive-drop,
 body[data-app-state="manual"] #manual-mode {
+  display: none;
+}
+body[data-app-state="data"] .lede,
+body[data-app-state="manual"] .lede {
+  margin-bottom: 0;
+}
+body[data-app-state="data"] .lede .headline,
+body[data-app-state="manual"] .lede .headline {
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+}
+body[data-app-state="data"] .lede .dek,
+body[data-app-state="manual"] .lede .dek {
   display: none;
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -498,7 +498,7 @@ function renderOverrideForm() {
       currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo
         ? 'open' : ''
     }>
-      <summary>Adjust the fit</summary>
+      <summary>Manual override (CP or date range)</summary>
       <form class="override-form" id="override-form">
         <label class="override-form__field">
           <span>CP override (W)</span>


### PR DESCRIPTION
## Summary
- Lede stays visible in data and manual states (just trimmed: dek hidden, headline sized down) so the page reads with a header instead of jumping straight to results.
- The FTP-synthesis disclosure stays visible in data state — manual override-with-data is a valid use case.
- "Adjust the fit" panel renamed to **"Manual override (CP or date range)"**.
- FTP-synthesis disclosure renamed to **"Synthesize CP / W' from FTP"** (one consistent label across all states).
- Methodology page picks up the rename and drops a stale sentence about the removed effort-filter toggle.

## Test plan
- [ ] Onboarding: lede + steps + drop zone + manual disclosure all visible.
- [ ] Cached: lede (compact) + results + manual disclosure (collapsed) visible. Predict block's override panel reads "Manual override (CP or date range)".
- [ ] Manual mode: lede (compact) + predict block visible; manual disclosure hidden (replaced by inline editor).
- [ ] Disclosure summary in every state reads "Synthesize CP / W' from FTP".