### PR TITLE
Manual override: accept FTP or CP at the user's choice

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -751,6 +751,37 @@ body[data-app-state="manual"] .lede .dek {
 }
 .override-form input:focus { border-bottom-color: var(--oxblood); }
 
+.override-form__combo {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.25rem 0;
+}
+.override-form__combo:focus-within { border-bottom-color: var(--oxblood); }
+.override-form__combo select {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--hair-strong);
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+}
+.override-form__combo input {
+  flex: 1;
+  border: none;
+  padding: 0;
+}
+.override-form__unit {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .override-form__check {
   grid-column: 1 / -1;
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -490,7 +490,15 @@ function pointsTooltip(n) {
 }
 
 function renderOverrideForm() {
-  const cp = currentSettings.cpOverrideW ?? '';
+  // The applied override is always stored as cpOverrideW. The
+  // input mode (`overrideUnit`: 'ftp' | 'cp') controls how we
+  // round-trip the number through the form: FTP mode displays
+  // cpOverrideW / 0.95 and saves user_value × 0.95 back.
+  const unit = currentSettings.overrideUnit === 'cp' ? 'cp' : 'ftp';
+  const cpW = currentSettings.cpOverrideW;
+  const displayValue = Number.isFinite(cpW)
+    ? (unit === 'ftp' ? Math.round(cpW / 0.95) : Math.round(cpW))
+    : '';
   const from = currentSettings.dateFrom || '';
   const to = currentSettings.dateTo || '';
   return `
@@ -498,11 +506,18 @@ function renderOverrideForm() {
       currentSettings.cpOverrideW || currentSettings.dateFrom || currentSettings.dateTo
         ? 'open' : ''
     }>
-      <summary>Manual override (CP or date range)</summary>
+      <summary>Manual override (FTP/CP or date range)</summary>
       <form class="override-form" id="override-form">
         <label class="override-form__field">
-          <span>CP override (W)</span>
-          <input type="number" id="cp-override" min="50" max="600" step="1" value="${cp}" placeholder="e.g. 280">
+          <span>Override</span>
+          <div class="override-form__combo">
+            <select id="override-unit" aria-label="Override unit">
+              <option value="ftp" ${unit === 'ftp' ? 'selected' : ''}>FTP</option>
+              <option value="cp" ${unit === 'cp' ? 'selected' : ''}>CP</option>
+            </select>
+            <input type="number" id="cp-override" min="50" max="600" step="1" value="${displayValue}" placeholder="e.g. 280">
+            <span class="override-form__unit">W</span>
+          </div>
         </label>
         <label class="override-form__field">
           <span>From</span>
@@ -526,13 +541,18 @@ function wireOverrideForm() {
   if (!form) return;
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
-    const cpStr = document.getElementById('cp-override').value.trim();
+    const valueStr = document.getElementById('cp-override').value.trim();
+    const unit = document.getElementById('override-unit').value === 'cp' ? 'cp' : 'ftp';
     const from = document.getElementById('date-from').value;
     const to = document.getElementById('date-to').value;
-    const cp = cpStr ? Number(cpStr) : null;
+    const value = valueStr ? Number(valueStr) : null;
+    const cpW = Number.isFinite(value)
+      ? (unit === 'ftp' ? value * 0.95 : value)
+      : null;
     currentSettings = {
       ...currentSettings,
-      cpOverrideW: Number.isFinite(cp) ? cp : null,
+      cpOverrideW: cpW,
+      overrideUnit: unit,
       dateFrom: from || null,
       dateTo: to || null,
     };


### PR DESCRIPTION
## Summary
The "Manual override" panel's wattage input now sits next to a small **FTP / CP** selector. Most users know their FTP, not their CP — defaulting to FTP keeps the panel approachable. CP-aware users (or those who've done a real CP test) can switch.

Internally the applied override is still stored as \`cpOverrideW\`; the selector controls how we round-trip the displayed number. FTP mode multiplies by 0.95 on save and divides by 0.95 on display.

## Test plan
- [ ] Open Manual override — selector defaults to FTP, blank value field.
- [ ] Type 280, switch to CP, value stays at 280 → wait, switching unit should update display? Acceptable to leave the typed value alone until apply. Check that Apply with FTP=280 yields CP ≈ 266 W on the predict block.
- [ ] Reload — selector still reads FTP and the field shows 280 (round-tripped from 266 / 0.95).
- [ ] Switch to CP, type 250, Apply → CP reads 250 W exactly. Reload, selector reads CP, field is 250.
- [ ] Reset wipes both unit and value back to defaults.