### PR TITLE
Clean up the data-state header

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -392,28 +392,17 @@ main {
 
 /* App-state-driven layout. The body's data-app-state attribute
    ("onboarding" | "data" | "manual") controls which top-level
-   sections are visible so each state shows only what's relevant.
-   The lede stays visible in every state (it's the page header).
-   The manual-override disclosure is available in onboarding and
-   data states; it's only hidden in manual state because the
-   predict block already has the inline editors. */
+   sections are visible. The site-header wordmark serves as the
+   page identity in data/manual states; the marketing lede only
+   appears for fresh visitors. */
+body[data-app-state="data"] .lede,
 body[data-app-state="data"] .steps,
 body[data-app-state="data"] #archive-drop,
+body[data-app-state="data"] #manual-mode,
+body[data-app-state="manual"] .lede,
 body[data-app-state="manual"] .steps,
 body[data-app-state="manual"] #archive-drop,
 body[data-app-state="manual"] #manual-mode {
-  display: none;
-}
-body[data-app-state="data"] .lede,
-body[data-app-state="manual"] .lede {
-  margin-bottom: 0;
-}
-body[data-app-state="data"] .lede .headline,
-body[data-app-state="manual"] .lede .headline {
-  font-size: clamp(1.6rem, 3vw, 2.2rem);
-}
-body[data-app-state="data"] .lede .dek,
-body[data-app-state="manual"] .lede .dek {
   display: none;
 }
 
@@ -435,6 +424,11 @@ body[data-app-state="manual"] .lede .dek {
   color: var(--ink-soft);
 }
 .manual-mode > summary::-webkit-details-marker { display: none; }
+.manual-mode > summary:focus { outline: none; }
+.manual-mode > summary:focus-visible {
+  outline: 2px solid var(--oxblood);
+  outline-offset: -2px;
+}
 .manual-mode > summary::before {
   content: '+';
   display: inline-block;

--- a/src/app.js
+++ b/src/app.js
@@ -399,6 +399,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       </p>
       <div class="results-foot__actions">
         <button type="button" class="link-button" id="upload-another">Upload another archive</button>
+        <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP instead</button>
         <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
       </div>
     </div>
@@ -409,6 +410,16 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
   document.getElementById('upload-another').addEventListener('click', () => {
     fileInput?.click();
+  });
+  document.getElementById('manual-from-data').addEventListener('click', () => {
+    // Drop into manual mode with default starting numbers — the
+    // inline editor inside the manual block lets the user adjust
+    // from there. Pre-seed FTP from the override if one exists.
+    const seedFtp = Number.isFinite(currentSettings.cpOverrideW)
+      ? Math.round(currentSettings.cpOverrideW / 0.95)
+      : 280;
+    const fit = synthesizeFit({ ftpW: seedFtp });
+    if (fit) renderManualMode(fit, { ftpW: seedFtp });
   });
   wirePredictForm();
   wireCurveChart();


### PR DESCRIPTION
## Summary
- Drop the marketing lede ("How many watts. For how long.") in data and manual states. The site-header wordmark + nav already provides identity; the lede is for fresh visitors only.
- Hide the freestanding "Synthesize CP / W' from FTP" disclosure in data state. Manual override is still one click away — there's now a "Synthesize from FTP instead" link in the results foot row alongside Upload another / Clear cached.
- Replace the default browser focus ring on the disclosure summary with a custom oxblood outline so it stops clashing with the editorial palette.

## Test plan
- [ ] Cached visitor: page reads site-header → results immediately, no lede, no orphan disclosure. Foot row shows three link-buttons (Upload another / Synthesize from FTP / Clear cached).
- [ ] Click "Synthesize from FTP instead" → drops into manual mode with FTP pre-filled (280 default, or your prior CP-override rounded to FTP). Inline editor lets you adjust.
- [ ] "Back to my data" returns to the data view cleanly.
- [ ] Onboarding (no cache): full lede + steps + drop zone + disclosure unchanged.
- [ ] Tab to the disclosure summary in onboarding → focus ring is oxblood, not browser blue.