### PR TITLE
Restore lede everywhere; CP/FTP toggle on the synthesis disclosure

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,12 +55,21 @@
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>
     </div>
 
+    <p class="manual-mode-divider"><span>or, in lieu of an archive</span></p>
+
     <details id="manual-mode" class="manual-mode">
-      <summary id="manual-mode-summary">Synthesize CP / W' from FTP</summary>
+      <summary id="manual-mode-summary">Skip the upload — estimate from FTP or CP</summary>
       <form id="manual-form" class="manual-form" novalidate>
         <label class="manual-form__field">
-          <span>FTP (W)</span>
-          <input type="number" id="manual-ftp" min="50" max="600" step="1" placeholder="280" autocomplete="off" required>
+          <span>Threshold</span>
+          <div class="manual-form__combo">
+            <select id="manual-unit" aria-label="Threshold unit">
+              <option value="ftp" selected>FTP</option>
+              <option value="cp">CP</option>
+            </select>
+            <input type="number" id="manual-threshold" min="50" max="600" step="1" placeholder="280" autocomplete="off" required>
+            <span class="manual-form__unit">W</span>
+          </div>
         </label>
         <label class="manual-form__field">
           <span>Best 1-min power (W) <em>optional</em></span>
@@ -71,9 +80,9 @@
         </div>
       </form>
       <p class="results-foot__note">
-        A coarse CP/W' synthesized from FTP. CP is set to 0.95 × FTP; W' comes from your 1-min sprint when given,
-        otherwise defaults to 18 kJ (middle of the trained-cyclist range). Upload your archive when you can —
-        the prediction tightens up considerably with real data.
+        A coarse synthesis. CP is set to 0.95 × FTP (or used directly if you enter CP); W' comes from your 1-min
+        sprint when given, otherwise defaults to 18 kJ (middle of the trained-cyclist range). Upload your archive
+        when you can — the prediction tightens up considerably with real data.
       </p>
     </details>
     <p id="progress" class="progress" hidden></p>

--- a/shared.css
+++ b/shared.css
@@ -390,24 +390,47 @@ main {
 .mmp-table tbody td.featured { color: var(--oxblood); font-weight: 500; }
 .mmp-table tbody tr:hover td { background: var(--paper-soft); }
 
-/* App-state-driven layout. The body's data-app-state attribute
-   ("onboarding" | "data" | "manual") controls which top-level
-   sections are visible. The site-header wordmark serves as the
-   page identity in data/manual states; the marketing lede only
-   appears for fresh visitors. */
-body[data-app-state="data"] .lede,
+/* App-state-driven layout. The lede stays visible in every state
+   (it's the page header). State controls the secondary sections:
+   onboarding shows the steps + drop zone + synth disclosure;
+   data and manual hide all of those in favor of the results. */
 body[data-app-state="data"] .steps,
 body[data-app-state="data"] #archive-drop,
 body[data-app-state="data"] #manual-mode,
-body[data-app-state="manual"] .lede,
 body[data-app-state="manual"] .steps,
 body[data-app-state="manual"] #archive-drop,
 body[data-app-state="manual"] #manual-mode {
   display: none;
 }
 
+.manual-mode-divider {
+  text-align: center;
+  margin: 1.75rem auto 0.25rem;
+  max-width: 36rem;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.manual-mode-divider::before,
+.manual-mode-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--hair-strong);
+}
+.manual-mode-divider span { white-space: nowrap; }
+body[data-app-state="data"] .manual-mode-divider,
+body[data-app-state="manual"] .manual-mode-divider { display: none; }
+
 .manual-mode {
-  margin: 1.5rem auto 0;
+  margin: 0.5rem auto 0;
   max-width: 36rem;
   border: 1px solid var(--hair);
   background: var(--paper-soft);
@@ -480,6 +503,37 @@ body[data-app-state="manual"] #manual-mode {
   outline: none;
 }
 .manual-form input:focus { border-bottom-color: var(--oxblood); }
+
+.manual-form__combo {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--ink);
+  padding: 0.4rem 0;
+}
+.manual-form__combo:focus-within { border-bottom-color: var(--oxblood); }
+.manual-form__combo select {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-soft);
+  background: transparent;
+  border: 1px solid var(--hair-strong);
+  padding: 0.2rem 0.5rem;
+  cursor: pointer;
+}
+.manual-form__combo input {
+  flex: 1;
+  border: none;
+  padding: 0;
+}
+.manual-form__unit {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
 .manual-form__actions {
   grid-column: 1 / -1;
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -44,12 +44,14 @@ const manualForm = document.getElementById('manual-form');
 if (manualForm) {
   manualForm.addEventListener('submit', (e) => {
     e.preventDefault();
-    const ftpW = Number(document.getElementById('manual-ftp').value);
+    const unit = document.getElementById('manual-unit').value === 'cp' ? 'cp' : 'ftp';
+    const value = Number(document.getElementById('manual-threshold').value);
+    const ftpW = unit === 'cp' ? value / 0.95 : value;
     const sprintRaw = document.getElementById('manual-1min').value.trim();
     const sprint1minW = sprintRaw ? Number(sprintRaw) : null;
     const fit = synthesizeFit({ ftpW, sprint1minW });
     if (!fit) {
-      setProgress('Enter a positive FTP value (typical range 100-450 W).');
+      setProgress('Enter a positive FTP or CP value (typical range 100-450 W).');
       return;
     }
     renderManualMode(fit, { ftpW, sprint1minW });


### PR DESCRIPTION
## Summary
- Stop hiding the lede in data and manual states. Full kicker + headline + dek now show in every state — the user explicitly wants it as the page header throughout.
- Add an "or, in lieu of an archive" divider above the synthesis disclosure in onboarding so it reads as an explicit alternative to the upload, not a separate option.
- Rename the disclosure summary to "Skip the upload — estimate from FTP or CP" to match.
- Replace the disclosure's bare FTP input with the same FTP/CP unit-toggle widget already used in the manual override panel. CP entries divide by 0.95 before being handed to \`synthesizeFit\`, so the rest of the pipeline remains FTP-based.

## Test plan
- [ ] Onboarding (no cache): full lede visible. Drop zone, then a horizontal "or, in lieu of an archive" divider, then the disclosure (collapsed) reading "Skip the upload — estimate from FTP or CP".
- [ ] Open the disclosure → threshold input has FTP/CP selector + value + W suffix; sprint input still standalone.
- [ ] Submit FTP=280 → manual mode renders with CP ≈ 266 W as before.
- [ ] Submit CP=250 → manual mode renders with CP = 250 W exactly.
- [ ] Cached state: lede still visible; divider + disclosure both hidden as expected.