### PR TITLE
Drop redundant 'or, in lieu of an archive' divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,6 @@
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>
     </div>
 
-    <p class="manual-mode-divider"><span>or, in lieu of an archive</span></p>
-
     <details id="manual-mode" class="manual-mode">
       <summary id="manual-mode-summary">Skip the upload — estimate from FTP or CP</summary>
       <form id="manual-form" class="manual-form" novalidate>

--- a/shared.css
+++ b/shared.css
@@ -403,34 +403,8 @@ body[data-app-state="manual"] #manual-mode {
   display: none;
 }
 
-.manual-mode-divider {
-  text-align: center;
-  margin: 1.75rem auto 0.25rem;
-  max-width: 36rem;
-  font-family: var(--sans);
-  font-size: 0.7rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--muted);
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-.manual-mode-divider::before,
-.manual-mode-divider::after {
-  content: "";
-  flex: 1;
-  height: 1px;
-  background: var(--hair-strong);
-}
-.manual-mode-divider span { white-space: nowrap; }
-body[data-app-state="data"] .manual-mode-divider,
-body[data-app-state="manual"] .manual-mode-divider { display: none; }
-
 .manual-mode {
-  margin: 0.5rem auto 0;
+  margin: 1.5rem auto 0;
   max-width: 36rem;
   border: 1px solid var(--hair);
   background: var(--paper-soft);


### PR DESCRIPTION
## Summary
The disclosure summary already says "Skip the upload — estimate from FTP or CP," which makes the meaning clear without a separator above. Drop the divider element + CSS and restore the disclosure's natural top margin.

## Test plan
- [ ] Onboarding: drop zone, then disclosure (collapsed) directly below — no horizontal "or" line between them.
- [ ] Spacing between drop zone and disclosure still feels balanced.