### PR TITLE
Fade-in the FTP-synthesis disclosure on load

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1220,7 +1220,8 @@ body[data-app-state="manual"] #manual-mode {
 
 .lede > *,
 .steps > li,
-.drop {
+.drop,
+.manual-mode {
   opacity: 0;
   animation: rise 720ms cubic-bezier(.2, .8, .2, 1) forwards;
 }
@@ -1231,6 +1232,7 @@ body[data-app-state="manual"] #manual-mode {
 .steps > li:nth-child(2) { animation-delay: 640ms; }
 .steps > li:nth-child(3) { animation-delay: 740ms; }
 .drop        { animation-delay: 880ms; }
+.manual-mode { animation-delay: 980ms; }
 
 #results[data-revealed] {
   animation: rise 600ms cubic-bezier(.2, .8, .2, 1);
@@ -1242,7 +1244,7 @@ body[data-app-state="manual"] #manual-mode {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
-  .lede > *, .steps > li, .drop { opacity: 1; }
+  .lede > *, .steps > li, .drop, .manual-mode { opacity: 1; }
 }
 
 /* RESPONSIVE */


### PR DESCRIPTION
## Summary
The lede, steps, and drop zone all fade in on initial page load via the existing \`rise\` keyframe with staggered delays. The FTP-synthesis disclosure was missing from that list and popped in instantly. Add \`.manual-mode\` to the animation list with a 980 ms delay so it lands just after the drop zone, and include it in the reduced-motion override.

## Test plan
- [ ] Fresh load (or reload) — disclosure fades in alongside the other onboarding elements rather than appearing abruptly.
- [ ] With \`prefers-reduced-motion: reduce\` (System Settings → Accessibility), disclosure renders at full opacity immediately like everything else.