### PR TITLE
Move manual-mode action links below the predict form

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -608,6 +608,15 @@ body[data-app-state="manual"] #manual-mode {
   gap: 1.25rem;
   flex-wrap: wrap;
 }
+.results-foot--manual {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--hair);
+  justify-content: flex-end;
+}
+.manual-note {
+  margin-bottom: 1.5rem;
+}
 
 .link-button {
   background: none;

--- a/src/app.js
+++ b/src/app.js
@@ -650,17 +650,11 @@ function renderManualMode(fit, inputs = {}) {
         </div>
       </dl>
 
-      <div class="results-foot">
-        <p class="results-foot__note">
-          Predictions will be coarse compared to a real archive — the model has no information about your
-          sprint kinetics or your endurance fade. Upload your Strava archive when you can to anchor the
-          long-duration end of the curve.
-        </p>
-        <div class="results-foot__actions">
-          ${hasPriorData ? `<button type="button" class="link-button" id="manual-back">← Back to my data (${priorActivities.length})</button>` : ''}
-          <button type="button" class="link-button" id="manual-upload">Upload an archive</button>
-        </div>
-      </div>
+      <p class="results-foot__note manual-note">
+        Predictions will be coarse compared to a real archive — the model has no information about your
+        sprint kinetics or your endurance fade. Upload your Strava archive when you can to anchor the
+        long-duration end of the curve.
+      </p>
 
       <form class="predict-form" id="predict-form">
         <label class="predict-form__field">
@@ -670,6 +664,13 @@ function renderManualMode(fit, inputs = {}) {
         <button type="submit">Predict</button>
       </form>
       <output class="predict-output" id="predict-output" hidden></output>
+
+      <div class="results-foot results-foot--manual">
+        <div class="results-foot__actions">
+          ${hasPriorData ? `<button type="button" class="link-button" id="manual-back">← Back to my data (${priorActivities.length})</button>` : ''}
+          <button type="button" class="link-button" id="manual-upload">Upload an archive</button>
+        </div>
+      </div>
     </section>
   `;
   resultsEl.hidden = false;


### PR DESCRIPTION
## Summary
The "Upload an archive" link sat between the manual-mode note and the "Target duration" label, breaking the form's vertical flow. Move the action row to the bottom of the manual block (after the predict form and output) with a small hairline separator above it.

## Test plan
- [ ] Manual mode block reads top-to-bottom: header → inline FTP/sprint editor → CP/W' stats → note → predict form (label + input + button) → output (when shown) → action row.
- [ ] Action links sit at the bottom-right with a thin top rule separating them from the form/output.
- [ ] Clicking Upload an archive still opens the file picker; Back to my data still returns to the cached view.