### PR TITLE
Drop 'edits update live' from manual-mode meta

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -623,7 +623,7 @@ function renderManualMode(fit, inputs = {}) {
     <section class="predict predict--manual">
       <header class="results-head">
         <h2>Predict <span class="override-badge">MANUAL MODE</span></h2>
-        <span class="results-head__meta">Synthesized from FTP · edits update live</span>
+        <span class="results-head__meta">Synthesized from FTP</span>
       </header>
 
       <form class="manual-inline" id="manual-inline" novalidate>


### PR DESCRIPTION
## Summary
Trim the manual-mode header meta from "Synthesized from FTP · edits update live" to just "Synthesized from FTP." The live-update behavior is obvious once you start typing.

## Test plan
- [ ] Manual mode header reads "Synthesized from FTP" with no trailing dot or "edits update live".