### PR TITLE
3-parameter Morton CP fit

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -74,18 +74,23 @@
 
     <h2>3. The Critical Power model</h2>
 
-    <p>For durations from roughly 3 minutes to 20 minutes, sustainable power is well-described by the <strong>2-parameter Critical Power model</strong>:</p>
+    <p>Power Predict tries the <strong>3-parameter Morton model</strong> first and falls back to the classic 2-parameter form when the data is too sparse for the extra parameter to behave.</p>
 
-    <p class="formula"><em>P</em>(<em>t</em>) = CP + <em>W</em>′ / <em>t</em></p>
+    <p class="formula"><em>P</em>(<em>t</em>) = CP + <em>W</em>′ / (<em>t</em> + <em>W</em>′ / (<em>P</em><sub>max</sub> &minus; CP))</p>
 
     <p>where</p>
 
     <ul>
       <li><strong>CP</strong> (watts) is the asymptote &mdash; the power you could theoretically hold indefinitely if no other systems failed first.</li>
       <li><strong>W&prime;</strong> (joules) is the finite work you can do above CP before exhausting that anaerobic reserve.</li>
+      <li><strong>P<sub>max</sub></strong> (watts) is the short-duration asymptote that tames the curve below 3 minutes &mdash; the value the model approaches as <em>t</em> → 0.</li>
     </ul>
 
-    <p>With <em>x</em> = 1 / <em>t</em>, the formula becomes a line, and we fit it by ordinary least squares. <em>W&prime;</em> falls out as the slope, CP as the intercept. Power Predict reports the fit's RMSE alongside CP and W&prime; so you can see how well your data matches the model.</p>
+    <p>With τ = <em>W</em>′ / (<em>P</em><sub>max</sub> &minus; CP), the model collapses to a linear regression for any fixed τ: <em>P</em> = CP + <em>W</em>′ / (<em>t</em> + τ). We dense-grid τ in [1, 90] s, solve CP and <em>W</em>′ in closed form for each candidate, and pick the τ with minimum residual subject to physical sanity bounds (CP ∈ [50, 600] W, <em>W</em>′ ∈ [1, 60] kJ, <em>P</em><sub>max</sub> ∈ [CP+100, 2500] W).</p>
+
+    <p>The 3-parameter form lets the fitting window extend down to 30 seconds where the 2-parameter hyperbola would predict runaway power. When fewer than three points fall in the fit range, or no τ produces a sane combination, Power Predict falls back to the 2-parameter form fitted on 180&ndash;1200 s, which only needs two anchor points but distorts below 3 minutes.</p>
+
+    <p>Either way the result reports CP, <em>W</em>′, RMSE, and the number of fit points; the 3-parameter fit also exposes <em>P</em><sub>max</sub> in the CP cell tooltip and labels the predict block "3-param CP" rather than "2-param CP".</p>
 
     <h3>Why the fit line doesn't pass through every dot</h3>
 
@@ -157,7 +162,6 @@
     <p>Today's predictions assume your last 90 days of data accurately reflect your current fitness. Issues planned for upcoming releases:</p>
 
     <ul>
-      <li><strong>3-parameter CP fit</strong> &mdash; add a P<sub>max</sub> term so the model behaves on the &lt;3 minute end. Today the regression window starts at 3 min because the 2-parameter form distorts below that.</li>
       <li><strong>Training-load adjustment</strong> &mdash; modulate predictions by recent CTL/ATL/TSB so a rider mid-taper doesn't get the same forecast as a rider mid-build.</li>
     </ul>
 

--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ import {
   loadSettings,
   saveSettings,
 } from './storage.js';
-import { fitCp2, predictPower, mmpToPoints } from './cpfit.js';
+import { fitCp2, fitCp3, predictPower, mmpToPoints } from './cpfit.js';
 import { parseDuration } from './duration.js';
 import { synthesizeFit } from './manual.js';
 
@@ -356,8 +356,20 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const allTimeFitNorm = rollingBest(drift.activities, effortOpts);
   currentEftpNow = drift.eftpNow;
 
-  const primaryFit = fitCp2(mmpToPoints(last90Fit), undefined, { observedPoints: mmpToPoints(last90) });
-  const fallbackFit = fitCp2(mmpToPoints(allTimeFitNorm), undefined, { observedPoints: mmpToPoints(allTime) });
+  // Prefer the 3-parameter (Morton) fit when it produces a sane
+  // result — it handles short-duration data the 2-param hyperbola
+  // can't. Fall back to 2-param if the data is too sparse or no
+  // tau lands in the physical envelope.
+  const primaryPoints = mmpToPoints(last90Fit);
+  const primaryObserved = mmpToPoints(last90);
+  const primaryFit =
+    fitCp3(primaryPoints, undefined, { observedPoints: primaryObserved })
+    || fitCp2(primaryPoints, undefined, { observedPoints: primaryObserved });
+  const fallbackPoints = mmpToPoints(allTimeFitNorm);
+  const fallbackObserved = mmpToPoints(allTime);
+  const fallbackFit =
+    fitCp3(fallbackPoints, undefined, { observedPoints: fallbackObserved })
+    || fitCp2(fallbackPoints, undefined, { observedPoints: fallbackObserved });
   currentFit = primaryFit
     ? { ...primaryFit, fallback: false }
     : (fallbackFit ? { ...fallbackFit, fallback: true } : null);
@@ -453,7 +465,10 @@ function cpQuality(fit) {
 }
 function cpTooltip(fit) {
   if (fit.overridden) return 'CP is pinned to your manual override. W\' is still derived from the regression so the curve shape stays data-driven.';
-  if (fit.fallback)   return 'The 90-day window had too few MMP points in the 3-20 min range, so the fit fell back to all-time data.';
+  if (fit.fallback)   return 'The 90-day window had too few MMP points in the fit range, so the fit fell back to all-time data.';
+  if (fit.model === '3p' && Number.isFinite(fit.pMaxW)) {
+    return `Critical Power asymptote — the wattage you could theoretically hold indefinitely if no other system failed. 3-parameter Morton fit: P_max ≈ ${Math.round(fit.pMaxW)} W (the short-duration asymptote that tames the curve below 3 minutes).`;
+  }
   return 'CP came from a normal regression on the active window (last 90 days or your custom range).';
 }
 function wPrimeQuality(wPrimeJ) {
@@ -756,9 +771,10 @@ function renderPredictBlock() {
     currentSettings.dateFrom ||
     currentSettings.dateTo
   );
+  const modelLabel = currentFit.model === '3p' ? '3-param CP' : '2-param CP';
   const headerMeta = overrideActive
-    ? `CP model · custom override`
-    : `CP model · last 90 days, effort-filtered`;
+    ? `${modelLabel} · custom override`
+    : `${modelLabel} · last 90 days, effort-filtered`;
 
   return `
     <section class="predict">

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -16,6 +16,12 @@
 
 export const DEFAULT_FIT_RANGE = { minS: 180, maxS: 1200 };
 
+// 3-parameter (Morton) range can extend further down because the
+// pMax term tames the short-end behavior the 2-param hyperbola
+// can't represent. Lower bound 30s is a practical floor — below
+// that, neuromuscular contributions still dominate.
+export const DEFAULT_FIT_RANGE_3P = { minS: 30, maxS: 1200 };
+
 // Convert an MMP map ({60: 350, 300: 280, ...}) to an array of points.
 export function mmpToPoints(mmp) {
   const out = [];
@@ -87,6 +93,90 @@ export function fitCp2(points, range = DEFAULT_FIT_RANGE, opts = {}) {
   };
 }
 
+// 3-parameter Critical Power (Morton):
+//   P(t) = CP + W' / (t + W'/(P_max - CP))
+//        = CP + W' / (t + τ),  τ = W'/(P_max - CP)
+//
+// P_max is the asymptotic short-duration power. The extra
+// parameter eliminates the 2-param model's runaway behavior at
+// very short durations and lets the fit window extend down to
+// roughly 30 seconds.
+//
+// We fit by searching τ on a dense grid: for each candidate τ,
+// the model collapses to a linear regression (P = CP + W' / (t+τ)),
+// which we solve in closed form. Across the τ grid we pick the
+// one with minimum residual subject to physical sanity bounds:
+// CP ∈ [50, 600] W, W' ∈ [1, 60] kJ, P_max ∈ [CP+100, 2500] W.
+//
+// Falls back to null if no τ in range produces a sane fit. Caller
+// is expected to fall back to the 2-param fit in that case.
+export function fitCp3(points, range = DEFAULT_FIT_RANGE_3P, opts = {}) {
+  const filtered = points.filter(
+    (p) => p.durationS >= range.minS && p.durationS <= range.maxS
+  );
+  if (filtered.length < 3) return null;
+
+  let best = null;
+  for (let tau = 1; tau <= 90; tau += 0.5) {
+    const fit = fitLinearWithTau(filtered, tau);
+    if (!fit) continue;
+    if (fit.cpW < 50 || fit.cpW > 600) continue;
+    if (fit.wPrimeJ < 1000 || fit.wPrimeJ > 60000) continue;
+    if (fit.pMaxW < fit.cpW + 100 || fit.pMaxW > 2500) continue;
+    if (!best || fit.sse < best.sse) best = { ...fit, tauS: tau };
+  }
+  if (!best) return null;
+
+  const n = filtered.length;
+  const rmse = Math.sqrt(best.sse / n);
+
+  const observed = (opts.observedPoints || points)
+    .filter((p) => Number.isFinite(p.durationS) && Number.isFinite(p.powerW))
+    .map((p) => ({ durationS: p.durationS, powerW: p.powerW }))
+    .sort((a, b) => a.durationS - b.durationS);
+  const longest = observed[observed.length - 1] || null;
+
+  return {
+    cpW: best.cpW,
+    wPrimeJ: best.wPrimeJ,
+    pMaxW: best.pMaxW,
+    tauS: best.tauS,
+    rmse,
+    nPoints: n,
+    range,
+    minObservedS: filtered.reduce((m, p) => Math.min(m, p.durationS), Infinity),
+    maxObservedS: filtered.reduce((m, p) => Math.max(m, p.durationS), -Infinity),
+    longestS: longest?.durationS ?? null,
+    longestW: longest?.powerW ?? null,
+    points: observed,
+    model: '3p',
+  };
+}
+
+function fitLinearWithTau(points, tau) {
+  const n = points.length;
+  let sumX = 0, sumY = 0, sumXY = 0, sumX2 = 0;
+  for (const { durationS, powerW } of points) {
+    const x = 1 / (durationS + tau);
+    sumX += x;
+    sumY += powerW;
+    sumXY += x * powerW;
+    sumX2 += x * x;
+  }
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return null;
+  const wPrimeJ = (n * sumXY - sumX * sumY) / denom;
+  const cpW = (sumY - wPrimeJ * sumX) / n;
+  if (wPrimeJ <= 0) return null;
+  const pMaxW = cpW + wPrimeJ / tau;
+  let sse = 0;
+  for (const { durationS, powerW } of points) {
+    const predicted = cpW + wPrimeJ / (durationS + tau);
+    sse += (powerW - predicted) ** 2;
+  }
+  return { cpW, wPrimeJ, pMaxW, sse };
+}
+
 // Riegel-style fatigue decay applied beyond the CP-validity window.
 //   P(t) = P_anchor × (t_anchor / t)^k
 //
@@ -111,6 +201,13 @@ export const DEFAULT_DECAY = {
   k: 0.10,
 };
 
+// Baseline P(t) for the fit. 3-param fits include a tauS term;
+// 2-param fits don't, and the baseline collapses to CP + W'/t.
+function baselinePower(fit, t) {
+  const tau = Number.isFinite(fit.tauS) ? fit.tauS : 0;
+  return fit.cpW + fit.wPrimeJ / (t + tau);
+}
+
 // Predict sustainable power for a target duration.
 // Returns { powerW, low, high, extrapolated, fit, decayed } or null.
 //
@@ -127,7 +224,7 @@ export function predictPower(fit, durationS, opts = {}) {
   const decay = opts.decay === false ? null : { ...DEFAULT_DECAY, ...(opts.decay || {}) };
   const useObservedAnchors = opts.useObservedAnchors !== false;
 
-  let powerW = fit.cpW + fit.wPrimeJ / durationS;
+  let powerW = baselinePower(fit, durationS);
   let decayed = false;
   // Apply the observed-anchor envelope at *all* durations so the
   // chart line is continuous across the fit-window boundary. Inside
@@ -138,7 +235,7 @@ export function predictPower(fit, durationS, opts = {}) {
     // Inside the fit window the baseline is the model itself.
     // Outside, the threshold-anchored decay takes over (model at the
     // top of the fit window, then Riegel from there).
-    const thresholdAnchorPower = fit.cpW + fit.wPrimeJ / decay.fromS;
+    const thresholdAnchorPower = baselinePower(fit, decay.fromS);
     let best = durationS > decay.fromS
       ? thresholdAnchorPower * (decay.fromS / durationS) ** decay.k
       : powerW;
@@ -158,7 +255,7 @@ export function predictPower(fit, durationS, opts = {}) {
       // in CP/W'.)
       for (const p of fit.points) {
         if (p.durationS <= decay.fromS) continue;
-        const modelAtP = fit.cpW + fit.wPrimeJ / p.durationS;
+        const modelAtP = baselinePower(fit, p.durationS);
         if (p.powerW <= modelAtP) continue;
         const fromP = p.powerW * (p.durationS / durationS) ** decay.k;
         if (fromP > best) best = fromP;

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fitCp2, predictPower, mmpToPoints } from '../src/cpfit.js';
+import { fitCp2, fitCp3, predictPower, mmpToPoints } from '../src/cpfit.js';
 
 // Generate synthetic MMP points from a known CP/W' so we can verify
 // the fit recovers them.
@@ -155,5 +155,55 @@ describe('mmpToPoints', () => {
   it('skips invalid values', () => {
     const points = mmpToPoints({ 60: 350, 300: null, 600: undefined });
     expect(points).toHaveLength(1);
+  });
+});
+
+describe('fitCp3', () => {
+  // Synth from a known 3-param CP model so we can verify recovery.
+  function synth3p(cp, wPrime, pMax, durationsS) {
+    const tau = wPrime / (pMax - cp);
+    return durationsS.map((t) => ({ durationS: t, powerW: cp + wPrime / (t + tau) }));
+  }
+
+  it('recovers CP, W\', and P_max from noiseless 3-param synthetic data', () => {
+    const points = synth3p(260, 18000, 1400, [30, 60, 120, 300, 600, 900, 1200]);
+    const fit = fitCp3(points);
+    expect(fit).not.toBeNull();
+    // The τ search has 0.5 s resolution, so recovery is approximate
+    // rather than exact — bound to a few percent of each parameter.
+    expect(Math.abs(fit.cpW - 260)).toBeLessThan(5);
+    expect(Math.abs(fit.wPrimeJ - 18000)).toBeLessThan(500);
+    expect(Math.abs(fit.pMaxW - 1400)).toBeLessThan(50);
+    expect(fit.model).toBe('3p');
+    expect(fit.tauS).toBeGreaterThan(0);
+  });
+
+  it('returns null when fewer than 3 points fall in the fitting window', () => {
+    expect(fitCp3([])).toBeNull();
+    expect(fitCp3([
+      { durationS: 60, powerW: 500 },
+      { durationS: 300, powerW: 300 },
+    ])).toBeNull();
+  });
+
+  it('rejects fits whose parameters land outside physical bounds', () => {
+    // Pure 2-param hyperbola has effectively infinite P_max (no
+    // taper at short durations). The 3-param search should fail
+    // its sanity bounds.
+    const points = [
+      { durationS: 30, powerW: 1900 },   // 2-param would imply P_max ≫ 2500
+      { durationS: 60, powerW: 1100 },
+      { durationS: 300, powerW: 380 },
+      { durationS: 1200, powerW: 280 },
+    ];
+    const fit = fitCp3(points);
+    if (fit) expect(fit.pMaxW).toBeLessThanOrEqual(2500);
+  });
+
+  it('predictPower uses the 3-param baseline when tauS is present', () => {
+    const fit = fitCp3(synth3p(260, 18000, 1400, [30, 60, 120, 300, 600, 1200]));
+    const at60 = predictPower(fit, 60, { decay: false });
+    const expected = fit.cpW + fit.wPrimeJ / (60 + fit.tauS);
+    expect(at60.powerW).toBeCloseTo(expected, 4);
   });
 });


### PR DESCRIPTION
## Summary
- New \`fitCp3(points)\` in \`src/cpfit.js\` implements the Morton 3-parameter model, \`P(t) = CP + W' / (t + W'/(P_max - CP))\`. Solved by searching τ on a 0.5 s grid; for each candidate τ the model is linear in CP and W', so each iteration is closed-form. Final τ wins the minimum residual subject to physical bounds: CP ∈ [50, 600] W, W' ∈ [1, 60] kJ, P_max ∈ [CP+100, 2500] W.
- Wired into the app pipeline as the primary fit, with \`fitCp2\` as the fallback when 3p has insufficient data or every τ violates the bounds.
- The 3-parameter form lets the fitting window extend down to 30 seconds where the 2-parameter hyperbola predicted runaway power.
- \`predictPower\` baseline switches to the 3-param expression when \`fit.tauS\` is set, falling through to CP + W'/t otherwise. Chart picks it up for free.
- Predict header meta now reads "3-param CP" or "2-param CP" so the user knows which model landed; CP tooltip mentions P_max when 3-param.
- Methodology page updated; 4 new unit tests cover the recovery, sparse fallback, sanity bounds, and 3-param baseline path.

Closes #12.

## Test plan
- [ ] After Pages redeploys, the predict header reads "3-param CP · last 90 days, effort-filtered" (assuming sufficient short-duration data).
- [ ] CP / W' values are still in the same ballpark as before (3-param doesn't dramatically shift CP/W', it just adds a sane short-end).
- [ ] Hover the CP cell — tooltip mentions P_max with a value somewhere in the 1000-2000 W range for typical cyclists.
- [ ] Curve chart no longer races toward kilowatts at the 1s end; it tapers toward the P_max asymptote.
- [ ] If you set a tight date range that has only 2 fit-window points, the header falls back to "2-param CP".
- [ ] All 76 unit tests pass.