### PR TITLE
Clear the post-parse toast on successful render

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -197,9 +197,15 @@ async function handleArchive(file) {
     return;
   }
 
-  setProgress(
-    `Done. ${all.length} activities cached locally (${newList.length} new this run, ${skipped} already cached, ${withPower} with power out of ${lastActivitiesSeen} activity files).`
-  );
+  // The activity count is already in the results foot note, so we
+  // skip the "Done. N activities cached…" toast and just render —
+  // leaving it up between the lede and the table read as orphaned
+  // copy.
+  if (progressEl) {
+    progressEl.textContent = '';
+    progressEl.hidden = true;
+    progressEl.innerHTML = '';
+  }
   renderCurves(all);
 }
 


### PR DESCRIPTION
## Summary
The "Done. 2979 activities cached locally (2979 new this run, 0 already cached, 2979 with power out of 6683 activity files)" message stayed visible after a successful parse, sitting between the page header and the MMP table as orphaned copy. The activity count is already reported in the results-foot note ("2979 activities cached locally"), so just hide the progress element before \`renderCurves\` paints.

## Test plan
- [ ] Upload an archive end-to-end: progress bar runs, then the page transitions straight to the MMP table with no leftover toast above it.
- [ ] Activity count is still visible in the foot note below the table.
- [ ] Error / no-power-found paths still surface their messages (those don't render results, so progress stays visible there).