### PR TITLE
Add vertical breathing room between chart and predict form

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -673,7 +673,7 @@ body[data-app-state="manual"] #manual-mode {
 /* CURVE CHART */
 
 .curve-chart-section {
-  margin: 1.5rem 0 0;
+  margin: 1.5rem 0 2rem;
 }
 .curve-chart-head {
   display: flex;


### PR DESCRIPTION
## Summary
The Target Duration label sat hard against the bottom edge of the curve chart's legend. Add a 2rem bottom margin to \`.curve-chart-section\` so the predict form below it reads as its own block.

## Test plan
- [ ] Predict section: noticeable gap between the chart legend (Time / Observed MMP / CP fit / Extrapolation) and the "Target duration" label below.