### PR TITLE
Parse TCX activities alongside FIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Open issues are grouped by phase: see [milestones](https://github.com/iammike/po
 
 - **Phase 3 (modeling)** — 3-parameter CP fit with P_max (#12), training-load adjustment via CTL/ATL/TSB (#42)
 - **Phase 4 (sync)** — Strava OAuth + webhook ingest (#20, #21), 180-day API backfill (#39), rate-limit budget (#22), connect UI (#26)
-- **Phase 5 (polish)** — privacy / accessibility / account deletion, robust FIT error recovery (#29), TCX/GPX support (#8)
+- **Phase 5 (polish)** — privacy / accessibility / account deletion, robust FIT error recovery (#29)
 
 ## Strava setup (for Phase 4)
 

--- a/docs/strava-archive-guide.html
+++ b/docs/strava-archive-guide.html
@@ -53,7 +53,7 @@
     <p>Open Power Predict and drag the zip onto the upload area. Everything happens in your browser:</p>
     <ul>
       <li>The zip is unpacked locally</li>
-      <li>Each <code>activities/&lt;id&gt;.fit.gz</code> file is parsed for its power stream</li>
+      <li>Each <code>activities/&lt;id&gt;.fit.gz</code> or <code>.tcx.gz</code> file is parsed for its power stream</li>
       <li>Power-duration curves are computed and displayed</li>
     </ul>
 
@@ -66,7 +66,8 @@
       <tbody>
         <tr><td><code>activities.csv</code></td><td>Metadata for every activity (date, name, distance, duration).</td></tr>
         <tr><td><code>activities/&lt;id&gt;.fit.gz</code></td><td>Full FIT file — power, HR, cadence, GPS at 1 Hz.</td></tr>
-        <tr><td><code>activities/&lt;id&gt;.tcx.gz</code> / <code>.gpx.gz</code></td><td>Older or non-FIT activities.</td></tr>
+        <tr><td><code>activities/&lt;id&gt;.tcx.gz</code></td><td>Older Garmin Connect uploads. Power read from the <code>&lt;Watts&gt;</code> extension when present.</td></tr>
+        <tr><td><code>activities/&lt;id&gt;.gpx.gz</code></td><td>GPX rarely carries power, so these are skipped.</td></tr>
         <tr><td><code>media/</code></td><td>Activity photos. Power Predict ignores these.</td></tr>
         <tr><td><code>profile.csv</code>, <code>bikes.csv</code></td><td>Account info. Also ignored.</td></tr>
       </tbody>

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -11,9 +11,11 @@
 
 import { Unzip, UnzipInflate, gunzipSync } from 'fflate';
 import { parseFit } from './fit.js';
+import { parseTcx } from './tcx.js';
 import { extractMmp } from './mmp.js';
 
-const ACTIVITY_PATH = /^activities\/[^/]+\.fit(\.gz)?$/i;
+const FIT_PATH = /^activities\/[^/]+\.fit(\.gz)?$/i;
+const TCX_PATH = /^activities\/[^/]+\.tcx(\.gz)?$/i;
 const ACTIVITIES_CSV = /^activities\.csv$/i;
 const CHUNK_BYTES = 1 << 20; // 1 MB
 
@@ -73,7 +75,9 @@ async function parseArchive(file) {
         entry.start();
         return;
       }
-      if (!ACTIVITY_PATH.test(entry.name)) {
+      const isFit = FIT_PATH.test(entry.name);
+      const isTcx = TCX_PATH.test(entry.name);
+      if (!isFit && !isTcx) {
         entry.ondata = () => {};
         entry.start();
         return;
@@ -81,6 +85,7 @@ async function parseArchive(file) {
       activitiesSeen++;
       const chunks = [];
       let totalSize = 0;
+      const kind = isTcx ? 'tcx' : 'fit';
       entry.ondata = (err, chunk, final) => {
         if (err) { console.warn('zip entry error', entry.name, err); return; }
         if (chunk) { chunks.push(chunk); totalSize += chunk.length; }
@@ -89,7 +94,7 @@ async function parseArchive(file) {
           let offset = 0;
           for (const c of chunks) { bytes.set(c, offset); offset += c.length; }
           chunks.length = 0;
-          pendingFits.push({ name: entry.name, bytes });
+          pendingFits.push({ name: entry.name, bytes, kind });
         }
       };
       entry.start();
@@ -122,13 +127,12 @@ async function parseArchive(file) {
   // small differences in CSV path formatting don't break linking.
   const idByName = csvBytes ? buildIdMap(csvBytes) : null;
 
-  // ------- Parse FIT files -------
-  for (const { name, bytes } of pendingFits) {
-    let p = name;
+  // ------- Parse FIT and TCX files -------
+  for (const { name, bytes, kind } of pendingFits) {
     let b = bytes;
     try {
-      if (p.endsWith('.gz')) b = gunzipSync(b);
-      const activity = await parseFit(b);
+      if (name.endsWith('.gz')) b = gunzipSync(b);
+      const activity = kind === 'tcx' ? parseTcx(b) : await parseFit(b);
       if (activity?.powerStream) {
         const mmp = extractMmp(activity.powerStream);
         // Average power across the activity's full power stream

--- a/src/tcx.js
+++ b/src/tcx.js
@@ -1,0 +1,79 @@
+// TCX file → { startTime, durationS, distanceM, powerStream } extraction.
+//
+// Garmin's TCX is XML. Power lives in
+//   <Trackpoint>
+//     <Time>...</Time>
+//     <DistanceMeters>...</DistanceMeters>
+//     <Extensions><ns:TPX><ns:Watts>NNN</ns:Watts></ns:TPX></Extensions>
+//   </Trackpoint>
+// where the Activity Extensions namespace prefix varies by writer.
+//
+// Older Strava archives ship a meaningful share of activities as TCX
+// (Garmin Connect imports, third-party tools). We parse them exactly
+// the way we parse FIT: build a 1 Hz power stream rounded by timestamp,
+// require enough non-zero samples to call it a real power recording,
+// and hand back the same activity shape.
+
+const POWER_TAG_RE = /<(?:[A-Za-z0-9_]+:)?Watts[^>]*>([^<]+)<\/(?:[A-Za-z0-9_]+:)?Watts>/;
+
+export function parseTcx(bytes) {
+  const text = typeof bytes === 'string'
+    ? bytes
+    : new TextDecoder('utf-8').decode(bytes);
+  const trackpoints = extractTrackpoints(text);
+  if (trackpoints.length === 0) return null;
+
+  const t0 = trackpoints[0].t;
+  const tEnd = trackpoints[trackpoints.length - 1].t;
+  const durationS = Math.max(1, Math.round((tEnd - t0) / 1000) + 1);
+
+  const powerStream = new Float32Array(durationS);
+  let nonZeroSamples = 0;
+  let lastDistance = null;
+  for (const tp of trackpoints) {
+    if (typeof tp.distance === 'number') lastDistance = tp.distance;
+    if (typeof tp.power !== 'number') continue;
+    const idx = Math.round((tp.t - t0) / 1000);
+    if (idx >= 0 && idx < durationS) powerStream[idx] = tp.power;
+    if (tp.power > 0) nonZeroSamples++;
+  }
+
+  const minNonZero = Math.max(60, Math.floor(durationS * 0.05));
+  if (nonZeroSamples < minNonZero) {
+    return { startTime: t0, durationS, distanceM: lastDistance, powerStream: null };
+  }
+  return { startTime: t0, durationS, distanceM: lastDistance, powerStream };
+}
+
+// String-scan instead of building a DOM tree. Web Workers in
+// modern browsers ship DOMParser, but TCX files can be tens of MB
+// per activity and the regex pass is significantly faster on the
+// shapes we care about.
+function extractTrackpoints(text) {
+  const out = [];
+  const tpRe = /<Trackpoint[^>]*>([\s\S]*?)<\/Trackpoint>/g;
+  let m;
+  while ((m = tpRe.exec(text)) !== null) {
+    const inner = m[1];
+    const time = matchTag(inner, 'Time');
+    if (!time) continue;
+    const t = Date.parse(time);
+    if (Number.isNaN(t)) continue;
+    const distanceText = matchTag(inner, 'DistanceMeters');
+    const distance = distanceText !== null ? Number(distanceText) : null;
+    const powerMatch = inner.match(POWER_TAG_RE);
+    const power = powerMatch ? Number(powerMatch[1]) : null;
+    out.push({
+      t,
+      distance: Number.isFinite(distance) ? distance : null,
+      power: Number.isFinite(power) ? power : null,
+    });
+  }
+  return out;
+}
+
+function matchTag(text, tag) {
+  const re = new RegExp(`<${tag}[^>]*>([^<]+)<\/${tag}>`);
+  const m = text.match(re);
+  return m ? m[1].trim() : null;
+}

--- a/tests/tcx.test.js
+++ b/tests/tcx.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseTcx } from '../src/tcx.js';
+
+function makeTcx({ start, samples }) {
+  const points = samples.map(({ offsetS, watts, distance }) => {
+    const ts = new Date(start + offsetS * 1000).toISOString();
+    return `
+      <Trackpoint>
+        <Time>${ts}</Time>
+        ${distance != null ? `<DistanceMeters>${distance}</DistanceMeters>` : ''}
+        <Extensions>
+          <ns3:TPX xmlns:ns3="http://www.garmin.com/xmlschemas/ActivityExtension/v2">
+            ${watts != null ? `<ns3:Watts>${watts}</ns3:Watts>` : ''}
+          </ns3:TPX>
+        </Extensions>
+      </Trackpoint>`;
+  }).join('');
+  return `<?xml version="1.0"?><TrainingCenterDatabase><Activities><Activity><Lap><Track>${points}</Track></Lap></Activity></Activities></TrainingCenterDatabase>`;
+}
+
+describe('parseTcx', () => {
+  it('builds a 1 Hz power stream from trackpoints', () => {
+    const start = Date.parse('2024-01-01T10:00:00Z');
+    const samples = [];
+    for (let i = 0; i < 120; i++) samples.push({ offsetS: i, watts: 200 + i, distance: i * 5 });
+    const xml = makeTcx({ start, samples });
+    const out = parseTcx(new TextEncoder().encode(xml));
+    expect(out).not.toBeNull();
+    expect(out.startTime).toBe(start);
+    expect(out.durationS).toBe(120);
+    expect(out.distanceM).toBe(595);
+    expect(out.powerStream.length).toBe(120);
+    expect(out.powerStream[0]).toBe(200);
+    expect(out.powerStream[119]).toBe(319);
+  });
+
+  it('returns powerStream:null when too few non-zero samples', () => {
+    // 200s activity, only 30 non-zero samples → below the 60s floor
+    const start = Date.parse('2024-01-01T10:00:00Z');
+    const samples = [];
+    for (let i = 0; i < 200; i++) samples.push({ offsetS: i, watts: i < 30 ? 250 : 0 });
+    const out = parseTcx(makeTcx({ start, samples }));
+    expect(out.powerStream).toBeNull();
+    expect(out.durationS).toBe(200);
+  });
+
+  it('returns null on empty / invalid XML', () => {
+    expect(parseTcx('')).toBeNull();
+    expect(parseTcx('<TrainingCenterDatabase></TrainingCenterDatabase>')).toBeNull();
+  });
+
+  it('handles the unprefixed <Watts> tag form some writers emit', () => {
+    const start = Date.parse('2024-01-01T10:00:00Z');
+    const samples = [];
+    for (let i = 0; i < 80; i++) {
+      const ts = new Date(start + i * 1000).toISOString();
+      samples.push(`
+        <Trackpoint>
+          <Time>${ts}</Time>
+          <Extensions><TPX><Watts>${250}</Watts></TPX></Extensions>
+        </Trackpoint>`);
+    }
+    const xml = `<TrainingCenterDatabase><Activities><Activity><Lap><Track>${samples.join('')}</Track></Lap></Activity></Activities></TrainingCenterDatabase>`;
+    const out = parseTcx(xml);
+    expect(out.powerStream).not.toBeNull();
+    expect(out.powerStream[0]).toBe(250);
+  });
+});


### PR DESCRIPTION
## Summary
Strava exports preserve each activity's original upload format. A long-history archive can mix FIT (modern Garmin/Wahoo) with TCX (older Garmin Connect / Zwift exporters). Today the worker silently skips TCX entries.

- New \`src/tcx.js\` parses TCX trackpoints with a regex scanner (faster than DOMParser on multi-MB files), extracts \`<Time>\`, \`<DistanceMeters>\`, and \`<Watts>\` (handling both prefixed and unprefixed forms), and returns the same activity shape as \`parseFit\`.
- Worker matches \`activities/*.tcx(.gz)?\` alongside \`*.fit(.gz)?\` and dispatches by file kind.
- GPX skipped — power streams in GPX are rare; out of scope for this PR.
- Archive guide and README updated.
- 4 new unit tests; full suite at 80 green.

Closes #8.

## Test plan
- [ ] Re-parse a Strava archive that contains older TCX activities. Activity counts should rise to include the previously-skipped TCX rides with power.
- [ ] No console errors on archives that have no TCX entries (the existing FIT path is unchanged).
- [ ] All 80 unit tests pass.