### PR TITLE
Tighten lede→steps gap

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -191,7 +191,7 @@ main {
 .steps {
   list-style: none;
   padding: 0;
-  margin: clamp(3rem, 6vw, 5rem) 0 2rem;
+  margin: clamp(2rem, 4vw, 3rem) 0 2rem;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   border-top: var(--rule-strong);


### PR DESCRIPTION
## Summary
The \`.steps\` block had a 3rem-5rem top margin clamp; on wide viewports the upper end made the empty space between "your recent fitness." and the "01 / Request" row read as a layout gap. Drop the clamp to 2rem-3rem so the steps follow the lede more naturally.

## Test plan
- [ ] Onboarding view: noticeably less empty space between the dek and the steps row, but the steps row still has visible breathing room.