### PR TITLE
MMP table stops filtering by manual date range

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -329,12 +329,17 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
         (!dateToMs   || a.startTime <= dateToMs))
     : activityMmps;
 
-  const allTime = rollingBest(filtered);
-  const last90 = rollingBest(filtered, { windowDays: 90 });
-  const last30 = rollingBest(filtered, { windowDays: 30 });
-  const allTimeOwners = rollingBestWithOwners(filtered);
-  const last90Owners = rollingBestWithOwners(filtered, { windowDays: 90 });
-  const last30Owners = rollingBestWithOwners(filtered, { windowDays: 30 });
+  // The MMP table reports the rider's actual rolling-best across
+  // their full archive — Last 30d, Last 90d, All-time are static
+  // facts about their history. Date-range overrides only steer the
+  // fit pipeline below; they don't recompute what the user has
+  // demonstrably ridden.
+  const allTime = rollingBest(activityMmps);
+  const last90 = rollingBest(activityMmps, { windowDays: 90 });
+  const last30 = rollingBest(activityMmps, { windowDays: 30 });
+  const allTimeOwners = rollingBestWithOwners(activityMmps);
+  const last90Owners = rollingBestWithOwners(activityMmps, { windowDays: 90 });
+  const last30Owners = rollingBestWithOwners(activityMmps, { windowDays: 30 });
   currentMmpByWindow = { last30, last90, allTime };
 
   // Effort-quality filter: drop activities whose IF (avg / FTP)


### PR DESCRIPTION
## Summary
The MMP table's three columns (Last 30d, Last 90d, All-time) were being computed from \`filtered\`, the date-range-trimmed activity list. That made the All-time column shrink to whatever sat inside the range — not what the column name promises. The fit pipeline still uses the filtered list, so manual overrides continue to work for the regression and chart; only the table is now decoupled.

## Test plan
- [ ] Set a date range under Manual override (e.g., last 6 months). Fit numbers (CP, W', RMSE, etc.) reflect the range as before.
- [ ] MMP table values are unchanged from before any override — All-time stays at your true lifetime peak; Last 30d / 90d still reflect today minus N days.
- [ ] Reset override → identical behavior, no regressions.