### PR TITLE
Date-range presets in the manual override panel

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -858,6 +858,41 @@ body[data-app-state="manual"] #manual-mode {
 }
 .override-form__check input { margin: 0; }
 
+.override-form__presets {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0 0;
+}
+.override-form__presets-label {
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  margin-right: 0.25rem;
+}
+.override-form__presets button {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--hair-strong);
+  padding: 0.3rem 0.6rem;
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+.override-form__presets button:hover,
+.override-form__presets button:focus-visible {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+  outline: none;
+}
+
 .override-form__actions {
   grid-column: 1 / -1;
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -564,6 +564,16 @@ function renderOverrideForm() {
           <span>To</span>
           <input type="date" id="date-to" value="${to}">
         </label>
+        <div class="override-form__presets" role="group" aria-label="Date range presets">
+          <span class="override-form__presets-label">Last</span>
+          <button type="button" data-preset-days="15">15d</button>
+          <button type="button" data-preset-days="30">30d</button>
+          <button type="button" data-preset-days="45">45d</button>
+          <button type="button" data-preset-days="60">60d</button>
+          <button type="button" data-preset-days="90">90d</button>
+          <button type="button" data-preset-days="180">6mo</button>
+          <button type="button" data-preset-days="365">1y</button>
+        </div>
         <div class="override-form__actions">
           <button type="submit">Apply</button>
           <button type="button" class="link-button" id="reset-override">Reset</button>
@@ -600,6 +610,22 @@ function wireOverrideForm() {
     currentSettings = {};
     await saveSettings({});
     renderCurves(currentActivities, { fromCache: true });
+  });
+  document.querySelectorAll('.override-form__presets [data-preset-days]').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const days = Number(btn.dataset.presetDays);
+      const today = new Date();
+      const from = new Date(today);
+      from.setDate(today.getDate() - days);
+      const fmt = (d) => d.toISOString().slice(0, 10);
+      currentSettings = {
+        ...currentSettings,
+        dateFrom: fmt(from),
+        dateTo: fmt(today),
+      };
+      await saveSettings(currentSettings);
+      renderCurves(currentActivities, { fromCache: true });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
Adds quick-select chips below the From/To inputs in the Manual override panel: **Last 15d / 30d / 45d / 60d / 90d / 6mo / 1y**. Each click writes \`dateFrom = today - N\` and \`dateTo = today\` into settings and re-renders immediately — no Apply step required.

## Test plan
- [ ] Open Manual override → "Last 15d, 30d, 45d, 60d, 90d, 6mo, 1y" chips visible below the From/To inputs.
- [ ] Click 30d → From and To inputs populate, fit recomputes against the last-30-days slice.
- [ ] Click another preset → range updates instantly.
- [ ] Reset clears both dates and the chips can be re-used.
- [ ] Hover/focus shows oxblood-style filled state on chips.