### PR TITLE
Override panel: or divider + date inputs above presets

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -805,28 +805,17 @@ body[data-app-state="manual"] #manual-mode {
   padding: 0;
   margin-bottom: 0.2rem;
 }
-.override-form__custom-range {
+.override-form__date-row {
   display: grid;
-  grid-template-columns: auto 1fr 1fr;
-  gap: 0.6rem 1rem;
-  align-items: center;
-  padding-top: 0.4rem;
-  border-top: 1px dashed var(--hair);
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
 }
-.override-form__custom-label {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 0.85rem;
-  color: var(--muted);
-  grid-column: 1 / -1;
-  margin-top: 0.25rem;
-}
-.override-form__custom-range label {
+.override-form__date-row label {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
 }
-.override-form__custom-range label span {
+.override-form__date-row label span {
   font-family: var(--sans);
   font-size: 0.66rem;
   font-weight: 600;
@@ -834,6 +823,28 @@ body[data-app-state="manual"] #manual-mode {
   letter-spacing: 0.14em;
   color: var(--muted);
 }
+
+.override-form__or {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--muted);
+  text-align: center;
+}
+.override-form__or::before,
+.override-form__or::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--hair-strong);
+}
+.override-form__or span { white-space: nowrap; }
 .override-form__field {
   display: flex;
   flex-direction: column;

--- a/src/app.js
+++ b/src/app.js
@@ -574,20 +574,11 @@ function renderOverrideForm() {
           </div>
         </fieldset>
 
+        <p class="override-form__or" aria-hidden="true"><span>or</span></p>
+
         <fieldset class="override-form__group">
           <legend>Date range</legend>
-          <div class="override-form__presets" role="group" aria-label="Date range presets">
-            <span class="override-form__presets-label">Last</span>
-            <button type="button" data-preset-days="15">15d</button>
-            <button type="button" data-preset-days="30">30d</button>
-            <button type="button" data-preset-days="45">45d</button>
-            <button type="button" data-preset-days="60">60d</button>
-            <button type="button" data-preset-days="90">90d</button>
-            <button type="button" data-preset-days="180">6mo</button>
-            <button type="button" data-preset-days="365">1y</button>
-          </div>
-          <div class="override-form__custom-range">
-            <span class="override-form__custom-label">or pick exact dates</span>
+          <div class="override-form__date-row">
             <label>
               <span>From</span>
               <input type="date" id="date-from" value="${from}">
@@ -596,6 +587,16 @@ function renderOverrideForm() {
               <span>To</span>
               <input type="date" id="date-to" value="${to}">
             </label>
+          </div>
+          <div class="override-form__presets" role="group" aria-label="Date range presets">
+            <span class="override-form__presets-label">Quick set</span>
+            <button type="button" data-preset-days="15">15d</button>
+            <button type="button" data-preset-days="30">30d</button>
+            <button type="button" data-preset-days="45">45d</button>
+            <button type="button" data-preset-days="60">60d</button>
+            <button type="button" data-preset-days="90">90d</button>
+            <button type="button" data-preset-days="180">6mo</button>
+            <button type="button" data-preset-days="365">1y</button>
           </div>
         </fieldset>
 


### PR DESCRIPTION
## Summary
- Add a horizontal "or" rule between the **Threshold** and **Date range** sections so they read as alternative override paths.
- Reorder the Date range fieldset: From / To inputs first, preset chips below as a "Quick set" row. Drops the now-unused dashed sub-divider and the "or pick exact dates" label.

## Test plan
- [ ] Open Manual override → Threshold section, then a horizontal **— or —** rule, then the Date range section.
- [ ] Date range fieldset has From / To inputs first, then a row of preset chips labelled "Quick set".
- [ ] Clicking any preset still applies the range immediately.
- [ ] Apply / Reset still work.