### PR TITLE
Cap override-form width so the inputs aren't absurdly wide

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -786,6 +786,7 @@ body[data-app-state="manual"] #manual-mode {
   flex-direction: column;
   gap: 1.25rem;
   padding: 1rem 1rem 0.75rem;
+  max-width: 38rem;
 }
 .override-form__group {
   border: none;


### PR DESCRIPTION
## Summary
The Manual override form was stretching the entire predict-section width, making the Threshold input and From/To date fields ridiculously long on desktop and pushing Apply/Reset off to the far right.

Cap \`.override-form\` at \`max-width: 38rem\` so the form sits as a contained block on the left while the panel's outer chrome and the rest of the section can stay full-width.

## Test plan
- [ ] Open Manual override on a wide viewport — Threshold input is reasonably sized, From/To inputs aren't ridiculous, Apply/Reset sit close to the form rather than at the page edge.
- [ ] Narrow viewport: form still fits within the panel without overflow.