### PR TITLE
Form-based prediction nudge from CTL/ATL/TSB

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ wrangler secret put STRAVA_WEBHOOK_VERIFY_TOKEN
 
 Open issues are grouped by phase: see [milestones](https://github.com/iammike/power-predict/milestones). Highlights still queued:
 
-- **Phase 3 (modeling)** — 3-parameter CP fit with P_max (#12), training-load adjustment via CTL/ATL/TSB (#42)
+- **Phase 3 (modeling)** — done. 3-parameter CP fit with P_max (#12), training-load adjustment via CTL/ATL/TSB (#42), fitness-drift normalization (#17), anomaly filter (#18), manual mode (#73).
 - **Phase 4 (sync)** — Strava OAuth + webhook ingest (#20, #21), 180-day API backfill (#39), rate-limit budget (#22), connect UI (#26)
 - **Phase 5 (polish)** — privacy / accessibility / account deletion, robust FIT error recovery (#29)
 

--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -157,6 +157,21 @@
 
     <p>Manual mode is intentionally coarse. It can't anchor the long-duration end of the curve to real data, so 4-hour and 12-hour predictions fall back to the model's pure decay rather than observed history. Upload an archive when possible &mdash; the prediction quality improves materially.</p>
 
+    <h2>Form-based prediction nudge (CTL / ATL / TSB)</h2>
+
+    <p>Power Predict computes the standard cycling training-load triumvirate from your activity history and uses it to nudge predictions toward your current state of rest or fatigue:</p>
+
+    <ul>
+      <li><strong>TSS</strong> per activity = (IF² × duration<sub>h</sub> × 100), where IF = NP / FTP. NP is Coggan's normalized-power form (4th-root-of-mean-of-30s-rolling-avg<sup>4</sup>); FTP is taken as 0.95 × CP from the active fit. Capped at 600 to swallow data noise.</li>
+      <li><strong>CTL</strong> (Chronic Training Load) — exponentially-weighted average TSS, time constant 42 days. Proxy for fitness.</li>
+      <li><strong>ATL</strong> (Acute Training Load) — same, 7-day time constant. Proxy for fatigue.</li>
+      <li><strong>TSB</strong> (Training Stress Balance) = CTL − ATL. Positive values mean you're rested; negative means you're carrying fatigue.</li>
+    </ul>
+
+    <p>The predict block surfaces TSB as a <strong>Form</strong> stat. A small multiplier flows from TSB back into the prediction: peaking riders get a few percent up, deeply fatigued riders get a few percent down, capped at &plusmn;5 % so this is a nudge, not a rewrite. The output's confidence band carries the same multiplier.</p>
+
+    <p>The motivating case: a rider with a high CP who's spent 30 days on zone-2 base reads low on the rolling-90-day MMP because the recent rides aren't peak efforts. CTL stays high, ATL drops, TSB swings positive — the form adjustment recognizes they're rested and lifts the prediction by a couple of percent. Conversely, after a hard block: TSB negative, prediction trims a couple of percent, the model is honest about fatigue.</p>
+
     <h2>Limitations and planned improvements</h2>
 
     <p>Today's predictions assume your last 90 days of data accurately reflect your current fitness. Issues planned for upcoming releases:</p>

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import {
 import { fitCp2, fitCp3, predictPower, mmpToPoints } from './cpfit.js';
 import { parseDuration } from './duration.js';
 import { synthesizeFit } from './manual.js';
+import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
 
 const dropZone = document.getElementById('archive-drop');
 const fileInput = document.getElementById('archive-input');
@@ -151,6 +152,7 @@ async function handleArchive(file) {
                 durationS: msg.durationS,
                 distanceM: msg.distanceM,
                 avgPower: msg.avgPower,
+                npW: msg.npW ?? msg.avgPower,
                 mmp: msg.mmp,
                 stravaId: msg.stravaId ?? null,
               });
@@ -313,6 +315,7 @@ function formatBytes(bytes) {
 // Held in module scope so the predict form + chart toggles can read.
 let currentFit = null;
 let currentEftpNow = null;
+let currentLoad = { ctl: 0, atl: 0, tsb: 0, hasFtp: false };
 let currentMmpByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
@@ -400,6 +403,13 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   if (currentFit && Number.isFinite(currentSettings.cpOverrideW)) {
     currentFit = { ...currentFit, cpW: currentSettings.cpOverrideW, overridden: true };
   }
+
+  // Training-load (CTL/ATL/TSB) computed against the full archive,
+  // not the date-filtered slice — TSB is about *current* fitness vs.
+  // fatigue, anchored at "now," regardless of any fit override.
+  // FTP for the IF calculation: 0.95 × CP from the fit (or null).
+  const ftpForLoad = currentFit?.cpW ? currentFit.cpW / 0.95 : null;
+  currentLoad = computeLoadSeries(activityMmps, ftpForLoad);
 
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)
@@ -531,6 +541,27 @@ function eftpTooltip() {
     ? 'within your selected date range'
     : 'from your most recent 90 days';
   return `Estimated FTP ${range}: 0.95 × best 20-min MMP. Used to drift-normalize older efforts when the fit falls back to all-time data.`;
+}
+
+// Form (TSB) display helpers. TSB is unitless; we report it with a
+// sign so a glance tells the user whether they're fresh or fatigued.
+function formatTsb(tsb) {
+  const v = Math.round(tsb);
+  return v > 0 ? `+${v}` : String(v);
+}
+function formQuality() {
+  const band = tsbBand(currentLoad.tsb);
+  if (band === 'fresh')      return { label: 'fresh', cls: 'is-good' };
+  if (band === 'building')   return { label: 'building', cls: 'is-mid' };
+  if (band === 'overloaded') return { label: 'overloaded', cls: 'is-bad' };
+  return { label: 'stable', cls: 'is-good' };
+}
+function formTooltip() {
+  const ctl = Math.round(currentLoad.ctl);
+  const atl = Math.round(currentLoad.atl);
+  const adj = Math.round((formMultiplier(currentLoad.tsb) - 1) * 100);
+  const adjStr = adj === 0 ? 'no adjustment' : `${adj > 0 ? '+' : ''}${adj}% applied to predictions`;
+  return `Form (TSB) = CTL ${ctl} − ATL ${atl}. Positive = fresh; negative = fatigued. ${adjStr}. Capped at ±5%.`;
 }
 
 // Combined fit-quality summary: pick whichever of RMSE / points is
@@ -737,6 +768,7 @@ function renderManualMode(fit, inputs = {}) {
   const priorSettings = currentSettings;
   currentFit = fit;
   currentEftpNow = null;
+  currentLoad = { ctl: 0, atl: 0, tsb: 0, hasFtp: false };
   currentMmpByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
   const hasPriorData = priorActivities.length > 0;
 
@@ -911,6 +943,12 @@ function renderPredictBlock() {
           <dd>${formatPower(currentEftpNow)}</dd>
           <span class="fit-stats__quality is-good">${eftpWindowLabel()}</span>
         </div>` : ''}
+        ${currentLoad.hasFtp ? `
+        <div data-tooltip="${formTooltip()}">
+          <dt>Form</dt>
+          <dd>${formatTsb(currentLoad.tsb)}</dd>
+          <span class="fit-stats__quality ${formQuality().cls}">${formQuality().label}</span>
+        </div>` : ''}
         <div data-tooltip="${combinedFitTooltip(currentFit)}">
           <dt>Fit</dt>
           <dd>${currentFit.rmse.toFixed(1)}W · ${currentFit.nPoints}pt</dd>
@@ -960,12 +998,23 @@ function wirePredictForm() {
       out.innerHTML = `<p class="predict-output__error">Couldn't parse that. Try "45m", "1h30m", or "90s".</p>`;
       return;
     }
-    const result = predictPower(currentFit, seconds);
-    if (!result) {
+    const raw = predictPower(currentFit, seconds);
+    if (!raw) {
       out.hidden = false;
       out.innerHTML = `<p class="predict-output__error">Prediction failed.</p>`;
       return;
     }
+    // Apply the form-based multiplier to the predicted wattage and
+    // its confidence band. Capped at ±5% inside formMultiplier so
+    // it's a nudge, not a rewrite.
+    const mult = currentLoad.hasFtp ? formMultiplier(currentLoad.tsb) : 1;
+    const adjPct = Math.round((mult - 1) * 100);
+    const result = mult === 1 ? raw : {
+      ...raw,
+      powerW: raw.powerW * mult,
+      low: raw.low * mult,
+      high: raw.high * mult,
+    };
     out.hidden = false;
     out.innerHTML = `
       <p class="predict-output__label">Predicted for ${formatDuration(seconds)}</p>
@@ -973,6 +1022,7 @@ function wirePredictForm() {
       <p class="predict-output__band">
         Range ${Math.round(result.low)}–${Math.round(result.high)} W
         ${result.extrapolated ? '<span class="predict-output__flag">extrapolated</span>' : ''}
+        ${adjPct !== 0 ? `<span class="predict-output__flag">${adjPct > 0 ? '+' : ''}${adjPct}% form</span>` : ''}
       </p>
     `;
   });

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -13,6 +13,7 @@ import { Unzip, UnzipInflate, gunzipSync } from 'fflate';
 import { parseFit } from './fit.js';
 import { parseTcx } from './tcx.js';
 import { extractMmp } from './mmp.js';
+import { normalizedPower } from './aggregate.js';
 
 const FIT_PATH = /^activities\/[^/]+\.fit(\.gz)?$/i;
 const TCX_PATH = /^activities\/[^/]+\.tcx(\.gz)?$/i;
@@ -146,6 +147,11 @@ async function parseArchive(file) {
         const avgPower = activity.powerStream.length
           ? totalPower / activity.powerStream.length
           : 0;
+        // Normalized Power for TSS / training-load math. Coggan's
+        // 4th-root-of-mean-of-30s-rolling-avg^4 form. Falls back
+        // to avgPower for activities too short for a 30s window.
+        const npRaw = normalizedPower(activity.powerStream);
+        const npW = Number.isFinite(npRaw) && npRaw > 0 ? npRaw : avgPower;
         // Resolve the public Strava activity ID via activities.csv.
         // The number in the FIT filename is the upload ID — globally
         // unique but distinct from the activity ID a user URL uses,
@@ -158,6 +164,7 @@ async function parseArchive(file) {
           durationS: activity.durationS,
           distanceM: activity.distanceM,
           avgPower,
+          npW,
           mmp,
           stravaId,
         });

--- a/src/load.js
+++ b/src/load.js
@@ -1,0 +1,109 @@
+// Training-load math: TSS per activity, then CTL / ATL / TSB rolling.
+//
+//   TSS = (IF² × duration_h × 100), where IF = NP / FTP
+//   CTL = exponentially-weighted average TSS, time constant 42 days
+//   ATL = same, time constant 7 days
+//   TSB = CTL - ATL  (positive = fresh, negative = fatigued)
+//
+// We compute these on demand from cached activities rather than
+// persisting daily snapshots, since our archive ingest happens
+// once per upload and the EWMA is cheap (one O(N) pass).
+//
+// Rationale on EWMA vs. simple windowed average: the standard
+// Banister/Coggan formulation uses EWMA so a hard ride 30 days
+// ago gradually loses influence rather than dropping out abruptly
+// at the day-42 boundary. Same for ATL with a 7-day decay.
+
+const DAY_MS = 86_400_000;
+const CTL_TAU_DAYS = 42;
+const ATL_TAU_DAYS = 7;
+
+// TSS for a single activity. Returns null when we can't form a
+// well-defined intensity factor (no FTP, no NP, zero/negative
+// duration, etc.). Capped at 600 — even a multi-hour all-out effort
+// rarely scores above ~500 TSS, anything beyond is data noise.
+export function computeTss(activity, ftpW) {
+  if (!activity) return null;
+  if (!Number.isFinite(ftpW) || ftpW <= 0) return null;
+  const np = Number.isFinite(activity.npW) && activity.npW > 0
+    ? activity.npW
+    : (Number.isFinite(activity.avgPower) && activity.avgPower > 0
+        ? activity.avgPower
+        : null);
+  if (np === null) return null;
+  const durationH = activity.durationS / 3600;
+  if (!Number.isFinite(durationH) || durationH <= 0) return null;
+  const intensity = np / ftpW;
+  const tss = intensity * intensity * durationH * 100;
+  return Math.min(600, Math.max(0, tss));
+}
+
+// Discrete EWMA in the standard Banister form:
+//   load_today = load_yesterday + (tss_today - load_yesterday) / τ
+// We bucket activities by day (UTC), sum TSS per day, walk from
+// the first day to `now` accumulating two parallel EWMAs (CTL τ=42
+// days, ATL τ=7 days).
+export function computeLoadSeries(activities, ftpW, opts = {}) {
+  if (!Array.isArray(activities) || activities.length === 0) {
+    return { ctl: 0, atl: 0, tsb: 0, days: 0, hasFtp: false };
+  }
+  const hasFtp = Number.isFinite(ftpW) && ftpW > 0;
+  if (!hasFtp) return { ctl: 0, atl: 0, tsb: 0, days: 0, hasFtp: false };
+
+  const now = opts.now ?? Date.now();
+  const dayKey = (t) => Math.floor(t / DAY_MS);
+  const today = dayKey(now);
+
+  // Sum TSS per day key.
+  const tssByDay = new Map();
+  let firstDay = null;
+  for (const a of activities) {
+    const d = dayKey(a.startTime);
+    if (firstDay === null || d < firstDay) firstDay = d;
+    const tss = computeTss(a, ftpW);
+    if (!Number.isFinite(tss)) continue;
+    tssByDay.set(d, (tssByDay.get(d) || 0) + tss);
+  }
+  if (firstDay === null) return { ctl: 0, atl: 0, tsb: 0, days: 0, hasFtp: true };
+
+  const startDay = Math.min(firstDay, today - CTL_TAU_DAYS);
+  let ctl = 0;
+  let atl = 0;
+  for (let d = startDay; d <= today; d++) {
+    const tss = tssByDay.get(d) || 0;
+    ctl = ctl + (tss - ctl) / CTL_TAU_DAYS;
+    atl = atl + (tss - atl) / ATL_TAU_DAYS;
+  }
+  return {
+    ctl,
+    atl,
+    tsb: ctl - atl,
+    days: today - startDay + 1,
+    hasFtp: true,
+  };
+}
+
+// Map TSB to a tiny multiplier on the prediction. Conservative
+// envelope so this is a nudge, not a rewrite of the model:
+//   TSB ≥ +25  →  +5%   (peaking, capped)
+//   TSB ≈ 0    →   0%
+//   TSB ≤ -25  →  -5%   (deeply fatigued, capped)
+// Linear in between. Returns 1 (no adjustment) when TSB isn't
+// computable.
+export function formMultiplier(tsb, opts = {}) {
+  if (!Number.isFinite(tsb)) return 1;
+  const cap = opts.capPct ?? 0.05;
+  const tsbAtCap = opts.tsbAtCap ?? 25;
+  const adj = Math.max(-cap, Math.min(cap, (tsb / tsbAtCap) * cap));
+  return 1 + adj;
+}
+
+// Categorize the TSB value for UI labelling. Returns one of
+// 'fresh' | 'stable' | 'building' | 'overloaded'.
+export function tsbBand(tsb) {
+  if (!Number.isFinite(tsb)) return 'unknown';
+  if (tsb >= 5) return 'fresh';
+  if (tsb >= -5) return 'stable';
+  if (tsb >= -20) return 'building';
+  return 'overloaded';
+}

--- a/tests/load.test.js
+++ b/tests/load.test.js
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { computeTss, computeLoadSeries, formMultiplier, tsbBand } from '../src/load.js';
+
+const day = 86_400_000;
+
+describe('computeTss', () => {
+  it('returns null without an FTP', () => {
+    expect(computeTss({ npW: 200, durationS: 3600 }, null)).toBeNull();
+    expect(computeTss({ npW: 200, durationS: 3600 }, 0)).toBeNull();
+  });
+
+  it('returns null without a usable NP/avgPower', () => {
+    expect(computeTss({ durationS: 3600 }, 250)).toBeNull();
+  });
+
+  it('matches the textbook formula on a 1-hour FTP effort (TSS = 100)', () => {
+    expect(computeTss({ npW: 250, durationS: 3600 }, 250)).toBeCloseTo(100, 4);
+  });
+
+  it('falls back to avgPower when npW is missing', () => {
+    expect(computeTss({ avgPower: 200, durationS: 3600 }, 250)).toBeCloseTo(64, 4);
+  });
+
+  it('caps absurd values at 600', () => {
+    // 4 hours all-out at IF=2 would compute to (4)(4)(100) = 1600; cap.
+    expect(computeTss({ npW: 500, durationS: 4 * 3600 }, 250)).toBe(600);
+  });
+});
+
+describe('computeLoadSeries', () => {
+  it('returns zero series when no FTP', () => {
+    const out = computeLoadSeries([{ startTime: 0, npW: 200, durationS: 3600 }], null);
+    expect(out).toEqual({ ctl: 0, atl: 0, tsb: 0, days: 0, hasFtp: false });
+  });
+
+  it('a steady 100 TSS/day rider has CTL ≈ ATL ≈ 100', () => {
+    const ftp = 250;
+    const now = 60 * day;
+    const acts = [];
+    for (let d = 0; d < 60; d++) {
+      acts.push({ startTime: d * day + 12 * 3600 * 1000, npW: 250, durationS: 3600 });
+    }
+    const out = computeLoadSeries(acts, ftp, { now });
+    expect(out.hasFtp).toBe(true);
+    expect(out.ctl).toBeGreaterThan(70);
+    expect(out.ctl).toBeLessThan(105);
+    expect(Math.abs(out.ctl - out.atl)).toBeLessThan(15);
+    // TSB near zero for a stable rider.
+    expect(Math.abs(out.tsb)).toBeLessThan(15);
+  });
+
+  it('a hard finish bumps ATL faster than CTL → negative TSB', () => {
+    const ftp = 250;
+    const now = 30 * day;
+    const acts = [];
+    for (let d = 0; d < 23; d++) {
+      acts.push({ startTime: d * day, npW: 200, durationS: 3600 });
+    }
+    // Hard week to finish
+    for (let d = 23; d < 30; d++) {
+      acts.push({ startTime: d * day, npW: 280, durationS: 90 * 60 });
+    }
+    const out = computeLoadSeries(acts, ftp, { now });
+    expect(out.tsb).toBeLessThan(0);
+  });
+
+  it('a taper raises TSB above zero', () => {
+    const ftp = 250;
+    const now = 30 * day;
+    const acts = [];
+    for (let d = 0; d < 23; d++) {
+      acts.push({ startTime: d * day, npW: 240, durationS: 90 * 60 });
+    }
+    // Easy taper week
+    for (let d = 23; d < 30; d++) {
+      acts.push({ startTime: d * day, npW: 160, durationS: 30 * 60 });
+    }
+    const out = computeLoadSeries(acts, ftp, { now });
+    expect(out.tsb).toBeGreaterThan(0);
+  });
+});
+
+describe('formMultiplier', () => {
+  it('returns 1 when TSB is unknown', () => {
+    expect(formMultiplier(NaN)).toBe(1);
+    expect(formMultiplier(null)).toBe(1);
+  });
+  it('returns 1 at TSB = 0', () => {
+    expect(formMultiplier(0)).toBeCloseTo(1, 6);
+  });
+  it('caps at +5% above TSB +25', () => {
+    expect(formMultiplier(40)).toBeCloseTo(1.05, 4);
+    expect(formMultiplier(25)).toBeCloseTo(1.05, 4);
+  });
+  it('caps at -5% below TSB -25', () => {
+    expect(formMultiplier(-40)).toBeCloseTo(0.95, 4);
+    expect(formMultiplier(-25)).toBeCloseTo(0.95, 4);
+  });
+  it('scales linearly between caps', () => {
+    expect(formMultiplier(10)).toBeCloseTo(1.02, 4);
+  });
+});
+
+describe('tsbBand', () => {
+  it('bands TSB by sign and magnitude', () => {
+    expect(tsbBand(15)).toBe('fresh');
+    expect(tsbBand(0)).toBe('stable');
+    expect(tsbBand(-10)).toBe('building');
+    expect(tsbBand(-30)).toBe('overloaded');
+    expect(tsbBand(NaN)).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
Lands the standard cycling training-load triumvirate as a small multiplier on top of the predict block.

- **\`src/load.js\`** — TSS per activity (capped at 600), per-day Banister EWMA over the activity history (τ=42 days for CTL, τ=7 for ATL), TSB = CTL − ATL, and a \`formMultiplier(tsb)\` that caps at ±5% across TSB ±25.
- **\`src/archive-worker.js\`** — computes Coggan's normalized power per activity (4th-root-of-mean-of-30s-avg⁴) using the existing \`aggregate.normalizedPower\` helper. New cache records carry an \`npW\` field; legacy records fall back to \`avgPower\`-as-NP so we don't break old caches.
- **\`src/app.js\`** — \`currentLoad\` is computed once per render against the full activity list (not the date-filtered slice — TSB is anchored at "now," not at any range). The fit-stats block gains a **Form (TSB)** cell with signed value and a band label (fresh / stable / building / overloaded). The predict-form output applies \`formMultiplier\` to both the predicted watts and the confidence band, and surfaces a small "+N% form" badge when the multiplier ≠ 1.
- **Tests** — 15 new unit tests cover the TSS formula, the steady-rider asymptote, the hard-finish vs taper polarity, and the multiplier cap. Suite at 95 green.
- **Methodology page** — new "Form-based prediction nudge" section explaining TSS / CTL / ATL / TSB and the ±5% cap.
- **README** — Phase 3 modeling is now marked done.

## Test plan
- [ ] Re-parse an archive (fresh records get \`npW\`; legacy ones use avgPower fallback).
- [ ] Predict block shows a **Form** stat with a signed TSB value and an appropriate band label.
- [ ] Hover the Form cell — tooltip lists CTL, ATL, current adjustment %, capped at ±5%.
- [ ] Predict output: prediction reflects the multiplier; "+N% form" badge appears next to "extrapolated" when the adjustment is non-zero.
- [ ] All 95 unit tests pass.