### PR TITLE
Fit fit-stats grid to a single row at any cell count

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1090,7 +1090,8 @@ body[data-app-state="manual"] #manual-mode {
 
 .fit-stats {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
   gap: 0;
   margin: 1rem 0 1.75rem;
   padding: 0;
@@ -1098,9 +1099,10 @@ body[data-app-state="manual"] #manual-mode {
   border-bottom: var(--rule-soft);
 }
 .fit-stats > div {
-  padding: 0.85rem 1rem;
+  padding: 0.85rem 0.85rem;
   border-right: var(--rule-soft);
   position: relative;
+  min-width: 0;
 }
 .fit-stats > div[data-tooltip] { cursor: help; }
 .fit-stats > div[data-tooltip]:hover::after,
@@ -1148,11 +1150,12 @@ body[data-app-state="manual"] #manual-mode {
 .fit-stats dd {
   font-family: var(--serif);
   font-weight: 500;
-  font-size: 1.35rem;
+  font-size: clamp(1.05rem, 1.6vw, 1.35rem);
   letter-spacing: -0.01em;
   margin: 0;
   color: var(--ink);
   font-variation-settings: "opsz" 36;
+  white-space: nowrap;
 }
 .fit-stats__quality {
   display: block;


### PR DESCRIPTION
## Summary
The Form (TSB) cell I added in #109 took the predict block up to five cells; the four-column grid wrapped **Fit** onto its own row. Switch to a column-direction auto-flow grid (\`grid-auto-flow: column\`) with each track at \`minmax(0, 1fr)\` so the row always renders every cell side-by-side at equal width regardless of count (3, 4, or 5). Clamp the dd font size to a 1.05rem–1.35rem range so values stay legible on narrower viewports.

## Test plan
- [ ] Wide viewport: all five fit-stats cells (CP, W', eFTP, Form, Fit) sit on one row.
- [ ] Narrower viewport: text shrinks via clamp instead of wrapping.
- [ ] Tablet/phone: still readable.
- [ ] Without an eFTP or Form (legacy / no-FTP cases) the grid still uses equal widths.