### PR TITLE
Anchor envelope respects the active date range

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -385,7 +385,16 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // can't. Fall back to 2-param if the data is too sparse or no
   // tau lands in the physical envelope.
   const primaryPoints = mmpToPoints(last90Fit);
-  const primaryObserved = mmpToPoints(last90);
+  // Observed-point set for predictPower's Riegel anchor envelope.
+  // Default is the unfiltered last-90-days view so a real ride from
+  // a few weeks ago can still keep predictions honest. When the user
+  // has actively narrowed to a date range, the anchor set should
+  // match the range — otherwise an effort outside the chosen slice
+  // leaks back into the prediction and disagrees with the chart.
+  const primaryObservedRaw = (dateFromMs || dateToMs)
+    ? rollingBest(filtered)
+    : last90;
+  const primaryObserved = mmpToPoints(primaryObservedRaw);
   const primaryFit =
     fitCp3(primaryPoints, undefined, { observedPoints: primaryObserved })
     || fitCp2(primaryPoints, undefined, { observedPoints: primaryObserved });


### PR DESCRIPTION
## Summary
\`predictPower\` walks observed MMP points beyond the 20-min decay threshold and lifts predictions to whichever Riegel-decayed anchor exceeds the model's curve. That keeps predictions honest when the regression runs low. The anchor set, though, was always the unfiltered last-90-days rolling-best — even when the user had narrowed the fit to a 30-day date range. Result: predictions inside an override could leak in efforts from outside the chosen slice and disagree visibly with the chart's extrapolation line.

When a date range is active, switch the primary fit's \`observedPoints\` to \`rollingBest(filtered)\` (the date-filtered slice). No-override path unchanged.

## Test plan
- [ ] Apply a 30-day range that excludes recent peak efforts → 30-min prediction now sits closer to the in-range observed value and the chart extrapolation, not 50 W above.
- [ ] Without a range, the prediction still uses the last-90-days envelope (a 6-week-old peak still anchors honestly).
- [ ] All 95 unit tests pass.