### PR TITLE
Fit a personal Riegel fatigue exponent from long-duration MMP

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -117,7 +117,9 @@
 
     <p>The anchor is whichever is later: your longest observed MMP point, or the 20-minute model prediction. Anchoring at real data when available means a 12-hour forecast is grounded in your actual 4-hour or 6-hour ride, not extrapolated all the way from the CP fit.</p>
 
-    <p>The fatigue exponent <em>k</em> = 0.10. Skiba publishes 0.07, which fits the 1&ndash;4 hour range; observed pro and amateur ultra-endurance data falls off faster than that, more like 0.10 in the 8&ndash;24 hour range. Defaulting higher avoids the trap of ultra predictions reading too close to CP.</p>
+    <p>The fatigue exponent <em>k</em> defaults to 0.10. Skiba publishes 0.07, which fits the 1&ndash;4 hour range; observed pro and amateur ultra-endurance data falls off faster than that, more like 0.10 in the 8&ndash;24 hour range. Defaulting higher avoids the trap of ultra predictions reading too close to CP.</p>
+
+    <p>When your archive contains at least three MMP points between 20 minutes and 4 hours, Power Predict fits a <strong>personal</strong> <em>k</em> by linear regression on log&minus;log MMP data: log <em>P</em> = <em>a</em> &minus; <em>k</em> &middot; log <em>t</em>. The fitted value replaces the default at predict time, both in the chart's fatigue line and in the predict form. The result is clamped to the 0.04&ndash;0.20 envelope to ignore degenerate fits driven by a single low-effort long ride. The Fatigue&nbsp;k stat in the predict block reports which value is in use and how many points it was fitted on.</p>
 
     <table>
       <thead><tr><th>Duration</th><th>Typical fraction of CP</th><th>Power Predict default</th></tr></thead>

--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ import {
   loadSettings,
   saveSettings,
 } from './storage.js';
-import { fitCp2, fitCp3, predictPower, mmpToPoints } from './cpfit.js';
+import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints } from './cpfit.js';
 import { parseDuration } from './duration.js';
 import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
@@ -413,6 +413,14 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     currentFit = { ...currentFit, cpW: currentSettings.cpOverrideW, overridden: true };
   }
 
+  // Personal fatigue exponent fitted from long-duration MMP. Replaces
+  // the default Riegel k = 0.10 at predict time when enough 20-min-to-
+  // 4-hr points exist. Falls back to the default otherwise.
+  if (currentFit) {
+    const fatigueSource = currentFit.fallback ? fallbackObserved : primaryObserved;
+    currentFit = { ...currentFit, fatigue: fitFatigueK(fatigueSource) };
+  }
+
   // Training-load (CTL/ATL/TSB) computed against the full archive,
   // not the date-filtered slice — TSB is about *current* fitness vs.
   // fatigue, anchored at "now," regardless of any fit override.
@@ -589,6 +597,31 @@ function formTooltip() {
   const adj = Math.round((formMultiplier(currentLoad.tsb) - 1) * 100);
   const adjStr = adj === 0 ? 'no adjustment' : `${adj > 0 ? '+' : ''}${adj}% applied to predictions`;
   return `Form (TSB) = CTL ${ctl} − ATL ${atl}. Positive = fresh; negative = fatigued. ${adjStr}. Capped at ±5%.`;
+}
+
+// Fatigue k: personal Riegel exponent fitted from 20-min-to-4-hr MMP.
+// When data is too sparse to fit, predictions fall back to k = 0.10 —
+// we show that here too so the cell isn't ever blank.
+function fatigueValue(fit) {
+  const k = fit.fatigue?.k ?? 0.10;
+  return k.toFixed(2);
+}
+function fatigueQuality(fit) {
+  if (!fit.fatigue) return { label: 'default', cls: 'is-mid' };
+  if (fit.fatigue.clamped) return { label: 'clamped', cls: 'is-mid' };
+  return { label: `${fit.fatigue.nPoints} pts`, cls: 'is-good' };
+}
+function fatigueTooltip(fit) {
+  if (!fit.fatigue) {
+    return 'Riegel fatigue exponent k governs how predicted power decays past 20 min: '
+         + 'P(t) = P_anchor × (t_anchor / t)^k. Need 3+ MMP points between 20 min and 4 h '
+         + 'to fit a personal value; falling back to the cycling default 0.10.';
+  }
+  const note = fit.fatigue.clamped
+    ? ` Raw fit was ${fit.fatigue.kRaw.toFixed(2)}, clamped into the 0.04–0.20 plausible range.`
+    : '';
+  return `Personal Riegel fatigue exponent fitted from ${fit.fatigue.nPoints} long-duration MMP points `
+       + `(20 min – 4 h). Lower k = better endurance fall-off. Cycling default is 0.10.${note}`;
 }
 
 // Combined fit-quality summary: pick whichever of RMSE / points is
@@ -976,6 +1009,11 @@ function renderPredictBlock() {
           <dd>${formatTsb(currentLoad.tsb)}</dd>
           <span class="fit-stats__quality ${formQuality().cls}">${formQuality().label}</span>
         </div>` : ''}
+        <div data-tooltip="${fatigueTooltip(currentFit)}">
+          <dt>Fatigue k</dt>
+          <dd>${fatigueValue(currentFit)}</dd>
+          <span class="fit-stats__quality ${fatigueQuality(currentFit).cls}">${fatigueQuality(currentFit).label}</span>
+        </div>
         <div data-tooltip="${combinedFitTooltip(currentFit)}">
           <dt>Fit</dt>
           <dd>${currentFit.rmse.toFixed(1)}W · ${currentFit.nPoints}pt</dd>
@@ -1025,7 +1063,8 @@ function wirePredictForm() {
       out.innerHTML = `<p class="predict-output__error">Couldn't parse that. Try "45m", "1h30m", or "90s".</p>`;
       return;
     }
-    const raw = predictPower(currentFit, seconds);
+    const decayOpt = currentFit.fatigue ? { decay: { k: currentFit.fatigue.k } } : {};
+    const raw = predictPower(currentFit, seconds, decayOpt);
     if (!raw) {
       out.hidden = false;
       out.innerHTML = `<p class="predict-output__error">Prediction failed.</p>`;

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -201,6 +201,45 @@ export const DEFAULT_DECAY = {
   k: 0.10,
 };
 
+// Fit a personal Riegel exponent from MMP points in the long-duration
+// range (default 20 min – 4 h). The relation
+//   P(t) = P_anchor × (t_anchor / t)^k
+// linearizes under log/log to log P = a − k · log t, so a least-squares
+// regression on (log t, log P) gives slope = −k.
+//
+// We require at least three points and clamp k to a physically plausible
+// envelope: below ~0.04 implies near-zero fatigue (unrealistic over hours);
+// above ~0.20 implies catastrophic decay seen only in untrained or sick
+// riders. Outside that window we still report the clamped value with a
+// `clamped` flag so callers can distinguish "fitted" from "rail-pinned."
+export const DEFAULT_FATIGUE_RANGE = { minS: 1200, maxS: 14400 };
+const FATIGUE_K_MIN = 0.04;
+const FATIGUE_K_MAX = 0.20;
+const FATIGUE_MIN_POINTS = 3;
+
+export function fitFatigueK(points, range = DEFAULT_FATIGUE_RANGE) {
+  if (!Array.isArray(points)) return null;
+  const filtered = points.filter(
+    (p) => p && p.durationS >= range.minS && p.durationS <= range.maxS && p.powerW > 0
+  );
+  if (filtered.length < FATIGUE_MIN_POINTS) return null;
+  const n = filtered.length;
+  let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+  for (const p of filtered) {
+    const x = Math.log(p.durationS);
+    const y = Math.log(p.powerW);
+    sumX += x; sumY += y; sumXY += x * y; sumXX += x * x;
+  }
+  const denom = n * sumXX - sumX * sumX;
+  if (denom <= 0) return null;
+  const slope = (n * sumXY - sumX * sumY) / denom;
+  const kRaw = -slope;
+  if (!Number.isFinite(kRaw)) return null;
+  const clamped = kRaw < FATIGUE_K_MIN || kRaw > FATIGUE_K_MAX;
+  const k = Math.max(FATIGUE_K_MIN, Math.min(FATIGUE_K_MAX, kRaw));
+  return { k, kRaw, nPoints: n, clamped };
+}
+
 // Baseline P(t) for the fit. 3-param fits include a tauS term;
 // 2-param fits don't, and the baseline collapses to CP + W'/t.
 function baselinePower(fit, t) {

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -78,6 +78,7 @@ export function renderCurveChart(container, { mmp, fit }) {
   // Solid inside the fit window, dashed outside; both series share
   // d == DEFAULT_DECAY.fromS so the visual transition is seamless.
   const lineOpts = { useObservedAnchors: false };
+  if (fit.fatigue) lineOpts.decay = { k: fit.fatigue.k };
   const insideSeries = xs.map((d) => {
     if (d < fit.range.minS || d > DEFAULT_DECAY.fromS) return null;
     const out = predictPower(fit, d, lineOpts);

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fitCp2, fitCp3, predictPower, mmpToPoints } from '../src/cpfit.js';
+import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints } from '../src/cpfit.js';
 
 // Generate synthetic MMP points from a known CP/W' so we can verify
 // the fit recovers them.
@@ -205,5 +205,59 @@ describe('fitCp3', () => {
     const at60 = predictPower(fit, 60, { decay: false });
     const expected = fit.cpW + fit.wPrimeJ / (60 + fit.tauS);
     expect(at60.powerW).toBeCloseTo(expected, 4);
+  });
+});
+
+describe('fitFatigueK', () => {
+  // Build a synthetic Riegel-decayed dataset: P(t) = P0 × (t0 / t)^k
+  function riegel(p0, t0, k, durationsS) {
+    return durationsS.map((t) => ({ durationS: t, powerW: p0 * (t0 / t) ** k }));
+  }
+
+  it('recovers k on a noiseless synthetic decay', () => {
+    const pts = riegel(280, 1200, 0.08, [1200, 1800, 2700, 3600, 5400, 7200]);
+    const out = fitFatigueK(pts);
+    expect(out.k).toBeCloseTo(0.08, 4);
+    expect(out.clamped).toBe(false);
+    expect(out.nPoints).toBe(6);
+  });
+
+  it('returns null when fewer than 3 points fall in range', () => {
+    const pts = [
+      { durationS: 1200, powerW: 280 },
+      { durationS: 3600, powerW: 250 },
+    ];
+    expect(fitFatigueK(pts)).toBeNull();
+  });
+
+  it('ignores points outside the long-duration range', () => {
+    const pts = [
+      ...riegel(280, 1200, 0.08, [1200, 1800, 3600]),
+      { durationS: 60, powerW: 600 },   // sprint, ignored
+      { durationS: 300, powerW: 380 },  // 5 min, ignored
+    ];
+    const out = fitFatigueK(pts);
+    expect(out.nPoints).toBe(3);
+    expect(out.k).toBeCloseTo(0.08, 3);
+  });
+
+  it('clamps absurdly steep decays into the plausible envelope', () => {
+    const pts = riegel(280, 1200, 0.40, [1200, 1800, 3600, 7200]);
+    const out = fitFatigueK(pts);
+    expect(out.clamped).toBe(true);
+    expect(out.k).toBe(0.20);
+    expect(out.kRaw).toBeGreaterThan(0.30);
+  });
+
+  it('clamps near-zero decays into the plausible envelope', () => {
+    const pts = riegel(280, 1200, 0.005, [1200, 1800, 3600, 7200]);
+    const out = fitFatigueK(pts);
+    expect(out.clamped).toBe(true);
+    expect(out.k).toBe(0.04);
+  });
+
+  it('returns null for non-array input', () => {
+    expect(fitFatigueK(null)).toBeNull();
+    expect(fitFatigueK(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add `fitFatigueK` in `src/cpfit.js`. Linear regression on log–log MMP between 20 min and 4 h yields a personal Riegel exponent. Requires 3+ points; clamps to a 0.04–0.20 plausibility envelope; reports a `clamped` flag so the UI can flag rail-pinned fits.
- Wire the fitted k into both `predictPower` (predict form) and the chart line so the fatigue tail matches what the form predicts.
- New `Fatigue k` stat in the predict block, with a tooltip that explains the formula, the data source (n points), and falls back gracefully to the 0.10 default when the archive is sparse.
- Methodology doc updated.

Closes #115.

## Test plan
- [ ] 6 new tests in `tests/cpfit.test.js` cover noiseless recovery, sparse-data null, range filtering, high-side and low-side clamping, non-array input.
- [ ] Open the deployed app with a real archive — confirm the Fatigue k cell shows a fitted value and a `N pts` badge, and the chart tail no longer hugs the default 0.10 curve when your data implies a different rate.
- [ ] Confirm an archive without long-duration MMP still shows `k = 0.10` and `default` badge.