### PR TITLE
Surface count of files skipped due to parse errors

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -121,6 +121,8 @@ async function handleArchive(file) {
   let withPower = 0;
   let skipped = 0;
   let lastActivitiesSeen = 0;
+  let parseFailed = 0;
+  let parseFailedSamples = [];
 
   const worker = new Worker('dist/archive-worker.js');
 
@@ -162,6 +164,8 @@ async function handleArchive(file) {
             console.warn('cache check failed', err);
           }
         } else if (msg.type === 'done') {
+          parseFailed = msg.failed || 0;
+          parseFailedSamples = msg.failedSamples || [];
           resolve();
         } else if (msg.type === 'error') {
           reject(new Error(msg.message));
@@ -202,11 +206,22 @@ async function handleArchive(file) {
   // The activity count is already in the results foot note, so we
   // skip the "Done. N activities cached…" toast and just render —
   // leaving it up between the lede and the table read as orphaned
-  // copy.
+  // copy. The exception is when files failed to parse: that's
+  // information the user needs, so we keep the progress slot for a
+  // brief notice listing how many files were skipped.
   if (progressEl) {
-    progressEl.textContent = '';
-    progressEl.hidden = true;
-    progressEl.innerHTML = '';
+    if (parseFailed > 0) {
+      const sampleStr = parseFailedSamples.length
+        ? ` (${parseFailedSamples.slice(0, 3).join(', ')}${parseFailed > 3 ? ', …' : ''})`
+        : '';
+      const noun = parseFailed === 1 ? 'file' : 'files';
+      progressEl.hidden = false;
+      progressEl.innerHTML = `<p class="progress__note">Skipped ${parseFailed} ${noun} that couldn’t be parsed${sampleStr}. See console for details.</p>`;
+    } else {
+      progressEl.textContent = '';
+      progressEl.hidden = true;
+      progressEl.innerHTML = '';
+    }
   }
   renderCurves(all);
 }

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -37,6 +37,11 @@ async function parseArchive(file) {
   let activitiesSeen = 0;
   let parsedCount = 0;
   let withPower = 0;
+  let failed = 0;
+  // Sample of basenames for the first few failures, for the post-parse
+  // notice. Cap at 5 so a fully corrupt archive doesn't bloat the
+  // postMessage payload.
+  const failedSamples = [];
 
   // Buffers per pending activity entry. We can't parse FIT inside
   // ondata because parseFit is synchronous and slow — instead we
@@ -172,6 +177,10 @@ async function parseArchive(file) {
       }
     } catch (err) {
       console.warn('parse failed', name, err);
+      failed++;
+      if (failedSamples.length < 5) {
+        failedSamples.push(name.split('/').pop() || name);
+      }
     }
     parsedCount++;
     if (parsedCount % 5 === 0 || parsedCount === pendingFits.length) {
@@ -180,7 +189,7 @@ async function parseArchive(file) {
   }
   pendingFits.length = 0;
 
-  self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower });
+  self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower, failed, failedSamples });
 }
 
 export { buildIdMap, parseCsv };


### PR DESCRIPTION
## Summary
- Worker tracks per-archive parse-failure count and the first 5 failing basenames; posts both on 'done'.
- App reads them and, when non-zero, shows a brief notice in the progress slot ('Skipped 3 files that couldn't be parsed (foo.fit, bar.fit, …). See console for details.') instead of clearing the progress area.
- No notice when every file parses cleanly — silent success stays silent.

Closes #29.

## Test plan
- [ ] Upload an archive that includes a known-corrupt FIT — confirm the count appears with sample names, and console retains the per-file warnings.
- [ ] Upload a clean archive — progress slot clears as before.