### PR TITLE
Date the rolling-best MMP cells

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -616,6 +616,15 @@ body[data-app-state="manual"] #manual-mode {
   color: var(--oxblood);
   border-bottom-color: var(--oxblood);
 }
+.mmp-cell__date {
+  display: inline-block;
+  margin-left: 0.4rem;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
 
 
 .results-foot {

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -46,7 +46,7 @@ export function rollingBestWithOwners(activityMmps, {
       const v = cleaned?.[d];
       if (typeof v !== 'number') continue;
       if (best[d] === undefined || v > best[d].value) {
-        best[d] = { value: v, stravaId: a.stravaId ?? null };
+        best[d] = { value: v, stravaId: a.stravaId ?? null, startTime: a.startTime };
       }
     }
   }

--- a/src/app.js
+++ b/src/app.js
@@ -578,8 +578,11 @@ function wPrimeTooltip(wPrimeJ) {
 function renderMmpCell(owner) {
   if (!owner || typeof owner.value !== 'number') return '—';
   const watts = formatPower(owner.value);
-  if (!owner.stravaId) return watts;
-  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>`;
+  const dateStr = Number.isFinite(owner.startTime)
+    ? `<span class="mmp-cell__date">${new Date(owner.startTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>`
+    : '';
+  if (!owner.stravaId) return `${watts}${dateStr}`;
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>${dateStr}`;
 }
 
 // eFTP is computed from a 90-day window ending at the most recent

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -35,15 +35,15 @@ describe('rollingBestWithOwners', () => {
       { startTime: 2, stravaId: 'B', mmp: { 60: 300, 300: 200 } },
     ];
     expect(rollingBestWithOwners(acts)).toEqual({
-      60: { value: 300, stravaId: 'B' },
-      300: { value: 220, stravaId: 'A' },
+      60: { value: 300, stravaId: 'B', startTime: 2 },
+      300: { value: 220, stravaId: 'A', startTime: 1 },
     });
   });
 
   it('records null stravaId when activity has none', () => {
     const acts = [{ startTime: 1, mmp: { 60: 200 } }];
     expect(rollingBestWithOwners(acts)).toEqual({
-      60: { value: 200, stravaId: null },
+      60: { value: 200, stravaId: null, startTime: 1 },
     });
   });
 });


### PR DESCRIPTION
## Summary
- \`rollingBestWithOwners\` now retains the winning activity's \`startTime\` alongside the \`stravaId\`.
- \`renderMmpCell\` adds a small mono-date span ('302 W · Mar 14') so the user can skim when each best was recorded without clicking through.

## Test plan
- [ ] Confirm a date appears next to each populated MMP cell, in all three columns.
- [ ] Cells that link to Strava keep their dotted underline; the date sits outside the link.
- [ ] Stale cached data without the new owner shape gracefully omits the date instead of crashing (Number.isFinite guard).