### PR TITLE
Make chart hover crosshair visible with live readout

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -754,6 +754,20 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
+/* uPlot draws cursor crosshair lines as 1px borders on absolutely-
+   positioned divs. The default inherited color is nearly invisible
+   on our cream paper, so we pin them to ink with a hairline width. */
+.curve-chart .u-cursor-x,
+.curve-chart .u-cursor-y {
+  border-color: var(--ink);
+  opacity: 0.45;
+}
+/* Make the cursor point markers visible against light fills. */
+.curve-chart .u-cursor-pt {
+  border-color: var(--oxblood) !important;
+  background: var(--paper) !important;
+}
+
 /* OVERRIDE PANEL */
 
 .override-panel {

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -163,7 +163,14 @@ export function renderCurveChart(container, { mmp, fit }) {
     ],
     cursor: {
       drag: { x: false, y: false },
+      x: true,
+      y: true,
       points: { size: 6 },
+      // Snap the crosshair x to whatever data column is closest in
+      // pixel space, then read y values off each series for the live
+      // legend. (uPlot does this by default; declared here so future
+      // changes don't accidentally lose the hover readout.)
+      focus: { prox: 24 },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Style \`.u-cursor-x\` / \`.u-cursor-y\` to ink at 45% opacity so the crosshair is actually visible against the cream paper background. Cursor point markers get an oxblood ring on paper fill.
- Pin \`cursor.x / cursor.y / focus\` explicitly in the chart options so future opts changes don't accidentally lose the hover readout.
- The legend was already \`live: true\`, so hovering the curve now reads watts at any duration via the existing legend table.

## Test plan
- [ ] Move the cursor across the chart — vertical and horizontal hairlines follow it.
- [ ] Watts in the legend update as you move; duration in the x-series column reads as '5m', '20m', '1h', etc.
- [ ] Cursor markers on each series appear at the snapped x.