### PR TITLE
Move MMP cell date into the hover title

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -616,15 +616,6 @@ body[data-app-state="manual"] #manual-mode {
   color: var(--oxblood);
   border-bottom-color: var(--oxblood);
 }
-.mmp-cell__date {
-  display: inline-block;
-  margin-left: 0.4rem;
-  font-family: var(--mono);
-  font-size: 0.68rem;
-  letter-spacing: 0.04em;
-  color: var(--ink-soft);
-  font-variant-numeric: tabular-nums;
-}
 
 
 .results-foot {

--- a/src/app.js
+++ b/src/app.js
@@ -578,11 +578,14 @@ function wPrimeTooltip(wPrimeJ) {
 function renderMmpCell(owner) {
   if (!owner || typeof owner.value !== 'number') return '—';
   const watts = formatPower(owner.value);
-  const dateStr = Number.isFinite(owner.startTime)
-    ? `<span class="mmp-cell__date">${new Date(owner.startTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>`
-    : '';
-  if (!owner.stravaId) return `${watts}${dateStr}`;
-  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="Open this activity on Strava">${watts}</a>${dateStr}`;
+  const date = Number.isFinite(owner.startTime)
+    ? new Date(owner.startTime).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+    : null;
+  if (!owner.stravaId) {
+    return date ? `<span title="${date}">${watts}</span>` : watts;
+  }
+  const title = date ? `${date} · open on Strava` : 'Open this activity on Strava';
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="${title}">${watts}</a>`;
 }
 
 // eFTP is computed from a 90-day window ending at the most recent


### PR DESCRIPTION
## Summary
- Drop the inline mono-date span — too noisy in a table that's already dense, and a Mar 14 with no year stops being useful once the archive spans multiple seasons.
- Put the full date (with year) into the link's title attribute. Cells without a Strava link wrap the watts in a span carrying the same title.

## Test plan
- [ ] Table reads cleanly: just watts in each cell.
- [ ] Hover any populated cell — tooltip reads 'Mar 14, 2026 · open on Strava' (or just the date for cells without a link).