### PR TITLE
Drop the chart hover crosshair

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,20 +745,6 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* uPlot draws cursor crosshair lines as 1px borders on absolutely-
-   positioned divs. The default inherited color is nearly invisible
-   on our cream paper, so we pin them to ink with a hairline width. */
-.curve-chart .u-cursor-x,
-.curve-chart .u-cursor-y {
-  border-color: var(--ink);
-  opacity: 0.45;
-}
-/* Make the cursor point markers visible against light fills. */
-.curve-chart .u-cursor-pt {
-  border-color: var(--oxblood) !important;
-  background: var(--paper) !important;
-}
-
 /* OVERRIDE PANEL */
 
 .override-panel {

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -163,14 +163,9 @@ export function renderCurveChart(container, { mmp, fit }) {
     ],
     cursor: {
       drag: { x: false, y: false },
-      x: true,
-      y: true,
-      points: { size: 6 },
-      // Snap the crosshair x to whatever data column is closest in
-      // pixel space, then read y values off each series for the live
-      // legend. (uPlot does this by default; declared here so future
-      // changes don't accidentally lose the hover readout.)
-      focus: { prox: 24 },
+      x: false,
+      y: false,
+      points: { show: false },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Revert the cursor-line styling and the explicit cursor opts. Crosshair + point markers read busy against the editorial chart aesthetic.
- Live legend stays — hovering still updates the watts/duration readout, just without the visual noise.

## Test plan
- [ ] Move the cursor across the chart — no vertical/horizontal lines, no series cursor markers.
- [ ] Legend values still update as the cursor moves.