### PR TITLE
Restore cursor point markers without the crosshair lines

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,6 +745,13 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
+/* Cursor markers (one per series at the snapped x). Pin to oxblood
+   on a paper fill so the tracer reads as a marker, not a hairline. */
+.curve-chart .u-cursor-pt {
+  border-color: var(--oxblood) !important;
+  background: var(--paper) !important;
+}
+
 /* OVERRIDE PANEL */
 
 .override-panel {

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -163,9 +163,13 @@ export function renderCurveChart(container, { mmp, fit }) {
     ],
     cursor: {
       drag: { x: false, y: false },
+      // Suppress the full-length crosshair lines — they read too busy
+      // against the editorial chart style. Per-series cursor markers
+      // stay enabled (uPlot default), so hovering traces the curve
+      // and highlights the snapped MMP point at the cursor's x.
       x: false,
       y: false,
-      points: { show: false },
+      points: { size: 7 },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Re-enable the per-series cursor point markers (uPlot default) so hovering traces the fitted curve and highlights observed MMP points at the snapped x.
- Pin the marker style to oxblood-on-paper so it reads as a discrete tracer, not a hairline.
- Crosshair hairlines stay disabled — those were the noisy part.

## Test plan
- [ ] Move the cursor across the chart — small markers track each series at the snapped x; observed MMP dots get a ring as you pass over them.
- [ ] No vertical/horizontal lines.
- [ ] Legend continues to read live watts at the cursor.