### PR TITLE
Restyle chart cursor tracer as filled ink registration squares

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,11 +745,17 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* Cursor markers (one per series at the snapped x). Pin to oxblood
-   on a paper fill so the tracer reads as a marker, not a hairline. */
+/* Cursor markers (one per series at the snapped x). Filled ink
+   squares — registration-mark feel that sits inside the editorial
+   typographic palette, distinct from the round oxblood MMP dots so
+   the tracer never gets read as data. uPlot sizes them inline via
+   cursor.points.size; we strip the inherited circle styling. */
 .curve-chart .u-cursor-pt {
-  border-color: var(--oxblood) !important;
-  background: var(--paper) !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  background: var(--ink) !important;
+  box-shadow: none !important;
+  transition: transform 80ms ease-out;
 }
 
 /* OVERRIDE PANEL */

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -169,7 +169,7 @@ export function renderCurveChart(container, { mmp, fit }) {
       // and highlights the snapped MMP point at the cursor's x.
       x: false,
       y: false,
-      points: { size: 7 },
+      points: { size: 6 },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Switch cursor markers from oxblood rings on paper to small filled ink squares (border-radius: 0, no stroke). Reads as a printer's registration mark — sits comfortably in the editorial typographic palette and never gets confused with the round oxblood MMP data points.
- Drop point size from 7 → 6. Add an 80ms transform transition so movement feels deliberate, not jittery.

## Test plan
- [ ] Hover the curve — small ink squares trace along the lines and observed dots.
- [ ] Visually distinct from the round oxblood MMP dots.
- [ ] No spinning-loader-ring artifact.