### PR TITLE
Replace cursor tracer with a short vertical tick from the x-axis

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,18 +745,21 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* Cursor markers (one per series at the snapped x). Filled ink
-   squares — registration-mark feel that sits inside the editorial
-   typographic palette, distinct from the round oxblood MMP dots so
-   the tracer never gets read as data. uPlot sizes them inline via
-   cursor.points.size; we strip the inherited circle styling. */
-.curve-chart .u-cursor-pt {
-  border: 0 !important;
-  border-radius: 0 !important;
-  background: var(--ink) !important;
-  box-shadow: none !important;
-  transition: transform 80ms ease-out;
+/* The cursor x-line is a tick rising from the x-axis baseline rather
+   than a full-height crosshair. Reads as a typographic register
+   mark — just enough to indicate which duration is hovered, without
+   slicing the chart in half. uPlot positions .u-cursor-x with
+   top:0;bottom:0; we override to bottom-anchor it and clip to ~28%
+   of the plot height. */
+.curve-chart .u-cursor-x {
+  top: auto !important;
+  bottom: 0 !important;
+  height: 28% !important;
+  border-color: var(--ink) !important;
+  opacity: 0.55;
 }
+/* Cursor point markers stay off — see cursor.points.show:false. */
+.curve-chart .u-cursor-pt { display: none !important; }
 
 /* OVERRIDE PANEL */
 

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -163,13 +163,13 @@ export function renderCurveChart(container, { mmp, fit }) {
     ],
     cursor: {
       drag: { x: false, y: false },
-      // Suppress the full-length crosshair lines — they read too busy
-      // against the editorial chart style. Per-series cursor markers
-      // stay enabled (uPlot default), so hovering traces the curve
-      // and highlights the snapped MMP point at the cursor's x.
-      x: false,
+      // Vertical x-cursor enabled, but visually trimmed via CSS to a
+      // short tick rising from the x-axis (see .u-cursor-x styling).
+      // Horizontal cursor + per-series point markers stay off so the
+      // chart reads cleanly while still indicating the hovered duration.
+      x: true,
       y: false,
-      points: { size: 6 },
+      points: { show: false },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Disable per-series cursor markers entirely.
- Re-enable uPlot's vertical cursor line, then bottom-anchor it via CSS and clip to the lower 28% of the plot. Reads as a typographic register tick that points at the hovered duration without slicing the chart.
- Color: ink at 55% opacity. Quiet enough to read editorial, present enough to track the cursor.

## Test plan
- [ ] Hover the chart — short ink tick rises from the x-axis baseline at cursor x; no horizontal hairline, no per-series markers.
- [ ] Legend still updates with live watts/duration.