### PR TITLE
Trace the fit line with a single ink dot on hover

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,21 +745,15 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* The cursor x-line is a tick rising from the x-axis baseline rather
-   than a full-height crosshair. Reads as a typographic register
-   mark — just enough to indicate which duration is hovered, without
-   slicing the chart in half. uPlot positions .u-cursor-x with
-   top:0;bottom:0; we override to bottom-anchor it and clip to ~28%
-   of the plot height. */
-.curve-chart .u-cursor-x {
-  top: auto !important;
-  bottom: 0 !important;
-  height: 28% !important;
-  border-color: var(--ink) !important;
-  opacity: 0.55;
+/* Cursor tracer: a single small ink dot that follows the fit line.
+   Visibility is gated per-series in JS (see cursor.points.show), so
+   we only need to ensure the marker reads as a clean dot, not a
+   ringed ball. */
+.curve-chart .u-cursor-pt {
+  border: 0 !important;
+  box-shadow: none !important;
+  transition: transform 80ms ease-out;
 }
-/* Cursor point markers stay off — see cursor.points.show:false. */
-.curve-chart .u-cursor-pt { display: none !important; }
 
 /* OVERRIDE PANEL */
 

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -163,13 +163,29 @@ export function renderCurveChart(container, { mmp, fit }) {
     ],
     cursor: {
       drag: { x: false, y: false },
-      // Vertical x-cursor enabled, but visually trimmed via CSS to a
-      // short tick rising from the x-axis (see .u-cursor-x styling).
-      // Horizontal cursor + per-series point markers stay off so the
-      // chart reads cleanly while still indicating the hovered duration.
-      x: true,
+      x: false,
       y: false,
-      points: { show: false },
+      // One tracer dot that follows the fitted curve as the cursor
+      // moves. We enable cursor.points only on the line series (2 =
+      // fit, 3 = extrapolation) and only when that series has a
+      // non-null value at the snapped x. The observed-MMP series (1)
+      // gets no separate marker — when the cursor is at a recorded
+      // duration, the line tracer naturally lands on top of the
+      // existing oxblood dot, giving the "lock onto a point" feel
+      // without doubling up markers.
+      points: {
+        show: (u, sidx) => {
+          if (sidx !== 2 && sidx !== 3) return false;
+          const val = u.data[sidx]?.[u.cursor.idx];
+          return val != null;
+        },
+        size: 5,
+        fill: () => {
+          const styles = getComputedStyle(document.body);
+          return styles.getPropertyValue('--ink').trim() || '#1a1612';
+        },
+        stroke: () => 'transparent',
+      },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- Replace the bottom-axis tick with a single ink dot that follows the fit line as the cursor moves. Gate cursor.points.show per-series so only the active line series (2 = fit, 3 = extrapolation) draws a marker, and only when that series has a value at the snapped x.
- The observed-MMP series doesn't get its own marker — when the cursor lands at a recorded duration, the line tracer sits on top of the existing oxblood data dot, giving the 'locked onto a point' feel without doubling markers.
- Marker color drawn from the --ink CSS variable; 5px filled circle, no border, 80ms transform transition.

## Test plan
- [ ] Hover the chart — single ink dot traces the curve smoothly through the fit window and into the dashed extrapolation tail.
- [ ] No bottom-axis tick line.
- [ ] When cursor passes over an observed MMP duration, the tracer sits at that dot's location.