### PR TITLE
Fix chart crash from cursor.points.show reading u.data at init

### DIFF
--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -173,12 +173,16 @@ export function renderCurveChart(container, { mmp, fit }) {
       // duration, the line tracer naturally lands on top of the
       // existing oxblood dot, giving the "lock onto a point" feel
       // without doubling up markers.
+      // uPlot calls cursor.points.show per series at init (before
+      // u.data exists) and again on each cursor move. Returning a
+      // boolean here governs whether the DOM marker exists at all,
+      // not its per-frame visibility — so we enable it for the line
+      // series and let uPlot suppress drawing when the data value at
+      // the snapped x is null. (Series 2 = fit, 3 = extrapolation;
+      // null elsewhere, so the marker simply doesn't render outside
+      // each segment's domain.)
       points: {
-        show: (u, sidx) => {
-          if (sidx !== 2 && sidx !== 3) return false;
-          const val = u.data[sidx]?.[u.cursor.idx];
-          return val != null;
-        },
+        show: (_u, sidx) => sidx === 2 || sidx === 3,
         size: 5,
         fill: () => {
           const styles = getComputedStyle(document.body);


### PR DESCRIPTION
## Summary
- The previous \`cursor.points.show\` callback dereferenced \`u.data[sidx]\` to gate per-x visibility, but uPlot calls \`show\` during chart construction before \`u.data\` is populated — crashing with 'Cannot read properties of undefined (reading 2)'.
- Reduce the callback to a static per-series boolean. uPlot already suppresses cursor-marker rendering on null data, so the line tracer naturally disappears outside each segment's domain (fit: 3–20 min; extrapolation: 20 min+).

## Test plan
- [ ] Chart renders again on first load.
- [ ] Tracer dot follows the fit line and the dashed extrapolation tail; no doubled markers at the 20-min handoff.