### PR TITLE
Drive chart cursor tracer fill from CSS

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,11 +745,13 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* Cursor tracer: a single small ink dot that follows the fit line.
-   Visibility is gated per-series in JS (see cursor.points.show), so
-   we only need to ensure the marker reads as a clean dot, not a
-   ringed ball. */
+/* Cursor tracer: a small filled ink dot that follows the fit line.
+   uPlot draws cursor markers as bordered, transparent-background
+   divs by default; we paint over both with explicit ink fill and
+   no border so the marker reads as a clean dot rather than a ring.
+   Visibility is gated per-series in JS (see cursor.points.show). */
 .curve-chart .u-cursor-pt {
+  background: var(--ink) !important;
   border: 0 !important;
   box-shadow: none !important;
   transition: transform 80ms ease-out;

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -173,22 +173,13 @@ export function renderCurveChart(container, { mmp, fit }) {
       // duration, the line tracer naturally lands on top of the
       // existing oxblood dot, giving the "lock onto a point" feel
       // without doubling up markers.
-      // uPlot calls cursor.points.show per series at init (before
-      // u.data exists) and again on each cursor move. Returning a
-      // boolean here governs whether the DOM marker exists at all,
-      // not its per-frame visibility — so we enable it for the line
-      // series and let uPlot suppress drawing when the data value at
-      // the snapped x is null. (Series 2 = fit, 3 = extrapolation;
-      // null elsewhere, so the marker simply doesn't render outside
-      // each segment's domain.)
+      // Cursor markers only on the line series (2 = fit, 3 =
+      // extrapolation). Visual styling lives in CSS — uPlot's
+      // fill/stroke callbacks weren't applying reliably, and a
+      // static CSS rule is simpler. Marker auto-hides on null data.
       points: {
         show: (_u, sidx) => sidx === 2 || sidx === 3,
-        size: 5,
-        fill: () => {
-          const styles = getComputedStyle(document.body);
-          return styles.getPropertyValue('--ink').trim() || '#1a1612';
-        },
-        stroke: () => 'transparent',
+        size: 6,
       },
     },
     legend: {


### PR DESCRIPTION
## Summary
- The fill/stroke callbacks on \`cursor.points\` weren't applying reliably, leaving the marker bordered-but-empty (effectively invisible). Move styling to CSS — solid ink background, no border, 6px — so the tracer renders consistently.
- JS keeps the per-series show gate (line series only); marker auto-hides on null data.

## Test plan
- [ ] Hover the chart — small filled ink dot follows the fit line and the dashed extrapolation tail.
- [ ] Marker disappears outside each segment's domain (no stray dot at the y-axis edge).