### PR TITLE
Restore default cursor.points and force CSS dimensions

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -745,12 +745,16 @@ body[data-app-state="manual"] #manual-mode {
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
-/* Cursor tracer: a small filled ink dot that follows the fit line.
-   uPlot draws cursor markers as bordered, transparent-background
-   divs by default; we paint over both with explicit ink fill and
-   no border so the marker reads as a clean dot rather than a ring.
-   Visibility is gated per-series in JS (see cursor.points.show). */
+/* Cursor tracer dots — one per series at the snapped x. Rendered
+   only when the series has a non-null value at that x, so the line
+   markers trace the fit + extrapolation segments and the observed
+   marker only fires at recorded durations. Force a solid ink fill
+   with explicit dimensions so neither uPlot's defaults nor a
+   missing fill option leave the marker invisible. */
 .curve-chart .u-cursor-pt {
+  width: 7px !important;
+  height: 7px !important;
+  border-radius: 50% !important;
   background: var(--ink) !important;
   border: 0 !important;
   box-shadow: none !important;

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -173,14 +173,13 @@ export function renderCurveChart(container, { mmp, fit }) {
       // duration, the line tracer naturally lands on top of the
       // existing oxblood dot, giving the "lock onto a point" feel
       // without doubling up markers.
-      // Cursor markers only on the line series (2 = fit, 3 =
-      // extrapolation). Visual styling lives in CSS — uPlot's
-      // fill/stroke callbacks weren't applying reliably, and a
-      // static CSS rule is simpler. Marker auto-hides on null data.
-      points: {
-        show: (_u, sidx) => sidx === 2 || sidx === 3,
-        size: 6,
-      },
+      // Cursor markers on every series; uPlot suppresses rendering
+      // when the underlying data value is null, so the line tracer
+      // only shows along the fit and extrapolation segments and the
+      // observed-MMP marker only shows at recorded durations. All
+      // visual styling lives in CSS (.u-cursor-pt) — uPlot's
+      // fill/stroke options weren't applying reliably here.
+      points: { size: 7 },
     },
     legend: {
       show: true,


### PR DESCRIPTION
## Summary
- The custom \`cursor.points.show\` per-series gate may have been suppressing every marker. Drop the gate; let uPlot suppress markers on null data automatically.
- Pin \`width\`, \`height\`, \`background\`, and \`border-radius\` in CSS with \`!important\` so the dot is guaranteed to render regardless of uPlot's internal style application order.

## Test plan
- [ ] Hover the chart — small ink dots trace the fit line and the dashed extrapolation tail.
- [ ] If markers also appear on the observed series, expected behavior — they fire only at recorded durations.