### PR TITLE
Implement Strava OAuth authorize + callback in the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Open issues are grouped by phase: see [milestones](https://github.com/iammike/po
 
 ## Strava setup (for Phase 4)
 
-1. Register an app at https://www.strava.com/settings/api
-2. Authorization callback domain: `power.iammike.org`
-3. Copy `client_id` into `wrangler.toml` (public), `client_secret` via `wrangler secret put`
+1. Register an app at https://www.strava.com/settings/api.
+2. Authorization callback domain: the worker host (e.g. `api.power.iammike.org` or `power-predict-api.<account>.workers.dev`). The frontend domain is not the callback — the worker is.
+3. Copy `client_id` into `wrangler.toml` under `[vars]`, then push the secret:
+   ```bash
+   wrangler secret put STRAVA_CLIENT_SECRET
+   ```
+4. The OAuth flow is rooted at `/auth/strava/authorize` on the worker host. On success the worker redirects back to `FRONTEND_URL` with `#session=...&athlete_id=...` in the URL hash.

--- a/tests/strava-oauth.test.js
+++ b/tests/strava-oauth.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  refreshTokens,
+  generateRandomToken,
+} from '../worker/strava-oauth.js';
+
+describe('buildAuthorizeUrl', () => {
+  it('encodes all required params', () => {
+    const url = new URL(buildAuthorizeUrl({
+      clientId: '12345',
+      redirectUri: 'https://api.example.com/auth/strava/callback',
+      state: 'abc',
+      scope: 'read,activity:read_all',
+    }));
+    expect(url.origin + url.pathname).toBe('https://www.strava.com/oauth/authorize');
+    expect(url.searchParams.get('client_id')).toBe('12345');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://api.example.com/auth/strava/callback');
+    expect(url.searchParams.get('state')).toBe('abc');
+    expect(url.searchParams.get('scope')).toBe('read,activity:read_all');
+    expect(url.searchParams.get('response_type')).toBe('code');
+  });
+});
+
+describe('exchangeCodeForTokens', () => {
+  it('POSTs the code to Strava and returns the parsed JSON', async () => {
+    let capturedUrl, capturedInit;
+    const fakeFetch = async (u, init) => {
+      capturedUrl = u;
+      capturedInit = init;
+      return new Response(JSON.stringify({
+        access_token: 'a', refresh_token: 'r', expires_at: 9999, athlete: { id: 7 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+    const out = await exchangeCodeForTokens({
+      clientId: 'cid', clientSecret: 'sec', code: 'CODE',
+    }, fakeFetch);
+    expect(capturedUrl).toBe('https://www.strava.com/oauth/token');
+    expect(capturedInit.method).toBe('POST');
+    const params = new URLSearchParams(capturedInit.body);
+    expect(params.get('grant_type')).toBe('authorization_code');
+    expect(params.get('code')).toBe('CODE');
+    expect(params.get('client_id')).toBe('cid');
+    expect(params.get('client_secret')).toBe('sec');
+    expect(out.access_token).toBe('a');
+    expect(out.athlete.id).toBe(7);
+  });
+
+  it('throws when credentials are missing', async () => {
+    await expect(exchangeCodeForTokens({ code: 'x' }, async () => new Response('')))
+      .rejects.toThrow(/credentials missing/);
+  });
+
+  it('throws on non-2xx', async () => {
+    const fakeFetch = async () => new Response('bad request', { status: 400 });
+    await expect(exchangeCodeForTokens({
+      clientId: 'c', clientSecret: 's', code: 'x',
+    }, fakeFetch)).rejects.toThrow(/token exchange failed: 400/);
+  });
+});
+
+describe('refreshTokens', () => {
+  it('uses grant_type=refresh_token', async () => {
+    let captured;
+    const fakeFetch = async (_u, init) => {
+      captured = init;
+      return new Response(JSON.stringify({ access_token: 'new', refresh_token: 'next', expires_at: 1 }), { status: 200 });
+    };
+    const out = await refreshTokens({
+      clientId: 'c', clientSecret: 's', refreshToken: 'r',
+    }, fakeFetch);
+    const params = new URLSearchParams(captured.body);
+    expect(params.get('grant_type')).toBe('refresh_token');
+    expect(params.get('refresh_token')).toBe('r');
+    expect(out.access_token).toBe('new');
+  });
+});
+
+describe('generateRandomToken', () => {
+  it('returns a base64url string of expected length', () => {
+    const t = generateRandomToken(32);
+    // 32 bytes → 43 base64url chars (no padding)
+    expect(t).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(t.length).toBe(43);
+  });
+  it('produces distinct tokens across calls', () => {
+    const a = generateRandomToken();
+    const b = generateRandomToken();
+    expect(a).not.toBe(b);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -2,6 +2,12 @@
 // Handles Strava OAuth, webhook ingest, archive-upload coordination,
 // and rate-limit-budgeted Strava API proxying.
 
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  generateRandomToken,
+} from './worker/strava-oauth.js';
+
 const ALLOWED_ORIGINS = [
   'https://power.iammike.org',
   'https://iammike.github.io',
@@ -109,14 +115,103 @@ async function processWebhookEvent(_event, _env) {
   // TODO Phase 4: fetch single activity stream, compute MMP, upsert to D1.
 }
 
-function handleAuthorize(_request, _env, _url) {
-  // TODO Phase 4: build Strava authorize URL with state, redirect.
-  return new Response('not implemented', { status: 501 });
+async function handleAuthorize(request, env, url) {
+  const clientId = env.STRAVA_CLIENT_ID;
+  if (!clientId) return new Response('strava client not configured', { status: 503 });
+  // The frontend may pass an explicit return path (e.g. '/?after-auth=sync'),
+  // so the redirect lands the user back where they started.
+  const returnTo = url.searchParams.get('return_to') || '/';
+  const state = generateRandomToken();
+  // KV holds the state token + intended return path for ten minutes.
+  // Strava round-trips the state param back via the callback; we
+  // verify there before exchanging the auth code.
+  await env.RATE_LIMIT.put(`oauth-state:${state}`, returnTo, { expirationTtl: 600 });
+  const callbackUrl = `${url.origin}/auth/strava/callback`;
+  const authorize = buildAuthorizeUrl({
+    clientId,
+    redirectUri: callbackUrl,
+    state,
+    scope: 'read,activity:read_all',
+  });
+  return Response.redirect(authorize, 302);
 }
 
-function handleCallback(_request, _env, _origin) {
-  // TODO Phase 4: exchange code for tokens via Strava /oauth/token, persist user.
-  return new Response('not implemented', { status: 501 });
+async function handleCallback(request, env, origin) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const err = url.searchParams.get('error');
+  if (err) return redirectToFrontend(env, { error: err });
+  if (!code || !state) return new Response('missing code or state', { status: 400 });
+
+  // State must round-trip exactly; consume it (delete) so a leaked
+  // state can't be re-used by an attacker.
+  const storedReturn = await env.RATE_LIMIT.get(`oauth-state:${state}`);
+  if (storedReturn === null) return new Response('invalid or expired state', { status: 400 });
+  await env.RATE_LIMIT.delete(`oauth-state:${state}`);
+
+  let tokens;
+  try {
+    tokens = await exchangeCodeForTokens({
+      clientId: env.STRAVA_CLIENT_ID,
+      clientSecret: env.STRAVA_CLIENT_SECRET,
+      code,
+    });
+  } catch (e) {
+    return redirectToFrontend(env, { error: 'token_exchange_failed', return_to: storedReturn });
+  }
+
+  const athleteId = tokens.athlete?.id;
+  if (!athleteId) return new Response('strava response missing athlete id', { status: 502 });
+
+  // Upsert the user row. We persist the access + refresh tokens so a
+  // later /sync run can talk to Strava on the user's behalf.
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO users (id, display_name, access_token, refresh_token, token_expires_at, created_at, last_sync_at)
+     VALUES (?, ?, ?, ?, ?, ?, NULL)
+     ON CONFLICT(id) DO UPDATE SET
+       display_name = excluded.display_name,
+       access_token = excluded.access_token,
+       refresh_token = excluded.refresh_token,
+       token_expires_at = excluded.token_expires_at`
+  )
+    .bind(
+      athleteId,
+      `${tokens.athlete?.firstname ?? ''} ${tokens.athlete?.lastname ?? ''}`.trim() || null,
+      tokens.access_token,
+      tokens.refresh_token,
+      tokens.expires_at,
+      now,
+    )
+    .run();
+
+  // Issue our own opaque session token. Front-end stores it and uses
+  // it on subsequent /sync requests so we don't expose Strava's tokens
+  // to the browser. Thirty-day TTL — the user re-auths if they go
+  // longer than a month between visits.
+  const session = generateRandomToken();
+  await env.RATE_LIMIT.put(`session:${session}`, String(athleteId), {
+    expirationTtl: 60 * 60 * 24 * 30,
+  });
+
+  return redirectToFrontend(env, {
+    session,
+    athlete_id: String(athleteId),
+    return_to: storedReturn,
+  });
+}
+
+// Redirect back to the frontend with auth result encoded in the URL
+// hash (so it doesn't hit access logs). Frontend reads the hash on
+// load and stores the session token in IndexedDB.
+function redirectToFrontend(env, params) {
+  const base = env.FRONTEND_URL || 'https://power.iammike.org';
+  const returnTo = params.return_to || '/';
+  const cleanParams = { ...params };
+  delete cleanParams.return_to;
+  const hash = new URLSearchParams(cleanParams).toString();
+  return Response.redirect(`${base}${returnTo}#${hash}`, 302);
 }
 
 function handleArchiveUpload(_request, _env, _origin) {

--- a/worker/strava-oauth.js
+++ b/worker/strava-oauth.js
@@ -1,0 +1,89 @@
+// Strava OAuth helpers, kept separate from the Worker entry so they
+// can be unit-tested without booting Miniflare. The handlers in
+// worker.js wire these into KV / D1 state and the request lifecycle.
+
+const STRAVA_AUTHORIZE = 'https://www.strava.com/oauth/authorize';
+const STRAVA_TOKEN = 'https://www.strava.com/oauth/token';
+
+// Build the redirect URL we send the user to when they click
+// "Connect Strava." Strava round-trips state back to our callback
+// so we can defeat CSRF and resume a frontend return path.
+export function buildAuthorizeUrl({ clientId, redirectUri, state, scope }) {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    approval_prompt: 'auto',
+    scope,
+    state,
+  });
+  return `${STRAVA_AUTHORIZE}?${params.toString()}`;
+}
+
+// Exchange the short-lived auth code for a long-lived refresh token
+// and a six-hour access token. Strava's response also includes the
+// athlete profile, which we use to seed the users row.
+export async function exchangeCodeForTokens(
+  { clientId, clientSecret, code },
+  fetchImpl = fetch,
+) {
+  if (!clientId || !clientSecret) {
+    throw new Error('strava credentials missing');
+  }
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    grant_type: 'authorization_code',
+  });
+  const res = await fetchImpl(STRAVA_TOKEN, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`strava token exchange failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+// Refresh a near-expiry access token. Strava treats the refresh
+// endpoint identically to the initial exchange, just with a different
+// grant_type. Returns the same shape minus the athlete profile.
+export async function refreshTokens(
+  { clientId, clientSecret, refreshToken },
+  fetchImpl = fetch,
+) {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+  const res = await fetchImpl(STRAVA_TOKEN, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`strava token refresh failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+// 256-bit random token, base64url-encoded. Used for OAuth state and
+// for our opaque session tokens. Falls back gracefully if the
+// runtime hasn't exposed crypto.getRandomValues (very old environments).
+export function generateRandomToken(bytes = 32) {
+  const buf = new Uint8Array(bytes);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(buf);
+  } else {
+    for (let i = 0; i < bytes; i++) buf[i] = Math.floor(Math.random() * 256);
+  }
+  let bin = '';
+  for (let i = 0; i < buf.length; i++) bin += String.fromCharCode(buf[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,7 @@ compatibility_date = "2024-12-01"
 [vars]
 STRAVA_CLIENT_ID = ""           # filled in once Strava app is registered
 ALLOWED_ORIGIN = "https://power.iammike.org"
+FRONTEND_URL    = "https://power.iammike.org"
 
 # D1 database for users, activities, MMP records, CP fits
 [[d1_databases]]


### PR DESCRIPTION
## Summary

Foundational OAuth handlers for Phase 4 — towards #20 and a prerequisite for #39 (recent-window API backfill).

- \`/auth/strava/authorize\` mints a CSRF state token (KV, 10 min TTL) and redirects to Strava's authorize endpoint.
- \`/auth/strava/callback\` validates and consumes the state, exchanges the auth code for tokens, upserts the athlete row, mints an opaque session token (KV, 30-day TTL), and 302s the browser back to \`FRONTEND_URL\` with \`#session=...&athlete_id=...\` in the URL hash so it never hits access logs.
- Pure-function helpers in \`worker/strava-oauth.js\` (URL builder, code/refresh exchange, base64url random token) unit-test without booting Miniflare. 7 new tests, 108 passing total.

This PR is code-only — no resources are deployed. The user still needs to run the wrangler resource setup (D1, KV, R2) and \`wrangler secret put STRAVA_CLIENT_SECRET\` to make it functional. README updated with the steps.

## Test plan
- [ ] Tests pass locally (\`npm test\`).
- [ ] Code review: state lifecycle, token-storage shape, upsert SQL.
- [ ] After deploy + Strava app registration: hit \`/auth/strava/authorize\` and confirm the round-trip lands you at the frontend with a session in the hash.