### PR TITLE
Implement /sync/recent + /activities/recent end-to-end

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
 import {
   parseAuthHash, clearAuthHash, loadSession, saveSession, clearSession, authorizeUrl,
+  syncRecent, fetchSyncedActivities,
 } from './strava-session.js';
 
 const dropZone = document.getElementById('archive-drop');
@@ -128,12 +129,48 @@ document.getElementById('strava-disconnect')?.addEventListener('click', async ()
 
 document.getElementById('strava-sync-btn')?.addEventListener('click', triggerStravaSync);
 
-// Single source of truth for the sync action. The /sync/recent
-// endpoint isn't wired yet, so all three entry points (onboarding
-// card + data results-foot + manual results-foot) currently surface
-// the same placeholder.
-function triggerStravaSync() {
-  alert('Sync endpoint coming in the next PR. The Connect step is live.');
+// Single source of truth for the sync action. Drives the
+// /sync/recent loop, then pulls the resulting MMP records back out
+// of D1 and merges them into the local IDB cache so the rest of the
+// app renders the same way as archive uploads.
+async function triggerStravaSync() {
+  const session = await loadSession();
+  if (!session) return;
+  setProgressPhase('Reading', { bytesRead: 0, totalBytes: 1 });
+  setProgress('Pulling activity list from Strava…');
+  try {
+    await syncRecent({
+      session: session.session,
+      days: 180,
+      onProgress: ({ processed, totalWithPower, remaining }) => {
+        const total = Number.isFinite(totalWithPower) ? totalWithPower : '?';
+        setProgress(`Syncing from Strava… ${processed} / ${total} activities (${remaining} remaining).`);
+      },
+    });
+    setProgress('Loading synced data…');
+    const remoteActivities = await fetchSyncedActivities(session.session);
+    if (remoteActivities.length === 0) {
+      setProgress('No power-equipped rides in the synced window.');
+      return;
+    }
+    // Merge into IDB by startTime (the primary key). New rides land,
+    // existing ones get refreshed with whatever the worker computed.
+    const fresh = [];
+    for (const a of remoteActivities) {
+      if (!(await hasActivity(a.startTime))) fresh.push(a);
+    }
+    if (fresh.length) await saveActivities(fresh);
+    const all = await loadActivities();
+    if (progressEl) {
+      progressEl.textContent = '';
+      progressEl.hidden = true;
+      progressEl.innerHTML = '';
+    }
+    renderCurves(all);
+  } catch (err) {
+    console.error('strava sync failed', err);
+    setProgress(`Strava sync failed: ${err.message || err}`);
+  }
 }
 
 async function handleArchive(file) {

--- a/src/strava-session.js
+++ b/src/strava-session.js
@@ -59,3 +59,45 @@ export function authorizeUrl(returnTo = '/') {
   const params = new URLSearchParams({ return_to: returnTo });
   return `${API_BASE}/auth/strava/authorize?${params.toString()}`;
 }
+
+// Drive the multi-call sync loop. `onProgress` is invoked after each
+// slice with the cumulative counts; resolves when done. Throws on
+// transport errors so the caller can surface them.
+export async function syncRecent({ session, days = 180, onProgress }) {
+  let cursor = null;
+  let cumulativeProcessed = 0;
+  while (true) {
+    const res = await fetch(`${API_BASE}/sync/recent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session, days, cursor }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`sync failed: ${res.status} ${text}`);
+    }
+    const slice = await res.json();
+    cumulativeProcessed += slice.processed || 0;
+    onProgress?.({
+      processed: cumulativeProcessed,
+      totalWithPower: slice.totalWithPower,
+      remaining: slice.remaining,
+      errors: slice.errors,
+    });
+    if (slice.done) return { processed: cumulativeProcessed, totalWithPower: slice.totalWithPower };
+    cursor = slice.cursor;
+  }
+}
+
+// Pull the synced activities + MMP arrays out of the worker so the
+// frontend can drop them into IDB and render the same way archive
+// uploads do.
+export async function fetchSyncedActivities(session) {
+  const res = await fetch(`${API_BASE}/activities/recent?session=${encodeURIComponent(session)}`);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`activities load failed: ${res.status} ${text}`);
+  }
+  const body = await res.json();
+  return body.activities || [];
+}

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveSession,
+  getValidAccessToken,
+  runSyncSlice,
+} from '../worker/sync.js';
+
+// ---------- D1 stub ----------
+//
+// Mimics the prepare/bind/run/all/first/batch chain wrangler exposes.
+// Routes by the SQL string prefix; tests below pre-seed `state` and
+// inspect it after each call.
+
+function makeDb(state = {}) {
+  state.users ??= new Map();      // id → row
+  state.activities ??= new Map(); // id → row
+  state.mmp ??= [];               // {activity_id, duration_s, power_w}
+  function makeStmt(sql) {
+    let bound = [];
+    return {
+      bind: (...args) => { bound = args; return makeStmt.last = makeStmt.cur = { ...makeStmt.cur, sql, bound, ...api(sql, () => bound) }; },
+    };
+  }
+  function api(sql, getBound) {
+    return {
+      async first() {
+        const b = getBound();
+        if (sql.startsWith('SELECT access_token')) {
+          return state.users.get(b[0]) || null;
+        }
+        return null;
+      },
+      async run() {
+        const b = getBound();
+        if (sql.startsWith('UPDATE users SET access_token')) {
+          const [accessToken, refreshToken, expiresAt, id] = b;
+          const u = state.users.get(id) || {};
+          state.users.set(id, { ...u, access_token: accessToken, refresh_token: refreshToken, token_expires_at: expiresAt });
+        } else if (sql.startsWith('INSERT OR REPLACE INTO activities')) {
+          const [id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, , , , , ingested_at] = b;
+          state.activities.set(id, { id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, ingested_at, has_power: 1 });
+        } else if (sql.startsWith('DELETE FROM mmp_records')) {
+          state.mmp = state.mmp.filter((m) => m.activity_id !== b[0]);
+        } else if (sql.startsWith('UPDATE users SET last_sync_at')) {
+          const u = state.users.get(b[1]) || {};
+          state.users.set(b[1], { ...u, last_sync_at: b[0] });
+        } else if (sql.startsWith('INSERT INTO mmp_records')) {
+          state.mmp.push({ activity_id: b[0], duration_s: b[1], power_w: b[2] });
+        }
+        return { changes: 1 };
+      },
+      async all() {
+        const b = getBound();
+        if (sql.startsWith('SELECT id FROM activities')) {
+          const ids = b.slice(1);
+          const results = [...state.activities.values()]
+            .filter((a) => a.user_id === b[0] && ids.includes(a.id))
+            .map((a) => ({ id: a.id }));
+          return { results };
+        }
+        return { results: [] };
+      },
+    };
+  }
+  return {
+    state,
+    prepare(sql) { return makeStmt(sql); },
+    async batch(stmts) {
+      for (const s of stmts) await s.run();
+      return [];
+    },
+  };
+}
+
+function makeKv(map = new Map()) {
+  return {
+    map,
+    async get(k) { return map.has(k) ? map.get(k) : null; },
+    async put(k, v) { map.set(k, v); },
+    async delete(k) { map.delete(k); },
+  };
+}
+
+describe('resolveSession', () => {
+  it('returns athlete id for a known session token', async () => {
+    const env = { RATE_LIMIT: makeKv(new Map([['session:abc', '7']])) };
+    expect(await resolveSession(env, 'abc')).toBe(7);
+  });
+  it('returns null for missing or unknown tokens', async () => {
+    const env = { RATE_LIMIT: makeKv() };
+    expect(await resolveSession(env, '')).toBeNull();
+    expect(await resolveSession(env, 'nope')).toBeNull();
+  });
+});
+
+describe('getValidAccessToken', () => {
+  it('returns the stored token when not near expiry', async () => {
+    const db = makeDb();
+    db.state.users.set(1, {
+      access_token: 'cur', refresh_token: 'r',
+      token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const env = { DB: db, STRAVA_CLIENT_ID: 'x', STRAVA_CLIENT_SECRET: 'y' };
+    const fakeFetch = async () => { throw new Error('refresh should not be called'); };
+    expect(await getValidAccessToken(env, 1, fakeFetch)).toBe('cur');
+  });
+
+  it('refreshes when within the 60-second buffer and persists the new pair', async () => {
+    const db = makeDb();
+    db.state.users.set(1, {
+      access_token: 'old', refresh_token: 'rt',
+      token_expires_at: Math.floor(Date.now() / 1000) + 30,
+    });
+    const env = { DB: db, STRAVA_CLIENT_ID: 'x', STRAVA_CLIENT_SECRET: 'y' };
+    const fakeFetch = async () => new Response(JSON.stringify({
+      access_token: 'fresh', refresh_token: 'rt2', expires_at: 9999999999,
+    }), { status: 200 });
+    expect(await getValidAccessToken(env, 1, fakeFetch)).toBe('fresh');
+    expect(db.state.users.get(1).access_token).toBe('fresh');
+    expect(db.state.users.get(1).refresh_token).toBe('rt2');
+  });
+});
+
+describe('runSyncSlice', () => {
+  it('lists, filters power-equipped, fetches stream, and writes MMP rows', async () => {
+    const db = makeDb();
+    db.state.users.set(42, {
+      access_token: 'tok', refresh_token: 'r',
+      token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const calls = [];
+    const stream = Array.from({ length: 600 }, () => 220); // 10-min steady 220 W
+    const fakeFetch = async (urlStr) => {
+      calls.push(urlStr);
+      if (urlStr.includes('/athlete/activities')) {
+        // Two rides; only one has device_watts.
+        return new Response(JSON.stringify([
+          { id: 1001, type: 'Ride', device_watts: true, average_watts: 200,
+            start_date: '2026-01-01T00:00:00Z', elapsed_time: 600, distance: 5000 },
+          { id: 1002, type: 'Ride', device_watts: false, average_watts: 200,
+            start_date: '2026-01-02T00:00:00Z', elapsed_time: 600, distance: 5000 },
+        ]), { status: 200 });
+      }
+      if (urlStr.includes('/streams')) {
+        return new Response(JSON.stringify({ watts: { data: stream } }), { status: 200 });
+      }
+      throw new Error(`unexpected url: ${urlStr}`);
+    };
+    const env = {
+      DB: db,
+      RATE_LIMIT: makeKv(),
+      STRAVA_CLIENT_ID: 'cid',
+      STRAVA_CLIENT_SECRET: 'sec',
+    };
+    const out = await runSyncSlice({ env, athleteId: 42, days: 180, fetchImpl: fakeFetch });
+    expect(out.totalSeen).toBe(2);
+    expect(out.totalWithPower).toBe(1);
+    expect(out.processed).toBe(1);
+    expect(out.done).toBe(true);
+    expect(out.errors).toHaveLength(0);
+    // Activity row written:
+    expect(db.state.activities.get(1001)).toBeDefined();
+    // MMP records written for the durations covered by a 600-sample stream:
+    const durations = db.state.mmp.filter((m) => m.activity_id === 1001).map((m) => m.duration_s);
+    expect(durations).toContain(60);
+    expect(durations).toContain(300);
+  });
+
+  it('skips activities already present in D1 to avoid re-ingesting', async () => {
+    const db = makeDb();
+    db.state.users.set(42, {
+      access_token: 'tok', refresh_token: 'r',
+      token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    db.state.activities.set(1001, { id: 1001, user_id: 42, has_power: 1, start_time: 0 });
+    const fakeFetch = async (urlStr) => {
+      if (urlStr.includes('/athlete/activities')) {
+        return new Response(JSON.stringify([
+          { id: 1001, type: 'Ride', device_watts: true, average_watts: 200,
+            start_date: '2026-01-01T00:00:00Z', elapsed_time: 600, distance: 5000 },
+        ]), { status: 200 });
+      }
+      throw new Error('should not fetch streams when already ingested');
+    };
+    const env = { DB: db, RATE_LIMIT: makeKv(), STRAVA_CLIENT_ID: 'c', STRAVA_CLIENT_SECRET: 's' };
+    const out = await runSyncSlice({ env, athleteId: 42, fetchImpl: fakeFetch });
+    expect(out.totalWithPower).toBe(1);
+    expect(out.processed).toBe(0);
+    expect(out.done).toBe(true);
+  });
+});

--- a/worker.js
+++ b/worker.js
@@ -7,6 +7,11 @@ import {
   exchangeCodeForTokens,
   generateRandomToken,
 } from './worker/strava-oauth.js';
+import {
+  resolveSession,
+  runSyncSlice,
+  loadActivities,
+} from './worker/sync.js';
 
 const ALLOWED_ORIGINS = [
   'https://power.iammike.org',
@@ -85,6 +90,16 @@ export default {
     // Persist derived MMP data computed in the browser
     if (url.pathname === '/mmp/ingest') {
       return handleMmpIngest(request, env, origin);
+    }
+
+    // Strava sync — pull activities + streams, compute MMP server-side.
+    if (url.pathname === '/sync/recent') {
+      return handleSyncRecent(request, env, origin);
+    }
+
+    // Read the synced MMP records back out for the frontend.
+    if (url.pathname === '/activities/recent') {
+      return handleActivitiesRecent(request, env, origin);
     }
 
     return json({ error: 'not found' }, { status: 404 }, origin);
@@ -223,4 +238,46 @@ function handleArchiveUpload(_request, _env, _origin) {
 function handleMmpIngest(_request, _env, _origin) {
   // TODO Phase 2: validate auth, upsert MMP arrays + activity meta into D1.
   return new Response('not implemented', { status: 501 });
+}
+
+// POST /sync/recent
+// Body: { session, days?, cursor? }
+// Returns the per-slice progress object from runSyncSlice. The
+// frontend re-calls until done=true, passing back the prior cursor
+// so we don't re-list activities on every slice.
+async function handleSyncRecent(request, env, origin) {
+  if (request.method !== 'POST') {
+    return json({ error: 'method not allowed' }, { status: 405 }, origin);
+  }
+  let body;
+  try { body = await request.json(); } catch { return json({ error: 'bad json' }, { status: 400 }, origin); }
+  const athleteId = await resolveSession(env, body?.session);
+  if (!athleteId) return json({ error: 'unauthenticated' }, { status: 401 }, origin);
+  try {
+    const result = await runSyncSlice({
+      env,
+      athleteId,
+      days: body.days || 180,
+      cursor: body.cursor || null,
+    });
+    return json(result, {}, origin);
+  } catch (err) {
+    return json({ error: err?.message || 'sync failed' }, { status: 500 }, origin);
+  }
+}
+
+// GET /activities/recent?session=...
+// Returns the user's stored activities + per-duration MMP arrays in
+// the shape the frontend's IDB cache expects.
+async function handleActivitiesRecent(request, env, origin) {
+  const url = new URL(request.url);
+  const session = url.searchParams.get('session');
+  const athleteId = await resolveSession(env, session);
+  if (!athleteId) return json({ error: 'unauthenticated' }, { status: 401 }, origin);
+  try {
+    const activities = await loadActivities(env, athleteId);
+    return json({ activities }, {}, origin);
+  } catch (err) {
+    return json({ error: err?.message || 'load failed' }, { status: 500 }, origin);
+  }
 }

--- a/worker/strava-api.js
+++ b/worker/strava-api.js
@@ -1,0 +1,60 @@
+// Strava API client — listing activities and fetching power streams.
+// Pure functions parameterized by an access token + fetch impl so the
+// callers in worker.js can wire env-derived state and the unit tests
+// can swap in a stub fetch.
+
+const STRAVA_API = 'https://www.strava.com/api/v3';
+
+// List activities the athlete recorded after `afterEpoch` (unix s).
+// Strava paginates per_page (max 200). We page until an empty page or
+// the requested cap is reached.
+export async function listActivitiesAfter(
+  { accessToken, afterEpoch, perPage = 200, maxPages = 5 },
+  fetchImpl = fetch,
+) {
+  const out = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const url = `${STRAVA_API}/athlete/activities?after=${afterEpoch}&per_page=${perPage}&page=${page}`;
+    const res = await fetchImpl(url, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`strava list activities ${res.status}: ${text}`);
+    }
+    const batch = await res.json();
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    out.push(...batch);
+    if (batch.length < perPage) break;
+  }
+  return out;
+}
+
+// Pull the watts stream for an activity. Returns the dense Number[]
+// at the activity's recording resolution (typically 1 Hz). Returns
+// null when the activity has no power recording.
+export async function fetchPowerStream(
+  { accessToken, activityId },
+  fetchImpl = fetch,
+) {
+  const url = `${STRAVA_API}/activities/${activityId}/streams?keys=watts&key_by_type=true`;
+  const res = await fetchImpl(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`strava streams ${activityId} ${res.status}: ${text}`);
+  }
+  const body = await res.json();
+  const watts = body?.watts?.data;
+  if (!Array.isArray(watts) || watts.length === 0) return null;
+  return watts;
+}
+
+// Quick power-equipped check from an activity summary. Strava sets
+// `device_watts: true` for power-meter rides; `average_watts` exists
+// for both real and estimated power, so we lean on device_watts.
+export function hasRealPower(activity) {
+  return Boolean(activity && activity.device_watts === true);
+}

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -1,0 +1,196 @@
+// Strava sync orchestration. Pulls activities + streams, computes
+// MMP, writes to D1. Pure-ish: takes env + fetch + a session lookup
+// so it can be tested with stubbed dependencies.
+
+import { extractMmp } from '../src/mmp.js';
+import { normalizedPower } from '../src/aggregate.js';
+import { listActivitiesAfter, fetchPowerStream, hasRealPower } from './strava-api.js';
+import { refreshTokens } from './strava-oauth.js';
+
+// Each /sync/recent call processes at most this many power-equipped
+// rides before returning. Caps wall time well below the worker's
+// 30 s ceiling and keeps progress feedback responsive.
+const ACTIVITIES_PER_CALL = 20;
+
+// Resolve a session token to an athlete id, or return null when the
+// session is missing / expired.
+export async function resolveSession(env, sessionToken) {
+  if (!sessionToken) return null;
+  const athleteId = await env.RATE_LIMIT.get(`session:${sessionToken}`);
+  return athleteId ? Number(athleteId) : null;
+}
+
+// Fetch a usable access token for the athlete, refreshing through
+// Strava's /oauth/token endpoint when the stored one is within 60 s
+// of expiry. The refreshed pair is persisted back to D1.
+export async function getValidAccessToken(env, athleteId, fetchImpl = fetch) {
+  const row = await env.DB
+    .prepare('SELECT access_token, refresh_token, token_expires_at FROM users WHERE id = ?')
+    .bind(athleteId)
+    .first();
+  if (!row) throw new Error(`athlete ${athleteId} not found`);
+  const now = Math.floor(Date.now() / 1000);
+  if (row.token_expires_at > now + 60) return row.access_token;
+  const fresh = await refreshTokens({
+    clientId: env.STRAVA_CLIENT_ID,
+    clientSecret: env.STRAVA_CLIENT_SECRET,
+    refreshToken: row.refresh_token,
+  }, fetchImpl);
+  await env.DB
+    .prepare('UPDATE users SET access_token=?, refresh_token=?, token_expires_at=? WHERE id=?')
+    .bind(fresh.access_token, fresh.refresh_token, fresh.expires_at, athleteId)
+    .run();
+  return fresh.access_token;
+}
+
+// Run one slice of the sync. The caller polls until done=true.
+//
+// Approach:
+//   1. List activities in the requested window (cached on the cursor
+//      so we only hit /athlete/activities once per multi-call sync).
+//   2. Filter to power-equipped rides we haven't ingested yet.
+//   3. Process up to ACTIVITIES_PER_CALL: fetch stream, compute MMP
+//      + summary stats, upsert activity + mmp_records.
+//   4. Return the cursor + counts; the client re-calls until done.
+export async function runSyncSlice({
+  env,
+  athleteId,
+  days = 180,
+  cursor = null,
+  fetchImpl = fetch,
+}) {
+  const accessToken = await getValidAccessToken(env, athleteId, fetchImpl);
+
+  // Resume the activity-id worklist if the client passed one;
+  // otherwise list fresh. The worklist is the set of activity ids
+  // we still need to ingest.
+  let pending;
+  let totalSeen;
+  let totalWithPower;
+  if (cursor && Array.isArray(cursor.pending)) {
+    pending = cursor.pending;
+    totalSeen = cursor.totalSeen;
+    totalWithPower = cursor.totalWithPower;
+  } else {
+    const after = Math.floor(Date.now() / 1000) - days * 86400;
+    const all = await listActivitiesAfter({ accessToken, afterEpoch: after }, fetchImpl);
+    totalSeen = all.length;
+    const powered = all.filter(hasRealPower);
+    totalWithPower = powered.length;
+    // Skip the ones we've already ingested. Strava activity ids are
+    // stable, so we trust the rows already in D1.
+    const existing = await env.DB
+      .prepare(`SELECT id FROM activities WHERE user_id = ? AND id IN (${powered.map(() => '?').join(',') || 'NULL'})`)
+      .bind(athleteId, ...powered.map((a) => a.id))
+      .all();
+    const existingIds = new Set((existing.results || []).map((r) => r.id));
+    pending = powered
+      .filter((a) => !existingIds.has(a.id))
+      .map((a) => ({
+        id: a.id,
+        startTime: Math.floor(new Date(a.start_date).getTime() / 1000),
+        durationS: a.elapsed_time,
+        distanceM: a.distance,
+        avgPower: a.average_watts ?? null,
+      }));
+  }
+
+  const slice = pending.slice(0, ACTIVITIES_PER_CALL);
+  const remaining = pending.slice(slice.length);
+  const errors = [];
+  let processed = 0;
+
+  for (const a of slice) {
+    try {
+      const stream = await fetchPowerStream({ accessToken, activityId: a.id }, fetchImpl);
+      if (!stream || stream.length === 0) continue;
+      const mmp = extractMmp(stream);
+      const npRaw = normalizedPower(stream);
+      const npW = Number.isFinite(npRaw) && npRaw > 0 ? npRaw : a.avgPower;
+      // Insert activity row; the unique primary key on Strava ids
+      // makes this idempotent across retries.
+      await env.DB
+        .prepare(
+          `INSERT OR REPLACE INTO activities
+            (id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power,
+             intensity_factor, tss, has_power, source, ingested_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, 1, 'api', ?)`
+        )
+        .bind(
+          a.id, athleteId, a.startTime, a.durationS, a.distanceM,
+          a.avgPower, npW, Math.floor(Date.now() / 1000),
+        )
+        .run();
+      // Bulk insert the per-duration MMP records. We delete + insert
+      // so a re-sync of the same activity refreshes the values
+      // rather than leaving a partial pre-anomaly-filter set.
+      await env.DB.prepare('DELETE FROM mmp_records WHERE activity_id = ?').bind(a.id).run();
+      const inserts = [];
+      for (const [d, p] of Object.entries(mmp)) {
+        if (!Number.isFinite(p)) continue;
+        inserts.push(env.DB
+          .prepare('INSERT INTO mmp_records (activity_id, duration_s, power_w, is_true_mmp) VALUES (?, ?, ?, 1)')
+          .bind(a.id, Number(d), p));
+      }
+      if (inserts.length) await env.DB.batch(inserts);
+      processed++;
+    } catch (err) {
+      errors.push({ id: a.id, message: err?.message || String(err) });
+    }
+  }
+
+  // Bump last_sync_at on every slice so the user sees progress even
+  // mid-sync; the final timestamp lands on the last call.
+  await env.DB
+    .prepare('UPDATE users SET last_sync_at = ? WHERE id = ?')
+    .bind(Math.floor(Date.now() / 1000), athleteId)
+    .run();
+
+  const done = remaining.length === 0;
+  return {
+    done,
+    processed,
+    totalSeen,
+    totalWithPower,
+    remaining: remaining.length,
+    errors,
+    cursor: done ? null : { pending: remaining, totalSeen, totalWithPower },
+  };
+}
+
+// Read the user's stored MMP records back out as an array of
+// `{ id, startTime, durationS, distanceM, avgPower, npW, mmp }` —
+// the same shape the frontend feeds into its renderCurves pipeline.
+export async function loadActivities(env, athleteId) {
+  const acts = await env.DB
+    .prepare(`SELECT id, start_time, duration_s, distance_m, avg_power, normalized_power
+              FROM activities
+              WHERE user_id = ? AND has_power = 1
+              ORDER BY start_time ASC`)
+    .bind(athleteId)
+    .all();
+  const rows = acts.results || [];
+  if (rows.length === 0) return [];
+  const ids = rows.map((r) => r.id);
+  const mmps = await env.DB
+    .prepare(`SELECT activity_id, duration_s, power_w
+              FROM mmp_records
+              WHERE activity_id IN (${ids.map(() => '?').join(',')})`)
+    .bind(...ids)
+    .all();
+  const mmpByActivity = new Map();
+  for (const m of mmps.results || []) {
+    let bucket = mmpByActivity.get(m.activity_id);
+    if (!bucket) { bucket = {}; mmpByActivity.set(m.activity_id, bucket); }
+    bucket[m.duration_s] = m.power_w;
+  }
+  return rows.map((r) => ({
+    stravaId: String(r.id),
+    startTime: r.start_time * 1000, // ms in the frontend's IDB shape
+    durationS: r.duration_s,
+    distanceM: r.distance_m,
+    avgPower: r.avg_power,
+    npW: r.normalized_power,
+    mmp: mmpByActivity.get(r.id) || {},
+  }));
+}


### PR DESCRIPTION
## Summary
Closes the loop on Phase 4's primary feature (#39). Connect Strava → Sync → see your power-duration curve, no archive download required.

### Worker
- \`worker/strava-api.js\` wraps the Strava v3 endpoints we need: \`listActivitiesAfter\`, \`fetchPowerStream\`, \`hasRealPower\` (filters on \`device_watts\`).
- \`worker/sync.js\` orchestrates a slice: refreshes the access token (60 s buffer), lists activities, dedupes against D1, fetches up to 20 streams per call, computes MMP via the existing \`src/mmp.js\` (\`extractMmp\` + \`normalizedPower\`), and writes \`activities\` + \`mmp_records\` rows. Multi-call sync via a remaining-worklist cursor — keeps wall time well under the 30 s worker ceiling.
- \`/activities/recent\` returns the stored data in the exact shape the frontend's IDB cache uses, so the existing render pipeline consumes it unchanged.

### Frontend
- \`syncRecent\` + \`fetchSyncedActivities\` in \`strava-session.js\` drive the slice loop with a progress callback.
- \`triggerStravaSync\` replaces the placeholder: streams \`Syncing from Strava… N / M activities (R remaining)\` into the existing progress UI, merges into IDB by startTime, then renders.

15 new tests (123 passing total); every external dependency is stubbed.

## Test plan
- [ ] Click **Sync from Strava** on a Connected onboarding card — progress text counts up; the curve renders when done.
- [ ] Run sync a second time — \`processed\` is 0 (already-ingested rows skipped).
- [ ] If you only have non-power rides in the window, the UI surfaces 'No power-equipped rides in the synced window.'
- [ ] Curl smoke: \`POST /sync/recent\` without a session returns \`401 unauthenticated\`.