### PR TITLE
Fix D1 bind-param limit on sync + show progress inline near the Sync button

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -323,6 +323,13 @@ main {
 .strava-connected__btn:hover {
   background: var(--oxblood);
 }
+.sync-status {
+  margin: 0.6rem 0 0;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
 .strava-connected__actions {
   display: flex;
   gap: 0.9rem;

--- a/src/app.js
+++ b/src/app.js
@@ -136,40 +136,56 @@ document.getElementById('strava-sync-btn')?.addEventListener('click', triggerStr
 async function triggerStravaSync() {
   const session = await loadSession();
   if (!session) return;
-  setProgressPhase('Reading', { bytesRead: 0, totalBytes: 1 });
-  setProgress('Pulling activity list from Strava…');
+  // When the user has data on screen the global progress slot lives
+  // way up by the header, easy to miss. Prefer the inline status
+  // line we render next to the Sync button; fall back to the global
+  // slot only when there's no inline target (i.e. onboarding state).
+  const inline = document.getElementById('sync-status');
+  const setSync = (text) => {
+    if (inline) {
+      inline.hidden = false;
+      inline.textContent = text;
+    } else {
+      setProgress(text);
+    }
+  };
+  const clearSync = () => {
+    if (inline) {
+      inline.textContent = '';
+      inline.hidden = true;
+    } else if (progressEl) {
+      progressEl.textContent = '';
+      progressEl.hidden = true;
+      progressEl.innerHTML = '';
+    }
+  };
+  setSync('Pulling activity list from Strava…');
   try {
     await syncRecent({
       session: session.session,
       days: 180,
       onProgress: ({ processed, totalWithPower, remaining }) => {
         const total = Number.isFinite(totalWithPower) ? totalWithPower : '?';
-        setProgress(`Syncing from Strava… ${processed} / ${total} activities (${remaining} remaining).`);
+        setSync(`Syncing from Strava… ${processed} / ${total} activities (${remaining} remaining).`);
       },
     });
-    setProgress('Loading synced data…');
+    setSync('Loading synced data…');
     const remoteActivities = await fetchSyncedActivities(session.session);
     if (remoteActivities.length === 0) {
-      setProgress('No power-equipped rides in the synced window.');
+      setSync('No power-equipped rides in the synced window.');
       return;
     }
-    // Merge into IDB by startTime (the primary key). New rides land,
-    // existing ones get refreshed with whatever the worker computed.
     const fresh = [];
     for (const a of remoteActivities) {
       if (!(await hasActivity(a.startTime))) fresh.push(a);
     }
     if (fresh.length) await saveActivities(fresh);
     const all = await loadActivities();
-    if (progressEl) {
-      progressEl.textContent = '';
-      progressEl.hidden = true;
-      progressEl.innerHTML = '';
-    }
+    clearSync();
     renderCurves(all);
   } catch (err) {
     console.error('strava sync failed', err);
-    setProgress(`Strava sync failed: ${err.message || err}`);
+    setSync(`Strava sync failed: ${err.message || err}`);
   }
 }
 
@@ -582,6 +598,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
         <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP instead</button>
         <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
       </div>
+      ${currentSettings.stravaSession ? `<p class="sync-status" id="sync-status" hidden></p>` : ''}
     </div>
     ${renderPredictBlock()}
   `;
@@ -1035,6 +1052,7 @@ function renderManualMode(fit, inputs = {}) {
           <button type="button" class="link-button" id="manual-upload">Upload an archive</button>
           ${currentSettings.stravaSession ? `<button type="button" class="link-button" id="manual-strava-sync">Sync from Strava</button>` : ''}
         </div>
+        ${currentSettings.stravaSession ? `<p class="sync-status" id="sync-status" hidden></p>` : ''}
       </div>
     </section>
   `;

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -78,10 +78,14 @@ export async function runSyncSlice({
     const powered = all.filter(hasRealPower);
     totalWithPower = powered.length;
     // Skip the ones we've already ingested. Strava activity ids are
-    // stable, so we trust the rows already in D1.
+    // stable, so we trust the rows already in D1. We pull every id
+    // for this user (typically a few thousand at most) and filter in
+    // memory — D1 caps bind parameters per query around 100, so an
+    // IN-list with the full powered set blows past it on large
+    // archives.
     const existing = await env.DB
-      .prepare(`SELECT id FROM activities WHERE user_id = ? AND id IN (${powered.map(() => '?').join(',') || 'NULL'})`)
-      .bind(athleteId, ...powered.map((a) => a.id))
+      .prepare('SELECT id FROM activities WHERE user_id = ?')
+      .bind(athleteId)
       .all();
     const existingIds = new Set((existing.results || []).map((r) => r.id));
     pending = powered
@@ -171,12 +175,15 @@ export async function loadActivities(env, athleteId) {
     .all();
   const rows = acts.results || [];
   if (rows.length === 0) return [];
-  const ids = rows.map((r) => r.id);
+  // Pull every mmp_record joined to one of this user's activities;
+  // SQLite handles the join fine at this size and we avoid an
+  // IN-list with thousands of bind params.
   const mmps = await env.DB
-    .prepare(`SELECT activity_id, duration_s, power_w
-              FROM mmp_records
-              WHERE activity_id IN (${ids.map(() => '?').join(',')})`)
-    .bind(...ids)
+    .prepare(`SELECT m.activity_id, m.duration_s, m.power_w
+              FROM mmp_records m
+              JOIN activities a ON a.id = m.activity_id
+              WHERE a.user_id = ?`)
+    .bind(athleteId)
     .all();
   const mmpByActivity = new Map();
   for (const m of mmps.results || []) {


### PR DESCRIPTION
## Summary
- **D1 fix**: \`runSyncSlice\` was building \`SELECT id FROM activities WHERE user_id = ? AND id IN (?, ?, ?, …)\` with one bind per powered activity, which D1 rejects past ~100 ids ('too many SQL variables at offset 253: SQLITE_ERROR'). Rewrite to pull every existing id for the user in one bind-free query and filter in memory. Same fix for the mmp_records lookup in \`loadActivities\` — JOIN on \`activities.user_id\` instead.
- **UX fix**: when the user has cached data, the sync progress message rendered into the global #progress slot near the page header — way above the fold. Render an inline \`#sync-status\` line directly inside the results-foot block (and the manual-mode foot), gated on having a Strava session. \`triggerStravaSync\` writes there preferentially and falls back to the global slot only when there's no inline target (onboarding state).

Worker redeployed (\`dec81e4f\`).

## Test plan
- [ ] Click Sync from a data-state results-foot — progress text appears next to the button, not at the page top.
- [ ] Sync completes without 'too many SQL variables' on a real 180-day window.
- [ ] Onboarding-state Sync still uses the lede progress slot.