### PR TITLE
Animate Strava connect/sync + add Disconnect from data state

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -323,12 +323,98 @@ main {
 .strava-connected__btn:hover {
   background: var(--oxblood);
 }
+/* Connect button loading state: subtle ellipsis dots that animate
+   while the Strava redirect kicks in. Disabled state dims the bg. */
+.strava-connect__btn.is-loading,
+.strava-connected__btn.is-loading,
+.link-button.is-loading {
+  opacity: 0.7;
+  cursor: progress;
+  pointer-events: none;
+}
+.strava-connect__btn.is-loading::after,
+.strava-connected__btn.is-loading::after,
+.link-button.is-loading::after {
+  content: '';
+  display: inline-block;
+  width: 0.5em;
+  text-align: left;
+  animation: connect-dots 1200ms steps(4, end) infinite;
+}
+@keyframes connect-dots {
+  0%   { content: ''; }
+  25%  { content: '·'; }
+  50%  { content: '··'; }
+  75%  { content: '···'; }
+  100% { content: ''; }
+}
+
+/* Sync progress line. Editorial mono with oxblood numerals and a
+   small pulsing leading mark so it reads as live, not stale. The
+   marker runs only while the line is visible. */
 .sync-status {
-  margin: 0.6rem 0 0;
+  margin: 0.75rem 0 0;
+  padding-left: 1.1rem;
+  position: relative;
   font-family: var(--mono);
-  font-size: 0.78rem;
+  font-size: 0.8rem;
   color: var(--ink-soft);
   font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.sync-status::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--oxblood);
+  transform: translateY(-50%);
+  animation: sync-pulse 1400ms ease-in-out infinite;
+}
+@keyframes sync-pulse {
+  0%, 100% { opacity: 0.35; transform: translateY(-50%) scale(0.85); }
+  50%      { opacity: 1;    transform: translateY(-50%) scale(1.1); }
+}
+.sync-status[hidden] { display: none; }
+/* Numeric counts inside the line lean oxblood for emphasis. We tag
+   them at write time with a span; falling back to plain ink if no
+   span is provided. */
+.sync-status em {
+  font-style: normal;
+  color: var(--oxblood);
+  font-weight: 500;
+}
+
+/* Auth toast: brief editorial banner that fades in after the OAuth
+   round-trip lands. Keeps the user oriented so the page rebuild
+   doesn't read as a generic reload. */
+.auth-toast {
+  position: fixed;
+  top: 1.5rem;
+  left: 50%;
+  transform: translate(-50%, -0.5rem);
+  background: var(--ink);
+  color: var(--paper);
+  padding: 0.65rem 1.1rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 32px rgba(26, 22, 18, 0.28);
+  opacity: 0;
+  transition: opacity 280ms ease, transform 280ms ease;
+  z-index: 1000;
+  pointer-events: none;
+}
+.auth-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+.auth-toast--error {
+  background: var(--oxblood);
 }
 .strava-connected__actions {
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -98,12 +98,32 @@ async function consumeAuthHash() {
   if (!parsed) return;
   clearAuthHash();
   if (parsed.error) {
+    showAuthToast(`Connection failed: ${parsed.error}`, { error: true });
     console.warn('strava auth error', parsed.error);
     return;
   }
   if (parsed.session && parsed.athleteId) {
     await saveSession({ session: parsed.session, athleteId: parsed.athleteId });
+    showAuthToast(`Connected to Strava · athlete ${parsed.athleteId}`);
   }
+}
+
+// Brief overlay shown after a successful auth round-trip. Fades in,
+// dwells, fades out — gives the post-callback page rebuild a sense
+// of arrival instead of feeling like a stale reload.
+function showAuthToast(message, { error = false } = {}) {
+  const el = document.createElement('div');
+  el.className = `auth-toast${error ? ' auth-toast--error' : ''}`;
+  el.textContent = message;
+  document.body.appendChild(el);
+  // Force reflow so the .is-visible animation actually transitions.
+  // eslint-disable-next-line no-unused-expressions
+  el.offsetHeight;
+  el.classList.add('is-visible');
+  setTimeout(() => {
+    el.classList.remove('is-visible');
+    setTimeout(() => el.remove(), 400);
+  }, 2200);
 }
 
 async function refreshStravaUi() {
@@ -117,9 +137,25 @@ async function refreshStravaUi() {
   }
 }
 
-document.getElementById('strava-connect-btn')?.addEventListener('click', () => {
-  window.location.assign(authorizeUrl('/'));
+document.getElementById('strava-connect-btn')?.addEventListener('click', (e) => {
+  beginStravaConnect(e.currentTarget);
 });
+
+// Click feedback for any Connect Strava button (onboarding card or
+// the data-state results-foot variant). The redirect itself is fast,
+// but Strava's authorize screen takes a beat to load — without the
+// flash of in-progress state it just feels like a stuck click.
+function beginStravaConnect(btn) {
+  if (btn) {
+    btn.disabled = true;
+    btn.classList.add('is-loading');
+    btn.dataset.originalText = btn.textContent;
+    btn.textContent = 'Opening Strava…';
+  }
+  // Tiny defer so the disabled + label change actually paints before
+  // the navigation tears the page down.
+  setTimeout(() => window.location.assign(authorizeUrl('/')), 60);
+}
 
 document.getElementById('strava-disconnect')?.addEventListener('click', async () => {
   if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
@@ -141,12 +177,14 @@ async function triggerStravaSync() {
   // line we render next to the Sync button; fall back to the global
   // slot only when there's no inline target (i.e. onboarding state).
   const inline = document.getElementById('sync-status');
-  const setSync = (text) => {
+  const setSync = (html) => {
     if (inline) {
       inline.hidden = false;
-      inline.textContent = text;
+      inline.innerHTML = html;
     } else {
-      setProgress(text);
+      // Strip tags for the global progress slot — its CSS doesn't
+      // know about our <em> oxblood numerals and they'd render flat.
+      setProgress(html.replace(/<[^>]+>/g, ''));
     }
   };
   const clearSync = () => {
@@ -173,7 +211,7 @@ async function triggerStravaSync() {
       knownIds,
       onProgress: ({ processed, totalWithPower, remaining }) => {
         const total = Number.isFinite(totalWithPower) ? totalWithPower : '?';
-        setSync(`Syncing from Strava… ${processed} / ${total} activities (${remaining} remaining).`);
+        setSync(`Syncing from Strava · <em>${processed}</em> / <em>${total}</em> activities · <em>${remaining}</em> remaining`);
       },
     });
     setSync('Loading synced data…');
@@ -602,7 +640,8 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       <div class="results-foot__actions">
         <button type="button" class="link-button" id="upload-another">Upload another archive</button>
         ${currentSettings.stravaSession
-          ? `<button type="button" class="link-button" id="results-foot-sync">Sync from Strava</button>`
+          ? `<button type="button" class="link-button" id="results-foot-sync">Sync from Strava</button>
+             <button type="button" class="link-button" id="results-foot-disconnect">Disconnect Strava</button>`
           : `<button type="button" class="link-button" id="results-foot-connect">Connect Strava</button>`}
         <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP instead</button>
         <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
@@ -618,8 +657,14 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     fileInput?.click();
   });
   document.getElementById('results-foot-sync')?.addEventListener('click', triggerStravaSync);
-  document.getElementById('results-foot-connect')?.addEventListener('click', () => {
-    window.location.assign(authorizeUrl('/'));
+  document.getElementById('results-foot-connect')?.addEventListener('click', (e) => {
+    beginStravaConnect(e.currentTarget);
+  });
+  document.getElementById('results-foot-disconnect')?.addEventListener('click', async () => {
+    if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
+    await clearSession();
+    showAuthToast('Disconnected from Strava');
+    renderCurves(currentActivities, { fromCache: true });
   });
   document.getElementById('manual-from-data').addEventListener('click', () => {
     // Pre-seed from the current fit — CP is the natural unit here


### PR DESCRIPTION
## Summary
The Strava OAuth round-trip used to feel like a stuck click followed by a generic reload. Three pieces of polish:

1. **Connect button loading state** — clicking either Connect entry (onboarding card or data-state foot) flips the button to 'Opening Strava…' with an animated ellipsis before the navigation. 60 ms defer so the state actually paints.
2. **Post-OAuth toast** — when a session lands in the URL hash, show a top-center editorial toast ('Connected to Strava · athlete N'). Ink-on-paper, mono uppercase, drop shadow; 2.2 s dwell. Errors render the same toast in oxblood.
3. **Sync progress line** — restyled from flat mono into a padded line with an oxblood pulse marker on the left and oxblood-highlighted numerals via \`<em>\`. The global #progress slot still works as a fallback (strips tags).
4. **Disconnect from data state** — surface a Disconnect Strava button next to Sync in the data-state results-foot, mirror of the onboarding card. Confirms before clearing the session and pops a toast on success.

## Test plan
- [ ] Click Connect from onboarding or the data foot → button reads 'Opening Strava…' with dots, then navigates.
- [ ] Land back on /#session=… → top-center toast 'Connected to Strava · athlete N' fades in, dwells, fades out.
- [ ] Click Sync → progress line shows pulse marker + oxblood numerals updating in place.
- [ ] Click Disconnect from the data foot → confirm prompt, toast on success, Connect Strava replaces Sync/Disconnect.