### PR TITLE
Group results-foot actions by type so they don't wrap

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -782,6 +782,44 @@ body[data-app-state="manual"] #strava-connected {
   gap: 1.25rem;
   flex-wrap: wrap;
 }
+.results-foot__groups {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 1.4rem;
+  row-gap: 0.5rem;
+  align-items: baseline;
+  margin-top: 1rem;
+  width: 100%;
+}
+.results-foot__group {
+  display: contents;
+}
+.results-foot__group-label {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.results-foot__group-actions {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+@media (max-width: 600px) {
+  .results-foot__groups {
+    grid-template-columns: 1fr;
+    row-gap: 1rem;
+  }
+  .results-foot__group-actions {
+    flex-wrap: wrap;
+    white-space: normal;
+  }
+}
 .results-foot--manual {
   margin-top: 2rem;
   padding-top: 1rem;

--- a/src/app.js
+++ b/src/app.js
@@ -637,14 +637,24 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       <p class="results-foot__note">
         ${activityMmps.length} activities cached locally${fromCache ? ', loaded from your last visit.' : '.'}
       </p>
-      <div class="results-foot__actions">
-        <button type="button" class="link-button" id="upload-another">Upload another archive</button>
-        ${currentSettings.stravaSession
-          ? `<button type="button" class="link-button" id="results-foot-sync">Sync from Strava</button>
-             <button type="button" class="link-button" id="results-foot-disconnect">Disconnect Strava</button>`
-          : `<button type="button" class="link-button" id="results-foot-connect">Connect Strava</button>`}
-        <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP instead</button>
-        <button type="button" class="link-button" id="clear-cache">Clear cached data</button>
+      <div class="results-foot__groups">
+        <div class="results-foot__group">
+          <span class="results-foot__group-label">Archive</span>
+          <div class="results-foot__group-actions">
+            <button type="button" class="link-button" id="upload-another">Upload another</button>
+            <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP</button>
+            <button type="button" class="link-button" id="clear-cache">Clear cache</button>
+          </div>
+        </div>
+        <div class="results-foot__group">
+          <span class="results-foot__group-label">Strava</span>
+          <div class="results-foot__group-actions">
+            ${currentSettings.stravaSession
+              ? `<button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
+                 <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>`
+              : `<button type="button" class="link-button" id="results-foot-connect">Connect</button>`}
+          </div>
+        </div>
       </div>
       <p class="sync-status" id="sync-status" hidden></p>
     </div>


### PR DESCRIPTION
## Summary
Five link-buttons in one row was wrapping at common widths. Restructure into two labeled groups, each on its own line:

- **Archive**: Upload another · Synthesize from FTP · Clear cache
- **Strava**: Sync 180 days · Disconnect (or Connect when no session)

The small uppercase mono label sits in a left column via CSS Grid; each row's buttons keep \`white-space: nowrap\` and overflow-x as a safety. Mobile (≤600px) drops the two-column grid and lets buttons wrap.

Also tightened the button labels — 'Upload another' / 'Sync 180 days' / 'Clear cache' — so the unwrapped row has more breathing room without losing meaning.

## Test plan
- [ ] Two clearly grouped rows with small ARCHIVE / STRAVA labels at left.
- [ ] Each row stays on a single line at desktop widths.
- [ ] On a phone width the labels stack above their groups and buttons can wrap.