### PR TITLE
Redesign results-foot as an editorial colophon block

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -782,42 +782,215 @@ body[data-app-state="manual"] #strava-connected {
   gap: 1.25rem;
   flex-wrap: wrap;
 }
-.results-foot__groups {
+
+/* DATA SOURCES — editorial colophon block.
+   Two columns share a vertical hairline. Each column anchors with a
+   hero element (a stat number or status pill), reads as italic
+   running prose, and ends with a vertical action list whose arrow
+   prefixes glide on hover. */
+.data-sources {
+  margin-top: 2.25rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--hair-strong);
   display: grid;
-  grid-template-columns: max-content 1fr;
-  column-gap: 1.4rem;
-  row-gap: 0.5rem;
-  align-items: baseline;
-  margin-top: 1rem;
-  width: 100%;
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+  position: relative;
 }
-.results-foot__group {
-  display: contents;
+.data-sources::before {
+  /* Vertical center rule between the two columns, inset top/bottom
+     so it reads as a hairline mark, not a hard divide. */
+  content: '';
+  position: absolute;
+  top: 1.5rem;
+  bottom: 1rem;
+  left: 50%;
+  width: 1px;
+  background: var(--hair);
 }
-.results-foot__group-label {
+.data-sources__col {
+  padding: 0 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+.data-sources__col:first-child {
+  padding-left: 0;
+}
+.data-sources__col:last-child {
+  padding-right: 0;
+}
+
+/* Archive hero stat: oversized Fraunces, weighty oxblood, optical
+   size pinned to display. The number is the visual gravity of the
+   column. */
+.data-sources__stat {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: clamp(2.6rem, 5.5vw, 3.8rem);
+  line-height: 0.95;
+  color: var(--oxblood);
+  margin: 0;
+  font-variant-numeric: oldstyle-nums;
+  font-variation-settings: "opsz" 144, "SOFT" 30;
+  letter-spacing: -0.015em;
+}
+
+/* Strava status pill — stands in for the hero number on the right
+   column. Connected: oxblood with a pulsing dot. Off: neutral. */
+.data-sources__pill {
   font-family: var(--mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--oxblood);
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  /* Match the visual height of the stat column so both columns
+     start their lede line on roughly the same baseline. */
+  min-height: clamp(2.6rem, 5.5vw, 3.8rem);
+}
+.data-sources__pill--off {
+  color: var(--muted);
+}
+.data-sources__dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--oxblood);
+  animation: data-sources-dot 2s ease-in-out infinite;
+}
+@keyframes data-sources-dot {
+  0%, 100% { opacity: 0.45; transform: scale(0.85); }
+  50%      { opacity: 1;    transform: scale(1.1);  }
+}
+
+.data-sources__lede {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  margin: 0;
+  font-variation-settings: "opsz" 24;
+  max-width: 28ch;
+}
+.data-sources__lede em {
+  font-style: normal;
+  color: var(--oxblood);
+  font-family: var(--mono);
+  font-size: 0.88em;
+  letter-spacing: 0.04em;
+}
+
+.data-sources__label {
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--muted);
-  white-space: nowrap;
+  margin: 0.25rem 0 0;
+  position: relative;
+  padding-left: 1.4rem;
 }
-.results-foot__group-actions {
+.data-sources__label::before {
+  /* Tiny rule before the label, like a department mark in a magazine. */
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 1rem;
+  height: 1px;
+  background: var(--ink);
+  transform: translateY(-0.5px);
+}
+
+.data-sources__actions {
+  list-style: none;
+  margin: 0.6rem 0 0;
+  padding: 0;
   display: flex;
-  gap: 1.25rem;
-  flex-wrap: nowrap;
-  white-space: nowrap;
-  overflow-x: auto;
-  scrollbar-width: thin;
+  flex-direction: column;
+  gap: 0.4rem;
 }
-@media (max-width: 600px) {
-  .results-foot__groups {
+.data-sources__actions li {
+  margin: 0;
+}
+
+/* The action verbs read as inline editorial links, prefixed with a
+   gliding arrow that translates right on hover. */
+.data-sources__link {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  background: none;
+  border: 0;
+  padding: 0.15rem 0;
+  cursor: pointer;
+  position: relative;
+  padding-left: 1.4rem;
+  transition: color 160ms ease;
+}
+.data-sources__link::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-55%);
+  color: var(--oxblood);
+  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1.05);
+}
+.data-sources__link:hover,
+.data-sources__link:focus-visible {
+  color: var(--oxblood);
+  outline: none;
+}
+.data-sources__link:hover::before,
+.data-sources__link:focus-visible::before {
+  transform: translate(0.35rem, -55%);
+}
+.data-sources__link--quiet {
+  color: var(--muted);
+}
+.data-sources__link--quiet::before {
+  color: var(--hair-strong);
+}
+.data-sources__link.is-loading {
+  pointer-events: none;
+  opacity: 0.7;
+}
+.data-sources__link.is-loading::before {
+  animation: data-sources-link-loading 1s linear infinite;
+}
+@keyframes data-sources-link-loading {
+  0%   { transform: translate(0, -55%); }
+  50%  { transform: translate(0.45rem, -55%); }
+  100% { transform: translate(0, -55%); }
+}
+
+/* Sync status occupies the full width of the colophon, anchored to
+   the same starting edge as the archive lede. */
+.data-sources .sync-status {
+  grid-column: 1 / -1;
+  margin-top: 1rem;
+}
+
+@media (max-width: 720px) {
+  .data-sources {
     grid-template-columns: 1fr;
-    row-gap: 1rem;
   }
-  .results-foot__group-actions {
-    flex-wrap: wrap;
-    white-space: normal;
+  .data-sources::before {
+    display: none;
+  }
+  .data-sources__col {
+    padding: 1.25rem 0;
+    border-bottom: 1px solid var(--hair);
+  }
+  .data-sources__col:last-of-type {
+    border-bottom: 0;
   }
 }
 .results-foot--manual {

--- a/src/app.js
+++ b/src/app.js
@@ -633,31 +633,43 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       </thead>
       <tbody>${rows}</tbody>
     </table>
-    <div class="results-foot">
-      <p class="results-foot__note">
-        ${activityMmps.length} activities cached locally${fromCache ? ', loaded from your last visit.' : '.'}
-      </p>
-      <div class="results-foot__groups">
-        <div class="results-foot__group">
-          <span class="results-foot__group-label">Archive</span>
-          <div class="results-foot__group-actions">
-            <button type="button" class="link-button" id="upload-another">Upload another</button>
-            <button type="button" class="link-button" id="manual-from-data">Synthesize from FTP</button>
-            <button type="button" class="link-button" id="clear-cache">Clear cache</button>
-          </div>
-        </div>
-        <div class="results-foot__group">
-          <span class="results-foot__group-label">Strava</span>
-          <div class="results-foot__group-actions">
-            ${currentSettings.stravaSession
-              ? `<button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
-                 <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>`
-              : `<button type="button" class="link-button" id="results-foot-connect">Connect</button>`}
-          </div>
-        </div>
-      </div>
+    <aside class="data-sources" aria-label="Data sources">
+      <section class="data-sources__col data-sources__col--archive">
+        <p class="data-sources__stat">${activityMmps.length.toLocaleString()}</p>
+        <p class="data-sources__lede">
+          activities cached locally${fromCache ? ', loaded from your last visit' : ''}.
+        </p>
+        <p class="data-sources__label">Archive</p>
+        <ul class="data-sources__actions">
+          <li><button type="button" class="data-sources__link" id="upload-another">Upload another</button></li>
+          <li><button type="button" class="data-sources__link" id="manual-from-data">Synthesize from FTP</button></li>
+          <li><button type="button" class="data-sources__link data-sources__link--quiet" id="clear-cache">Clear cache</button></li>
+        </ul>
+      </section>
+      <section class="data-sources__col data-sources__col--strava">
+        ${currentSettings.stravaSession
+          ? `
+            <p class="data-sources__pill"><span class="data-sources__dot" aria-hidden="true"></span>Connected</p>
+            <p class="data-sources__lede">
+              athlete <em>#${currentSettings.stravaAthleteId}</em> · pull the last 180 days from Strava on demand.
+            </p>
+            <p class="data-sources__label">Strava</p>
+            <ul class="data-sources__actions">
+              <li><button type="button" class="data-sources__link" id="results-foot-sync">Sync 180 days</button></li>
+              <li><button type="button" class="data-sources__link data-sources__link--quiet" id="results-foot-disconnect">Disconnect</button></li>
+            </ul>`
+          : `
+            <p class="data-sources__pill data-sources__pill--off">Not connected</p>
+            <p class="data-sources__lede">
+              skip the archive download — sync the last 180 days straight from your Strava account.
+            </p>
+            <p class="data-sources__label">Strava</p>
+            <ul class="data-sources__actions">
+              <li><button type="button" class="data-sources__link" id="results-foot-connect">Connect</button></li>
+            </ul>`}
+      </section>
       <p class="sync-status" id="sync-status" hidden></p>
-    </div>
+    </aside>
     ${renderPredictBlock()}
   `;
   resultsEl.hidden = false;


### PR DESCRIPTION
## Summary
The flat link-button rows under the MMP table weren't using the space well. Reframe as a two-column 'data sources' colophon, magazine-end style:

- **Archive column**: oversized Fraunces stat number (display optical-size, oxblood, weight 500) of the cached activity count, italic serif lede, small department-mark caps label, then a vertical action list (Upload another · Synthesize from FTP · Clear cache).
- **Strava column**: mirror layout with a pulsing oxblood dot pill ('Connected') or a muted 'Not connected' pill in place of the stat, plus athlete id rendered as a mono accent inside the lede when connected.
- Vertical hairline rule between columns; below 720 px the grid collapses to stacked sections separated by hairlines.
- Action verbs are arrow-prefixed editorial links — arrow translates right on hover with a custom easing curve.

## Test plan
- [ ] Data screen below the MMP table shows the new colophon.
- [ ] Hero stat reads the cached activity count, locale-formatted.
- [ ] Strava connected: pulsing dot + 'Connected' + athlete id as oxblood mono inside the italic lede.
- [ ] Strava disconnected: muted pill + Connect arrow link.
- [ ] Hover any action link — arrow glides right, link colors oxblood.
- [ ] Mobile: columns stack with hairline dividers.