### PR TITLE
Quieter data-sources block + drop redundant Synthesize action

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -783,214 +783,73 @@ body[data-app-state="manual"] #strava-connected {
   flex-wrap: wrap;
 }
 
-/* DATA SOURCES — editorial colophon block.
-   Two columns share a vertical hairline. Each column anchors with a
-   hero element (a stat number or status pill), reads as italic
-   running prose, and ends with a vertical action list whose arrow
-   prefixes glide on hover. */
+/* DATA SOURCES — quiet two-line footer. Each row is a small mono
+   caps label sitting alongside a single sentence of status + the
+   inline action link-buttons separated by middots. No hero stats,
+   no animations, no department marks — utility row, not magazine
+   spread. */
 .data-sources {
-  margin-top: 2.25rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--hair-strong);
+  margin-top: 1.75rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--hair);
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0;
-  position: relative;
+  row-gap: 0.55rem;
 }
-.data-sources::before {
-  /* Vertical center rule between the two columns, inset top/bottom
-     so it reads as a hairline mark, not a hard divide. */
-  content: '';
-  position: absolute;
-  top: 1.5rem;
-  bottom: 1rem;
-  left: 50%;
-  width: 1px;
-  background: var(--hair);
+.data-sources__row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  align-items: baseline;
+  column-gap: 1rem;
 }
-.data-sources__col {
-  padding: 0 2rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-.data-sources__col:first-child {
-  padding-left: 0;
-}
-.data-sources__col:last-child {
-  padding-right: 0;
-}
-
-/* Archive hero stat: oversized Fraunces, weighty oxblood, optical
-   size pinned to display. The number is the visual gravity of the
-   column. */
-.data-sources__stat {
-  font-family: var(--serif);
-  font-weight: 500;
-  font-size: clamp(2.6rem, 5.5vw, 3.8rem);
-  line-height: 0.95;
-  color: var(--oxblood);
-  margin: 0;
-  font-variant-numeric: oldstyle-nums;
-  font-variation-settings: "opsz" 144, "SOFT" 30;
-  letter-spacing: -0.015em;
-}
-
-/* Strava status pill — stands in for the hero number on the right
-   column. Connected: oxblood with a pulsing dot. Off: neutral. */
-.data-sources__pill {
+.data-sources__label {
   font-family: var(--mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--oxblood);
-  margin: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
-  /* Match the visual height of the stat column so both columns
-     start their lede line on roughly the same baseline. */
-  min-height: clamp(2.6rem, 5.5vw, 3.8rem);
-}
-.data-sources__pill--off {
   color: var(--muted);
 }
-.data-sources__dot {
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: 50%;
-  background: var(--oxblood);
-  animation: data-sources-dot 2s ease-in-out infinite;
-}
-@keyframes data-sources-dot {
-  0%, 100% { opacity: 0.45; transform: scale(0.85); }
-  50%      { opacity: 1;    transform: scale(1.1);  }
-}
-
-.data-sources__lede {
+.data-sources__line {
+  margin: 0;
   font-family: var(--serif);
   font-style: italic;
-  font-size: 0.98rem;
-  line-height: 1.45;
+  font-size: 0.95rem;
+  line-height: 1.5;
   color: var(--ink-soft);
-  margin: 0;
   font-variation-settings: "opsz" 24;
-  max-width: 28ch;
 }
-.data-sources__lede em {
+.data-sources__status {
+  margin-right: 0.8rem;
+}
+.data-sources__status em {
   font-style: normal;
-  color: var(--oxblood);
   font-family: var(--mono);
   font-size: 0.88em;
   letter-spacing: 0.04em;
+  color: var(--oxblood);
 }
-
-.data-sources__label {
-  font-family: var(--mono);
-  font-size: 0.66rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin: 0.25rem 0 0;
-  position: relative;
-  padding-left: 1.4rem;
-}
-.data-sources__label::before {
-  /* Tiny rule before the label, like a department mark in a magazine. */
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  width: 1rem;
-  height: 1px;
-  background: var(--ink);
-  transform: translateY(-0.5px);
-}
-
 .data-sources__actions {
-  list-style: none;
-  margin: 0.6rem 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+  display: inline;
 }
-.data-sources__actions li {
-  margin: 0;
+.data-sources__actions .link-button {
+  margin-right: 0.65rem;
 }
-
-/* The action verbs read as inline editorial links, prefixed with a
-   gliding arrow that translates right on hover. */
-.data-sources__link {
-  font-family: var(--mono);
-  font-size: 0.82rem;
-  letter-spacing: 0.06em;
-  color: var(--ink);
-  background: none;
-  border: 0;
-  padding: 0.15rem 0;
-  cursor: pointer;
-  position: relative;
-  padding-left: 1.4rem;
-  transition: color 160ms ease;
-}
-.data-sources__link::before {
-  content: '→';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-55%);
-  color: var(--oxblood);
-  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1.05);
-}
-.data-sources__link:hover,
-.data-sources__link:focus-visible {
-  color: var(--oxblood);
-  outline: none;
-}
-.data-sources__link:hover::before,
-.data-sources__link:focus-visible::before {
-  transform: translate(0.35rem, -55%);
-}
-.data-sources__link--quiet {
-  color: var(--muted);
-}
-.data-sources__link--quiet::before {
+.data-sources__actions .link-button + .link-button::before {
+  content: '·';
   color: var(--hair-strong);
+  margin-right: 0.65rem;
+  font-style: normal;
 }
-.data-sources__link.is-loading {
-  pointer-events: none;
-  opacity: 0.7;
-}
-.data-sources__link.is-loading::before {
-  animation: data-sources-link-loading 1s linear infinite;
-}
-@keyframes data-sources-link-loading {
-  0%   { transform: translate(0, -55%); }
-  50%  { transform: translate(0.45rem, -55%); }
-  100% { transform: translate(0, -55%); }
-}
-
-/* Sync status occupies the full width of the colophon, anchored to
-   the same starting edge as the archive lede. */
 .data-sources .sync-status {
-  grid-column: 1 / -1;
-  margin-top: 1rem;
+  margin-top: 0.4rem;
+  margin-left: 6.5rem;
 }
-
-@media (max-width: 720px) {
-  .data-sources {
+@media (max-width: 600px) {
+  .data-sources__row {
     grid-template-columns: 1fr;
+    row-gap: 0.25rem;
   }
-  .data-sources::before {
-    display: none;
-  }
-  .data-sources__col {
-    padding: 1.25rem 0;
-    border-bottom: 1px solid var(--hair);
-  }
-  .data-sources__col:last-of-type {
-    border-bottom: 0;
+  .data-sources .sync-status {
+    margin-left: 0;
   }
 }
 .results-foot--manual {

--- a/src/app.js
+++ b/src/app.js
@@ -634,39 +634,30 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       <tbody>${rows}</tbody>
     </table>
     <aside class="data-sources" aria-label="Data sources">
-      <section class="data-sources__col data-sources__col--archive">
-        <p class="data-sources__stat">${activityMmps.length.toLocaleString()}</p>
-        <p class="data-sources__lede">
-          activities cached locally${fromCache ? ', loaded from your last visit' : ''}.
+      <section class="data-sources__row">
+        <span class="data-sources__label">Archive</span>
+        <p class="data-sources__line">
+          <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached${fromCache ? ', from your last visit' : ''}.</span>
+          <span class="data-sources__actions">
+            <button type="button" class="link-button" id="upload-another">Upload another</button>
+            <button type="button" class="link-button" id="clear-cache">Clear cache</button>
+          </span>
         </p>
-        <p class="data-sources__label">Archive</p>
-        <ul class="data-sources__actions">
-          <li><button type="button" class="data-sources__link" id="upload-another">Upload another</button></li>
-          <li><button type="button" class="data-sources__link" id="manual-from-data">Synthesize from FTP</button></li>
-          <li><button type="button" class="data-sources__link data-sources__link--quiet" id="clear-cache">Clear cache</button></li>
-        </ul>
       </section>
-      <section class="data-sources__col data-sources__col--strava">
-        ${currentSettings.stravaSession
-          ? `
-            <p class="data-sources__pill"><span class="data-sources__dot" aria-hidden="true"></span>Connected</p>
-            <p class="data-sources__lede">
-              athlete <em>#${currentSettings.stravaAthleteId}</em> · pull the last 180 days from Strava on demand.
-            </p>
-            <p class="data-sources__label">Strava</p>
-            <ul class="data-sources__actions">
-              <li><button type="button" class="data-sources__link" id="results-foot-sync">Sync 180 days</button></li>
-              <li><button type="button" class="data-sources__link data-sources__link--quiet" id="results-foot-disconnect">Disconnect</button></li>
-            </ul>`
-          : `
-            <p class="data-sources__pill data-sources__pill--off">Not connected</p>
-            <p class="data-sources__lede">
-              skip the archive download — sync the last 180 days straight from your Strava account.
-            </p>
-            <p class="data-sources__label">Strava</p>
-            <ul class="data-sources__actions">
-              <li><button type="button" class="data-sources__link" id="results-foot-connect">Connect</button></li>
-            </ul>`}
+      <section class="data-sources__row">
+        <span class="data-sources__label">Strava</span>
+        <p class="data-sources__line">
+          ${currentSettings.stravaSession
+            ? `<span class="data-sources__status">Connected as athlete <em>#${currentSettings.stravaAthleteId}</em>.</span>
+               <span class="data-sources__actions">
+                 <button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
+                 <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>
+               </span>`
+            : `<span class="data-sources__status">Sync the last 180 days from your Strava account — no archive download required.</span>
+               <span class="data-sources__actions">
+                 <button type="button" class="link-button" id="results-foot-connect">Connect</button>
+               </span>`}
+        </p>
       </section>
       <p class="sync-status" id="sync-status" hidden></p>
     </aside>
@@ -687,14 +678,6 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     await clearSession();
     showAuthToast('Disconnected from Strava');
     renderCurves(currentActivities, { fromCache: true });
-  });
-  document.getElementById('manual-from-data').addEventListener('click', () => {
-    // Pre-seed from the current fit — CP is the natural unit here
-    // since we have a fitted CP from data, not an FTP guess.
-    const seedCp = Number.isFinite(currentFit?.cpW) ? currentFit.cpW : 266;
-    const ftpW = seedCp / 0.95;
-    const fit = synthesizeFit({ ftpW });
-    if (fit) renderManualMode(fit, { ftpW, unit: 'cp' });
   });
   wirePredictForm();
   wireCurveChart();


### PR DESCRIPTION
## Summary
- Pull the colophon back to a calm two-row footer: small mono caps label, italic single-line status with inline link-buttons separated by middots. No hero stats, no pulse animations, no department marks.
- Drop the 'Synthesize from FTP' button from the Archive row. The override panel directly below already lets the user pin CP / FTP manually, so the action duplicates an existing affordance. Manual mode stays available from the onboarding screen as the no-archive entry point.

## Test plan
- [ ] Two rows, ARCHIVE / STRAVA, both single-line.
- [ ] No vertical hairline rule, no oversized number, no pulsing dot.
- [ ] Sync still works; Disconnect still confirms.
- [ ] Override panel below still operational for manual CP/FTP.