### PR TITLE
Tighten data-sources copy + fix link-button spacing

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -828,16 +828,9 @@ body[data-app-state="manual"] #strava-connected {
   color: var(--oxblood);
 }
 .data-sources__actions {
-  display: inline;
-}
-.data-sources__actions .link-button {
-  margin-right: 0.65rem;
-}
-.data-sources__actions .link-button + .link-button::before {
-  content: '·';
-  color: var(--hair-strong);
-  margin-right: 0.65rem;
-  font-style: normal;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1.1rem;
 }
 .data-sources .sync-status {
   margin-top: 0.4rem;

--- a/src/app.js
+++ b/src/app.js
@@ -637,7 +637,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
       <section class="data-sources__row">
         <span class="data-sources__label">Archive</span>
         <p class="data-sources__line">
-          <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached${fromCache ? ', from your last visit' : ''}.</span>
+          <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached.</span>
           <span class="data-sources__actions">
             <button type="button" class="link-button" id="upload-another">Upload another</button>
             <button type="button" class="link-button" id="clear-cache">Clear cache</button>
@@ -648,7 +648,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
         <span class="data-sources__label">Strava</span>
         <p class="data-sources__line">
           ${currentSettings.stravaSession
-            ? `<span class="data-sources__status">Connected as athlete <em>#${currentSettings.stravaAthleteId}</em>.</span>
+            ? `<span class="data-sources__status">Connected.</span>
                <span class="data-sources__actions">
                  <button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
                  <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>


### PR DESCRIPTION
## Summary
- Archive line: drop ', from your last visit' — adds noise.
- Strava line: just 'Connected.' instead of 'Connected as athlete #319829.' — id wasn't earning its keep.
- Replace middot separator with an inline-flex gap so the second link no longer has leading whitespace inside its box.

## Test plan
- [ ] Archive row reads '3,006 activities cached.   UPLOAD ANOTHER   CLEAR CACHE'.
- [ ] Strava row reads 'Connected.   SYNC 180 DAYS   DISCONNECT' (or the Connect equivalent).
- [ ] No leading space before the second link in either row.