### PR TITLE
Persist sync completion + fix disconnect rerender + animate strava cards

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -379,6 +379,24 @@ main {
   50%      { opacity: 1;    transform: translateY(-50%) scale(1.1); }
 }
 .sync-status[hidden] { display: none; }
+/* Persistent post-sync confirmation. Drops the pulse marker (sync is
+   over, not ongoing) and switches the bullet to a static check. */
+.sync-status.sync-status--done::before {
+  animation: none;
+  background: transparent;
+  width: 0.7rem;
+  height: 0.7rem;
+  top: 50%;
+  border: 0;
+  border-radius: 0;
+  content: '✓';
+  color: var(--oxblood);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  line-height: 1;
+  display: inline-block;
+  text-align: center;
+}
 /* Numeric counts inside the line lean oxblood for emphasis. We tag
    them at write time with a span; falling back to plain ink if no
    span is provided. */
@@ -1664,6 +1682,8 @@ body[data-app-state="manual"] #strava-connected {
 .lede > *,
 .steps > li,
 .drop,
+#strava-connect,
+#strava-connected,
 .manual-mode {
   opacity: 0;
   animation: rise 720ms cubic-bezier(.2, .8, .2, 1) forwards;
@@ -1674,8 +1694,10 @@ body[data-app-state="manual"] #strava-connected {
 .steps > li:nth-child(1) { animation-delay: 540ms; }
 .steps > li:nth-child(2) { animation-delay: 640ms; }
 .steps > li:nth-child(3) { animation-delay: 740ms; }
-.drop        { animation-delay: 880ms; }
-.manual-mode { animation-delay: 980ms; }
+.drop             { animation-delay: 880ms; }
+#strava-connect,
+#strava-connected { animation-delay: 940ms; }
+.manual-mode      { animation-delay: 1000ms; }
 
 #results[data-revealed] {
   animation: rise 600ms cubic-bezier(.2, .8, .2, 1);
@@ -1687,7 +1709,7 @@ body[data-app-state="manual"] #strava-connected {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
-  .lede > *, .steps > li, .drop, .manual-mode { opacity: 1; }
+  .lede > *, .steps > li, .drop, #strava-connect, #strava-connected, .manual-mode { opacity: 1; }
 }
 
 /* RESPONSIVE */

--- a/src/app.js
+++ b/src/app.js
@@ -160,6 +160,10 @@ function beginStravaConnect(btn) {
 document.getElementById('strava-disconnect')?.addEventListener('click', async () => {
   if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
   await clearSession();
+  // Re-hydrate currentSettings so the next render sees the cleared
+  // session keys; clearSession updates IDB but doesn't reach into the
+  // in-memory copy.
+  currentSettings = (await loadSettings()) || {};
   await refreshStravaUi();
 });
 
@@ -226,8 +230,21 @@ async function triggerStravaSync() {
     }
     if (fresh.length) await saveActivities(fresh);
     const all = await loadActivities();
-    clearSync();
     renderCurves(all);
+    // Persist a completion message in the freshly-rendered sync-status
+    // element. Stays put until the next render (override change,
+    // re-sync, etc.) or a page reload, so the user sees that the sync
+    // actually finished rather than the progress text just vanishing.
+    const noun = fresh.length === 1 ? 'ride' : 'rides';
+    const completion = fresh.length === 0
+      ? `Sync complete. No new rides — local cache already had everything in the synced window.`
+      : `Sync complete. <em>${fresh.length}</em> new ${noun} added to local cache.`;
+    const after = document.getElementById('sync-status');
+    if (after) {
+      after.hidden = false;
+      after.classList.add('sync-status--done');
+      after.innerHTML = completion;
+    }
   } catch (err) {
     console.error('strava sync failed', err);
     setSync(`Strava sync failed: ${err.message || err}`);
@@ -676,6 +693,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   document.getElementById('results-foot-disconnect')?.addEventListener('click', async () => {
     if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
     await clearSession();
+    currentSettings = (await loadSettings()) || {};
     showAuthToast('Disconnected from Strava');
     renderCurves(currentActivities, { fromCache: true });
   });


### PR DESCRIPTION
## Summary
Three things, all surfaced in one quick session:

- **Persistent sync completion**: after the sync finishes the inline progress flips to a confirmation line ('Sync complete. N new rides added.' or 'No new rides — already cached.') with a static check mark replacing the pulse marker. Stays until next render / reload.
- **Disconnect rerender**: \`clearSession\` updates IDB but didn't touch the in-memory \`currentSettings\`, so the next \`renderCurves\` still saw the session and the data-sources block stayed in 'Connected' state. Re-hydrate \`currentSettings\` from IDB after \`clearSession\` (in both onboarding and data-foot handlers).
- **Strava cards animate in**: \`#strava-connect\` and \`#strava-connected\` now ride the same staggered rise animation as the rest of the landing-screen elements (delay 940 ms, between drop and manual mode). They were the only onboarding elements that popped in flat.

Also clarifies for the record: synced rides land in the same IDB activities store as archive ingest, so they merge into one pool.

## Test plan
- [ ] Run a sync — progress shows; on completion the line stays as 'Sync complete. N new rides…' with a check mark.
- [ ] Click Disconnect — toast appears, the row instantly flips to 'Sync the last 180 days… Connect' without a manual reload.
- [ ] On a fresh page load (no archive), the Strava card fades up with the rest of the onboarding stack instead of appearing flat.