### PR TITLE
Reframe manual-mode summary so it doesn't say 'Skip the upload'

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     </section>
 
     <details id="manual-mode" class="manual-mode">
-      <summary id="manual-mode-summary">Skip the upload — estimate from FTP or CP</summary>
+      <summary id="manual-mode-summary">No data yet? Estimate from FTP or CP</summary>
       <form id="manual-form" class="manual-form" novalidate>
         <label class="manual-form__field">
           <span>Threshold</span>


### PR DESCRIPTION
## Summary
'Skip the upload — estimate from FTP or CP' was accurate when archive upload was the only way in. Strava sync is a peer now, so the framing has to cover both. New copy: 'No data yet? Estimate from FTP or CP' — implies the same skip-this-step idea without naming a specific path.

## Test plan
- [ ] Onboarding screen shows the new summary.
- [ ] Disclosure still expands to the FTP/CP form.