### PR TITLE
Mention sync alongside archive in the manual-mode foot note

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
       </form>
       <p class="results-foot__note">
         A coarse synthesis. CP is set to 0.95 × FTP (or used directly if you enter CP); W' comes from your 1-min
-        sprint when given, otherwise defaults to 18 kJ (middle of the trained-cyclist range). Upload your archive
-        when you can — the prediction tightens up considerably with real data.
+        sprint when given, otherwise defaults to 18 kJ (middle of the trained-cyclist range). Upload an archive or
+        sync from Strava when you can — the prediction tightens up considerably with real data.
       </p>
     </details>
     <p id="progress" class="progress" hidden></p>


### PR DESCRIPTION
## Summary
The footer told users to 'Upload your archive when you can.' Strava sync is a peer path now, so the nudge should mention both.

**New**: 'Upload an archive or sync from Strava when you can — the prediction tightens up considerably with real data.'

## Test plan
- [ ] Open the manual-mode disclosure; foot note reads the new copy.