### PR TITLE
Bump streams/slice with wall-time guard + plain manual summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     </section>
 
     <details id="manual-mode" class="manual-mode">
-      <summary id="manual-mode-summary">Have a recent FTP test? Sketch a curve from a single number</summary>
+      <summary id="manual-mode-summary">Predict from FTP or CP</summary>
       <form id="manual-form" class="manual-form" novalidate>
         <label class="manual-form__field">
           <span>Threshold</span>

--- a/src/strava-session.js
+++ b/src/strava-session.js
@@ -91,6 +91,12 @@ export async function syncRecent({ session, days = 180, knownIds = [], onProgres
     }
     const slice = await res.json();
     cumulativeProcessed += slice.processed || 0;
+    if (typeof slice.elapsedMs === 'number') {
+      // Visibility into per-slice wall time. Logged but not shown to
+      // the user — useful when tuning ACTIVITIES_PER_CALL or chasing
+      // a Strava-side slowdown.
+      console.debug(`[sync] slice ${slice.processed}/${slice.processed + slice.remaining} done in ${slice.elapsedMs}ms`);
+    }
     onProgress?.({
       processed: cumulativeProcessed,
       totalWithPower: slice.totalWithPower,

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -12,7 +12,14 @@ import { refreshTokens } from './strava-oauth.js';
 // 30 s ceiling and keeps progress feedback responsive. The first
 // call (no cursor) does the activity listing only and processes 0
 // streams, so the streams-only call rate is a clean N per slice.
-const ACTIVITIES_PER_CALL = 10;
+//
+// In addition to the per-slice cap, a wall-time guard inside the
+// loop breaks out early if the slice has been running long enough
+// that one more stream fetch could push past the worker's 30 s
+// budget. This way we adapt to slow Strava responses instead of
+// counting on the static cap alone.
+const ACTIVITIES_PER_CALL = 15;
+const SLICE_WALL_BUDGET_MS = 22_000;
 
 // Resolve a session token to an athlete id, or return null when the
 // session is missing / expired.
@@ -108,16 +115,27 @@ export async function runSyncSlice({
     };
   }
 
-  // Subsequent slice: process up to ACTIVITIES_PER_CALL streams.
+  // Subsequent slice: process up to ACTIVITIES_PER_CALL streams or
+  // until the wall-time guard fires, whichever comes first.
+  const sliceStartedAt = Date.now();
   const pending = cursor.pending;
   const totalSeen = cursor.totalSeen;
   const totalWithPower = cursor.totalWithPower;
   const slice = pending.slice(0, ACTIVITIES_PER_CALL);
-  const remaining = pending.slice(slice.length);
+  let remaining = pending.slice(slice.length);
   const errors = [];
   let processed = 0;
 
-  for (const a of slice) {
+  for (let i = 0; i < slice.length; i++) {
+    // Wall-time guard: if we're already past the budget, push what's
+    // left back onto the worklist and bail. Better to return early
+    // with a smaller chunk than risk the worker hitting its hard
+    // 30 s limit and dropping the response entirely.
+    if (Date.now() - sliceStartedAt >= SLICE_WALL_BUDGET_MS) {
+      remaining = slice.slice(i).concat(remaining);
+      break;
+    }
+    const a = slice[i];
     try {
       const stream = await fetchPowerStream({ accessToken, activityId: a.id }, fetchImpl);
       if (!stream || stream.length === 0) continue;
@@ -163,8 +181,10 @@ export async function runSyncSlice({
     .bind(Math.floor(Date.now() / 1000), athleteId)
     .run();
 
+  const elapsedMs = Date.now() - sliceStartedAt;
   const done = remaining.length === 0;
   return {
+    elapsedMs,
     done,
     processed,
     totalSeen,


### PR DESCRIPTION
## Summary
**Sync sizing**

- \`ACTIVITIES_PER_CALL\` bumped 10 → 15. ~500 ms / stream × 15 ≈ 7.5 s per slice on average; comfortable below the 30 s worker budget.
- New \`SLICE_WALL_BUDGET_MS = 22 s\` guard inside the loop. If we're past the budget when starting the next stream fetch, push remaining onto the worklist and return early with whatever's done. Adapts to slow Strava responses instead of relying on the static cap alone.
- Worker reports \`elapsedMs\` on each slice; frontend logs to console.debug for tuning visibility.

**Manual summary**

- 'Predict from FTP or CP' — straightforward, no nudging toward FTP tests, no flourishes.

## Test plan
- [ ] Sync a fresh window — DevTools console shows '[sync] slice N/M done in Xms' lines.
- [ ] If Strava is slow and elapsed exceeds the guard, the remaining activities show up on the next slice rather than disappearing.
- [ ] Manual disclosure now reads 'Predict from FTP or CP'.