### PR TITLE
Manual mode: decay from FTP at 60 min, not zero decay

### DIFF
--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -260,15 +260,21 @@ function baselinePower(fit, t) {
 //                          duration predictions never undercut a real ride.
 export function predictPower(fit, durationS, opts = {}) {
   if (!fit || !Number.isFinite(durationS) || durationS <= 0) return null;
-  // Manual-mode fits are synthesized from a single number (FTP / CP)
-  // and have no observed efforts behind them. Riegel decay only makes
-  // physical sense when calibrated against real long-duration rides;
-  // applying it on top of a synthesized hyperbola pulls predictions
-  // below the user's stated FTP at 60 min, which contradicts the
-  // input. Always skip decay for manual fits unless the caller forces
-  // an explicit decay opts in.
-  const decayDisabled = opts.decay === false || (fit.manual && opts.decay === undefined);
-  const decay = decayDisabled ? null : { ...DEFAULT_DECAY, ...(opts.decay || {}) };
+  // Manual-mode fits are synthesized from FTP, calibrated so the
+  // 2-param model returns FTP at 60 min. We still want Riegel decay
+  // for ultra-endurance, just anchored at 60 min instead of the
+  // default 20 min — otherwise decay starting at 20 min drags the
+  // 60-min prediction below the user's stated FTP. Inside 60 min
+  // the calibrated hyperbola handles things on its own.
+  const manualDecayDefault = { fromS: 3600, k: 0.10 };
+  let decay;
+  if (opts.decay === false) {
+    decay = null;
+  } else if (fit.manual && opts.decay === undefined) {
+    decay = manualDecayDefault;
+  } else {
+    decay = { ...DEFAULT_DECAY, ...(opts.decay || {}) };
+  }
   const useObservedAnchors = opts.useObservedAnchors !== false;
 
   let powerW = baselinePower(fit, durationS);

--- a/src/manual.js
+++ b/src/manual.js
@@ -16,9 +16,11 @@
 // number can't produce an absurd hyperbola.
 //
 // `manual: true` flags downstream code (predictPower, chart) to
-// skip Riegel fatigue decay — the synthesized fit has no observed
-// data behind it, so layering decay on top double-counts fatigue
-// and pulls 60-min predictions below the user's stated FTP.
+// shift the Riegel fatigue anchor from the default 20 min to 60 min.
+// Decay still applies for ultra-endurance durations (2 h+), but
+// kicks in from the user's stated FTP rather than from a model
+// value at 20 min — otherwise the decay would pull 60-min
+// predictions below the user's FTP, contradicting the input.
 
 const W_PRIME_DEFAULT_J = 18_000;
 const W_PRIME_MIN_J = 5_000;

--- a/tests/manual.test.js
+++ b/tests/manual.test.js
@@ -19,11 +19,23 @@ describe('synthesizeFit', () => {
     expect(fit.cpW + fit.wPrimeJ / 3600).toBeCloseTo(292, 4);
   });
 
-  it('predicts FTP at 60 min in the full predict path (no Riegel decay for manual fits)', () => {
+  it('predicts FTP at exactly 60 min in the full predict path', () => {
     const fit = synthesizeFit({ ftpW: 292 });
     const out = predictPower(fit, 3600);
+    // Riegel decay anchors at 60 min for manual fits, so the value
+    // at the anchor is exactly FTP and no decay applies yet.
     expect(out.powerW).toBeCloseTo(292, 1);
-    expect(out.decayed).toBe(false);
+  });
+
+  it('decays past 60 min, anchored at FTP', () => {
+    const fit = synthesizeFit({ ftpW: 280 });
+    // 2 h: 280 × (3600/7200)^0.10 ≈ 280 × 0.9330 ≈ 261.2
+    const at2h = predictPower(fit, 7200);
+    expect(at2h.powerW).toBeCloseTo(280 * (3600 / 7200) ** 0.10, 2);
+    // 4 h: deeper decay, well below FTP.
+    const at4h = predictPower(fit, 14400);
+    expect(at4h.powerW).toBeLessThan(280);
+    expect(at4h.powerW).toBeCloseTo(280 * (3600 / 14400) ** 0.10, 2);
   });
 
   it('derives W\' from a 1-min sprint via the 2-param hyperbola seed', () => {


### PR DESCRIPTION
## Problem
Last fix was over-corrected. Manual FTP=280 → predict 2 h = 278 W. Unphysiological.

## Fix
Don't skip decay for manual fits — *shift the anchor*. From 60 min onward we apply standard Riegel decay (k = 0.10) anchored at the user's stated FTP. Inside 60 min the calibrated 2-param hyperbola already handles things on its own.

## Result for FTP=280
| Duration | Predicted |
|----------|-----------|
| 60 min   | 280 W (anchor)   |
| 2 h      | 261 W |
| 4 h      | 244 W |
| 8 h      | 228 W |

## Test plan
- [ ] Manual FTP = 280 → predict 2 h ≈ 261. Predict 4 h ≈ 244. Predict 60 min = 280 exactly.
- [ ] Real-data fits unchanged (regression tests still pass; 127 total).