### PR TITLE
Keep data-source entries visible in manual mode

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -551,16 +551,18 @@ main {
    (it's the page header). State controls the secondary sections:
    onboarding shows the steps + drop zone + synth disclosure;
    data and manual hide all of those in favor of the results. */
+/* Data state owns the screen — every onboarding entry hides. Manual
+   state keeps the data-source entries visible at the top so the user
+   has natural access to upload / connect / sync without rebuilding
+   them inside the manual block. The manual disclosure itself does
+   hide (its inline editor lives inside the manual result block now). */
 body[data-app-state="data"] .steps,
 body[data-app-state="data"] #archive-drop,
 body[data-app-state="data"] #manual-mode,
 body[data-app-state="data"] #strava-connect,
 body[data-app-state="data"] #strava-connected,
 body[data-app-state="manual"] .steps,
-body[data-app-state="manual"] #archive-drop,
-body[data-app-state="manual"] #manual-mode,
-body[data-app-state="manual"] #strava-connect,
-body[data-app-state="manual"] #strava-connected {
+body[data-app-state="manual"] #manual-mode {
   display: none;
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1135,34 +1135,13 @@ function renderManualMode(fit, inputs = {}) {
       </form>
       <output class="predict-output" id="predict-output" hidden></output>
 
-      <aside class="data-sources data-sources--manual" aria-label="Data sources">
-        <section class="data-sources__row">
-          <span class="data-sources__label">Archive</span>
-          <p class="data-sources__line">
-            <span class="data-sources__status">Upload a Strava archive zip for the full power-duration curve from your real rides.</span>
-            <span class="data-sources__actions">
-              <button type="button" class="link-button" id="manual-upload">Upload archive</button>
-              ${hasPriorData ? `<button type="button" class="link-button" id="manual-back">Back to my data (${priorActivities.length})</button>` : ''}
-            </span>
-          </p>
-        </section>
-        <section class="data-sources__row">
-          <span class="data-sources__label">Strava</span>
-          <p class="data-sources__line">
-            ${currentSettings.stravaSession
-              ? `<span class="data-sources__status">Connected.</span>
-                 <span class="data-sources__actions">
-                   <button type="button" class="link-button" id="manual-strava-sync">Sync 180 days</button>
-                   <button type="button" class="link-button" id="manual-strava-disconnect">Disconnect</button>
-                 </span>`
-              : `<span class="data-sources__status">Sync the last 180 days from your Strava account — no archive download required.</span>
-                 <span class="data-sources__actions">
-                   <button type="button" class="link-button" id="manual-strava-connect">Connect</button>
-                 </span>`}
-          </p>
-        </section>
-        <p class="sync-status" id="sync-status" hidden></p>
-      </aside>
+      ${hasPriorData ? `
+        <div class="results-foot results-foot--manual">
+          <div class="results-foot__actions">
+            <button type="button" class="link-button" id="manual-back">← Back to my data (${priorActivities.length})</button>
+          </div>
+        </div>
+      ` : ''}
     </section>
   `;
   resultsEl.hidden = false;
@@ -1170,33 +1149,16 @@ function renderManualMode(fit, inputs = {}) {
   wirePredictForm();
   wireManualInline();
   setAppState('manual');
-  document.getElementById('manual-strava-sync')?.addEventListener('click', triggerStravaSync);
-  document.getElementById('manual-strava-connect')?.addEventListener('click', (e) => {
-    beginStravaConnect(e.currentTarget);
-  });
-  document.getElementById('manual-strava-disconnect')?.addEventListener('click', async () => {
-    if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
-    await clearSession();
-    currentSettings = (await loadSettings()) || {};
-    showAuthToast('Disconnected from Strava');
-    // Reconstruct the FTP from the current calibrated fit:
-    // CP = FTP − W'/3600, so FTP = CP + W'/3600. Re-render manual
-    // mode so the data-sources block flips to the disconnected
-    // variant in place.
-    const ftpW = currentFit ? currentFit.cpW + currentFit.wPrimeJ / 3600 : null;
-    if (ftpW) {
-      renderManualMode(synthesizeFit({ ftpW }), { ftpW, unit: inputs.unit || 'ftp' });
-    }
-  });
+  // Manual mode no longer rebuilds Archive / Strava controls in the
+  // result block — the onboarding entries at the top of the page stay
+  // visible across manual state, so users have natural access to drop
+  // an archive or hit Connect / Sync without leaving the page.
   if (hasPriorData) {
     document.getElementById('manual-back').addEventListener('click', () => {
       currentSettings = priorSettings;
       renderCurves(priorActivities, { fromCache: true });
     });
   }
-  document.getElementById('manual-upload')?.addEventListener('click', () => {
-    fileInput?.click();
-  });
   resultsEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 


### PR DESCRIPTION
## Summary
Last PR put a duplicate Archive / Strava colophon in the manual result block because we'd hidden the originals at the top. Simpler approach: just leave the originals visible across both states.

- CSS no longer hides \`#archive-drop\`, \`#strava-connect\`, \`#strava-connected\` when \`data-app-state="manual"\` — they stay where the user first saw them.
- Manual results-foot collapses back to a single 'Back to my data' button (or nothing if there's no prior data).
- Drop the duplicate Connect/Sync/Disconnect handlers we added at the bottom of the manual render.

## Test plan
- [ ] Enter manual mode (with or without an archive) — drop zone, Strava connect/connected card, and manual fit block all visible together.
- [ ] Click Connect / Sync from the top entries — works as before; sync transitions to data state.
- [ ] Drop an archive while in manual mode — parses, transitions to data state.