### PR TITLE
Unify Strava entry as a colophon row, drop athlete id

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,20 +55,15 @@
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>
     </div>
 
-    <section id="strava-connect" class="strava-connect" hidden>
-      <p class="strava-connect__lede">Or pull the last 180 days directly from Strava — instant, no archive download.</p>
-      <button type="button" id="strava-connect-btn" class="strava-connect__btn">Connect Strava</button>
-    </section>
-
-    <section id="strava-connected" class="strava-connected" hidden>
-      <p class="strava-connected__status">
-        Strava connected · athlete <span id="strava-athlete-id">…</span>
-      </p>
-      <div class="strava-connected__actions">
-        <button type="button" id="strava-sync-btn" class="strava-connected__btn">Sync last 180 days</button>
-        <button type="button" id="strava-disconnect" class="link-button">Disconnect</button>
-      </div>
-    </section>
+    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source" hidden>
+      <section class="data-sources__row">
+        <span class="data-sources__label">Strava</span>
+        <p class="data-sources__line">
+          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
+          <span class="data-sources__actions" id="strava-status-actions"></span>
+        </p>
+      </section>
+    </aside>
 
     <details id="manual-mode" class="manual-mode">
       <summary id="manual-mode-summary">Predict from FTP or CP</summary>

--- a/shared.css
+++ b/shared.css
@@ -292,48 +292,23 @@ main {
 /* Strava connect / connected blocks. Sit between the drop zone and
    the manual-mode disclosure on the onboarding screen. Quiet styling
    — the affordance is the button label, not a colored bar. */
-.strava-connect, .strava-connected {
+/* Inline data-sources block (top-of-page strava entry on the
+   onboarding/manual screens). Same row layout as the data-screen
+   colophon, but no top border / extra margin since it sits inline
+   between the drop zone and the manual disclosure rather than at
+   the foot of a results section. */
+.data-sources--inline {
   margin: 1rem 0 0;
-  padding: 1rem 1.25rem;
-  border: 1px solid var(--hair);
-  background: var(--paper-soft);
-}
-.strava-connect__lede,
-.strava-connected__status {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 0.95rem;
-  color: var(--ink-soft);
-  margin: 0 0 0.6rem;
-}
-.strava-connect__btn,
-.strava-connected__btn {
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  background: var(--ink);
-  color: var(--paper);
-  border: 0;
-  padding: 0.55rem 1rem;
-  cursor: pointer;
-  transition: background 160ms ease;
-}
-.strava-connect__btn:hover,
-.strava-connected__btn:hover {
-  background: var(--oxblood);
+  padding: 0.6rem 0;
+  border-top: 0;
 }
 /* Connect button loading state: subtle ellipsis dots that animate
-   while the Strava redirect kicks in. Disabled state dims the bg. */
-.strava-connect__btn.is-loading,
-.strava-connected__btn.is-loading,
+   while the Strava redirect kicks in. */
 .link-button.is-loading {
   opacity: 0.7;
   cursor: progress;
   pointer-events: none;
 }
-.strava-connect__btn.is-loading::after,
-.strava-connected__btn.is-loading::after,
 .link-button.is-loading::after {
   content: '';
   display: inline-block;
@@ -434,18 +409,6 @@ main {
 .auth-toast--error {
   background: var(--oxblood);
 }
-.strava-connected__actions {
-  display: flex;
-  gap: 0.9rem;
-  align-items: center;
-}
-#strava-athlete-id {
-  font-family: var(--mono);
-  font-style: normal;
-  font-variant-numeric: tabular-nums;
-  color: var(--oxblood);
-}
-
 .progress {
   margin: 1.25rem 0 0;
   display: flex;
@@ -559,8 +522,7 @@ main {
 body[data-app-state="data"] .steps,
 body[data-app-state="data"] #archive-drop,
 body[data-app-state="data"] #manual-mode,
-body[data-app-state="data"] #strava-connect,
-body[data-app-state="data"] #strava-connected,
+body[data-app-state="data"] #strava-data-source,
 body[data-app-state="manual"] .steps,
 body[data-app-state="manual"] #manual-mode {
   display: none;
@@ -1684,8 +1646,7 @@ body[data-app-state="manual"] #manual-mode {
 .lede > *,
 .steps > li,
 .drop,
-#strava-connect,
-#strava-connected,
+#strava-data-source,
 .manual-mode {
   opacity: 0;
   animation: rise 720ms cubic-bezier(.2, .8, .2, 1) forwards;
@@ -1696,10 +1657,9 @@ body[data-app-state="manual"] #manual-mode {
 .steps > li:nth-child(1) { animation-delay: 540ms; }
 .steps > li:nth-child(2) { animation-delay: 640ms; }
 .steps > li:nth-child(3) { animation-delay: 740ms; }
-.drop             { animation-delay: 880ms; }
-#strava-connect,
-#strava-connected { animation-delay: 940ms; }
-.manual-mode      { animation-delay: 1000ms; }
+.drop              { animation-delay: 880ms; }
+#strava-data-source { animation-delay: 940ms; }
+.manual-mode       { animation-delay: 1000ms; }
 
 #results[data-revealed] {
   animation: rise 600ms cubic-bezier(.2, .8, .2, 1);
@@ -1711,7 +1671,7 @@ body[data-app-state="manual"] #manual-mode {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
-  .lede > *, .steps > li, .drop, #strava-connect, #strava-connected, .manual-mode { opacity: 1; }
+  .lede > *, .steps > li, .drop, #strava-data-source, .manual-mode { opacity: 1; }
 }
 
 /* RESPONSIVE */

--- a/src/app.js
+++ b/src/app.js
@@ -25,8 +25,7 @@ const dropZone = document.getElementById('archive-drop');
 const fileInput = document.getElementById('archive-input');
 const progressEl = document.getElementById('progress');
 const resultsEl = document.getElementById('results');
-const stravaConnectEl = document.getElementById('strava-connect');
-const stravaConnectedEl = document.getElementById('strava-connected');
+const stravaDataSourceEl = document.getElementById('strava-data-source');
 
 if (dropZone && fileInput) {
   dropZone.addEventListener('click', () => fileInput.click());
@@ -127,24 +126,41 @@ function showAuthToast(message, { error = false } = {}) {
 }
 
 async function refreshStravaUi() {
-  if (!stravaConnectEl || !stravaConnectedEl) return;
+  if (!stravaDataSourceEl) return;
   const session = await loadSession();
-  stravaConnectEl.hidden = !!session;
-  stravaConnectedEl.hidden = !session;
+  const statusEl = document.getElementById('strava-status-text');
+  const actionsEl = document.getElementById('strava-status-actions');
+  if (!statusEl || !actionsEl) return;
+  stravaDataSourceEl.hidden = false;
   if (session) {
-    const idEl = document.getElementById('strava-athlete-id');
-    if (idEl) idEl.textContent = session.athleteId;
+    statusEl.textContent = 'Connected.';
+    actionsEl.innerHTML = `
+      <button type="button" class="link-button" id="strava-sync-btn">Sync 180 days</button>
+      <button type="button" class="link-button" id="strava-disconnect">Disconnect</button>
+    `;
+    document.getElementById('strava-sync-btn').addEventListener('click', triggerStravaSync);
+    document.getElementById('strava-disconnect').addEventListener('click', handleDisconnect);
+  } else {
+    statusEl.textContent = 'Sync the last 180 days from your Strava account — no archive download required.';
+    actionsEl.innerHTML = `<button type="button" class="link-button" id="strava-connect-btn">Connect</button>`;
+    document.getElementById('strava-connect-btn').addEventListener('click', (e) => {
+      beginStravaConnect(e.currentTarget);
+    });
   }
 }
 
-document.getElementById('strava-connect-btn')?.addEventListener('click', (e) => {
-  beginStravaConnect(e.currentTarget);
-});
+async function handleDisconnect() {
+  if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
+  await clearSession();
+  currentSettings = (await loadSettings()) || {};
+  showAuthToast('Disconnected from Strava');
+  await refreshStravaUi();
+}
 
-// Click feedback for any Connect Strava button (onboarding card or
-// the data-state results-foot variant). The redirect itself is fast,
-// but Strava's authorize screen takes a beat to load — without the
-// flash of in-progress state it just feels like a stuck click.
+// Click feedback for any Connect Strava button. The redirect itself
+// is fast, but Strava's authorize screen takes a beat to load —
+// without the flash of in-progress state it just feels like a stuck
+// click.
 function beginStravaConnect(btn) {
   if (btn) {
     btn.disabled = true;
@@ -152,22 +168,8 @@ function beginStravaConnect(btn) {
     btn.dataset.originalText = btn.textContent;
     btn.textContent = 'Opening Strava…';
   }
-  // Tiny defer so the disabled + label change actually paints before
-  // the navigation tears the page down.
   setTimeout(() => window.location.assign(authorizeUrl('/')), 60);
 }
-
-document.getElementById('strava-disconnect')?.addEventListener('click', async () => {
-  if (!confirm('Disconnect this browser from Strava? You can reconnect anytime.')) return;
-  await clearSession();
-  // Re-hydrate currentSettings so the next render sees the cleared
-  // session keys; clearSession updates IDB but doesn't reach into the
-  // in-memory copy.
-  currentSettings = (await loadSettings()) || {};
-  await refreshStravaUi();
-});
-
-document.getElementById('strava-sync-btn')?.addEventListener('click', triggerStravaSync);
 
 // Single source of truth for the sync action. Drives the
 // /sync/recent loop, then pulls the resulting MMP records back out


### PR DESCRIPTION
## Summary
The Strava connect / connected cards on the onboarding screen used a different visual language from the data-screen colophon — bordered card, big ink button, athlete id splayed across the top. Unify on the same format the data screen already uses:

\`STRAVA   Connected.   SYNC 180 DAYS · DISCONNECT\`

…or…

\`STRAVA   Sync the last 180 days from your Strava account…   CONNECT\`

- One \`#strava-data-source\` element renders both states; JS swaps the status text + action buttons based on session.
- Athlete id removed — it wasn't earning its keep.
- New \`.data-sources--inline\` modifier strips the top border for the onboarding placement.
- All \`.strava-connect*\` / \`.strava-connected*\` / \`#strava-athlete-id\` CSS removed.
- Animation + state-hiding selectors updated to the new id.

## Test plan
- [ ] Onboarding without session: row reads STRAVA · 'Sync the last 180 days…' · CONNECT.
- [ ] After OAuth round-trip: row reads STRAVA · Connected. · SYNC 180 DAYS · DISCONNECT.
- [ ] Manual mode: same row stays visible at top alongside drop zone.
- [ ] Data state: row hidden (data-screen colophon already covers it).