### PR TITLE
Unify status messages into a floating top-of-page banner

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -327,87 +327,61 @@ main {
 /* Sync progress line. Editorial mono with oxblood numerals and a
    small pulsing leading mark so it reads as live, not stale. The
    marker runs only while the line is visible. */
-.sync-status {
-  margin: 0.75rem 0 0;
-  padding-left: 1.1rem;
-  position: relative;
-  font-family: var(--mono);
-  font-size: 0.8rem;
-  color: var(--ink-soft);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.02em;
-}
-.sync-status::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  width: 0.4rem;
-  height: 0.4rem;
-  border-radius: 50%;
-  background: var(--oxblood);
-  transform: translateY(-50%);
-  animation: sync-pulse 1400ms ease-in-out infinite;
-}
-@keyframes sync-pulse {
-  0%, 100% { opacity: 0.35; transform: translateY(-50%) scale(0.85); }
-  50%      { opacity: 1;    transform: translateY(-50%) scale(1.1); }
-}
-.sync-status[hidden] { display: none; }
-/* Persistent post-sync confirmation. Drops the pulse marker (sync is
-   over, not ongoing) and switches the bullet to a static check. */
-.sync-status.sync-status--done::before {
-  animation: none;
-  background: transparent;
-  width: 0.7rem;
-  height: 0.7rem;
-  top: 50%;
-  border: 0;
-  border-radius: 0;
-  content: '✓';
-  color: var(--oxblood);
-  font-family: var(--mono);
-  font-size: 0.7rem;
-  line-height: 1;
-  display: inline-block;
-  text-align: center;
-}
-/* Numeric counts inside the line lean oxblood for emphasis. We tag
-   them at write time with a span; falling back to plain ink if no
-   span is provided. */
-.sync-status em {
-  font-style: normal;
-  color: var(--oxblood);
-  font-weight: 500;
-}
-
-/* Auth toast: brief editorial banner that fades in after the OAuth
-   round-trip lands. Keeps the user oriented so the page rebuild
-   doesn't read as a generic reload. */
-.auth-toast {
+/* Floating status banner — single element shared by auth toasts,
+   sync progress, sync completion, errors. Fixed at top-center so the
+   message is visible regardless of page scroll. */
+.status-banner {
   position: fixed;
   top: 1.5rem;
   left: 50%;
-  transform: translate(-50%, -0.5rem);
+  transform: translate(-50%, -0.6rem);
+  padding: 0.7rem 1.2rem;
   background: var(--ink);
   color: var(--paper);
-  padding: 0.65rem 1.1rem;
   font-family: var(--mono);
   font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  box-shadow: 0 12px 32px rgba(26, 22, 18, 0.28);
+  box-shadow: 0 14px 36px rgba(26, 22, 18, 0.3);
   opacity: 0;
   transition: opacity 280ms ease, transform 280ms ease;
   z-index: 1000;
   pointer-events: none;
+  white-space: nowrap;
 }
-.auth-toast.is-visible {
+.status-banner.is-visible {
   opacity: 1;
   transform: translate(-50%, 0);
 }
-.auth-toast--error {
+.status-banner em {
+  font-style: normal;
+  color: var(--paper);
   background: var(--oxblood);
+  padding: 0.05rem 0.4rem;
+  margin: 0 0.2rem;
+}
+.status-banner--success { background: var(--ink); }
+.status-banner--error   { background: var(--oxblood); }
+.status-banner--progress {
+  background: var(--ink);
+  /* Subtle left-side mark that pulses while progress is live. */
+  padding-left: 2.1rem;
+}
+.status-banner--progress::before {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--oxblood);
+  transform: translateY(-50%);
+  animation: status-pulse 1400ms ease-in-out infinite;
+}
+@keyframes status-pulse {
+  0%, 100% { opacity: 0.45; transform: translate(0, -50%) scale(0.85); }
+  50%      { opacity: 1;    transform: translate(0, -50%) scale(1.15); }
 }
 .progress {
   margin: 1.25rem 0 0;
@@ -814,17 +788,10 @@ body[data-app-state="manual"] #manual-mode {
   align-items: baseline;
   gap: 1.1rem;
 }
-.data-sources .sync-status {
-  margin-top: 0.4rem;
-  margin-left: 6.5rem;
-}
 @media (max-width: 600px) {
   .data-sources__row {
     grid-template-columns: 1fr;
     row-gap: 0.25rem;
-  }
-  .data-sources .sync-status {
-    margin-left: 0;
   }
 }
 .results-foot--manual {

--- a/src/app.js
+++ b/src/app.js
@@ -107,22 +107,54 @@ async function consumeAuthHash() {
   }
 }
 
-// Brief overlay shown after a successful auth round-trip. Fades in,
-// dwells, fades out — gives the post-callback page rebuild a sense
-// of arrival instead of feeling like a stale reload.
-function showAuthToast(message, { error = false } = {}) {
-  const el = document.createElement('div');
-  el.className = `auth-toast${error ? ' auth-toast--error' : ''}`;
-  el.textContent = message;
-  document.body.appendChild(el);
-  // Force reflow so the .is-visible animation actually transitions.
+// Floating status banner anchored to the top of the page. One DOM
+// element, shared across:
+//   - auth toasts (transient, dismiss after 2.2 s)
+//   - sync progress (live-updating, persists until cleared)
+//   - sync completion (persists until next render)
+//   - errors (oxblood styling, persists until cleared)
+//
+// `kind` controls styling. `persistent: true` skips the auto-dismiss
+// timer so progress + completion stay visible. innerHTML accepted so
+// callers can wrap numerals in <em> for the oxblood numeric accent.
+let statusEl = null;
+let statusDismissTimer = null;
+function showStatus(html, { kind = 'info', persistent = false, dwellMs = 2200 } = {}) {
+  if (!statusEl) {
+    statusEl = document.createElement('div');
+    statusEl.className = 'status-banner';
+    document.body.appendChild(statusEl);
+  }
+  clearTimeout(statusDismissTimer);
+  statusEl.className = `status-banner status-banner--${kind}`;
+  statusEl.innerHTML = html;
+  // Force reflow so .is-visible always animates in cleanly even when
+  // we're re-using the element across rapid updates.
   // eslint-disable-next-line no-unused-expressions
-  el.offsetHeight;
-  el.classList.add('is-visible');
+  statusEl.offsetHeight;
+  statusEl.classList.add('is-visible');
+  if (!persistent) {
+    statusDismissTimer = setTimeout(() => clearStatus(), dwellMs);
+  }
+}
+function clearStatus() {
+  if (!statusEl) return;
+  clearTimeout(statusDismissTimer);
+  statusEl.classList.remove('is-visible');
+  // Match the CSS transition duration before pulling the element so
+  // the fade-out actually completes.
   setTimeout(() => {
-    el.classList.remove('is-visible');
-    setTimeout(() => el.remove(), 400);
-  }, 2200);
+    if (statusEl && !statusEl.classList.contains('is-visible')) {
+      statusEl.remove();
+      statusEl = null;
+    }
+  }, 320);
+}
+
+// Back-compat shim: showAuthToast still works, just routed through
+// the unified banner.
+function showAuthToast(message, { error = false } = {}) {
+  showStatus(message, { kind: error ? 'error' : 'success' });
 }
 
 async function refreshStravaUi() {
@@ -157,16 +189,17 @@ async function handleDisconnect() {
   await refreshStravaUi();
 }
 
-// Click feedback for any Connect Strava button. The redirect itself
-// is fast, but Strava's authorize screen takes a beat to load —
-// without the flash of in-progress state it just feels like a stuck
-// click.
+// Click feedback for any Connect Strava button. If Strava's session
+// cookie auto-approves the flow, the user never actually sees
+// Strava's UI — the redirect bounces back almost instantly. So the
+// label says 'Connecting' rather than 'Opening Strava' to be honest
+// in both cases.
 function beginStravaConnect(btn) {
   if (btn) {
     btn.disabled = true;
     btn.classList.add('is-loading');
     btn.dataset.originalText = btn.textContent;
-    btn.textContent = 'Opening Strava…';
+    btn.textContent = 'Connecting to Strava…';
   }
   setTimeout(() => window.location.assign(authorizeUrl('/')), 60);
 }
@@ -178,32 +211,11 @@ function beginStravaConnect(btn) {
 async function triggerStravaSync() {
   const session = await loadSession();
   if (!session) return;
-  // When the user has data on screen the global progress slot lives
-  // way up by the header, easy to miss. Prefer the inline status
-  // line we render next to the Sync button; fall back to the global
-  // slot only when there's no inline target (i.e. onboarding state).
-  const inline = document.getElementById('sync-status');
-  const setSync = (html) => {
-    if (inline) {
-      inline.hidden = false;
-      inline.innerHTML = html;
-    } else {
-      // Strip tags for the global progress slot — its CSS doesn't
-      // know about our <em> oxblood numerals and they'd render flat.
-      setProgress(html.replace(/<[^>]+>/g, ''));
-    }
-  };
-  const clearSync = () => {
-    if (inline) {
-      inline.textContent = '';
-      inline.hidden = true;
-    } else if (progressEl) {
-      progressEl.textContent = '';
-      progressEl.hidden = true;
-      progressEl.innerHTML = '';
-    }
-  };
-  setSync('Pulling activity list from Strava…');
+  // All sync messaging flows through the floating top-of-page status
+  // banner — visible regardless of scroll position and consistent
+  // with auth toasts / errors.
+  const setSync = (html) => showStatus(html, { kind: 'progress', persistent: true });
+  showStatus('Pulling activity list from Strava…', { kind: 'progress', persistent: true });
   try {
     // Tell the worker which Strava ids the IDB cache already has so it
     // skips them in the worklist — no point re-fetching streams the
@@ -223,7 +235,7 @@ async function triggerStravaSync() {
     setSync('Loading synced data…');
     const remoteActivities = await fetchSyncedActivities(session.session);
     if (remoteActivities.length === 0) {
-      setSync('No power-equipped rides in the synced window.');
+      showStatus('No power-equipped rides in the synced window.', { kind: 'success', dwellMs: 3500 });
       return;
     }
     const fresh = [];
@@ -233,23 +245,14 @@ async function triggerStravaSync() {
     if (fresh.length) await saveActivities(fresh);
     const all = await loadActivities();
     renderCurves(all);
-    // Persist a completion message in the freshly-rendered sync-status
-    // element. Stays put until the next render (override change,
-    // re-sync, etc.) or a page reload, so the user sees that the sync
-    // actually finished rather than the progress text just vanishing.
     const noun = fresh.length === 1 ? 'ride' : 'rides';
     const completion = fresh.length === 0
-      ? `Sync complete. No new rides — local cache already had everything in the synced window.`
-      : `Sync complete. <em>${fresh.length}</em> new ${noun} added to local cache.`;
-    const after = document.getElementById('sync-status');
-    if (after) {
-      after.hidden = false;
-      after.classList.add('sync-status--done');
-      after.innerHTML = completion;
-    }
+      ? `Sync complete · already had everything in the window`
+      : `Sync complete · <em>${fresh.length}</em> new ${noun} added`;
+    showStatus(completion, { kind: 'success', dwellMs: 3500 });
   } catch (err) {
     console.error('strava sync failed', err);
-    setSync(`Strava sync failed: ${err.message || err}`);
+    showStatus(`Strava sync failed: ${err.message || err}`, { kind: 'error', dwellMs: 5000 });
   }
 }
 
@@ -678,7 +681,6 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
                </span>`}
         </p>
       </section>
-      <p class="sync-status" id="sync-status" hidden></p>
     </aside>
     ${renderPredictBlock()}
   `;


### PR DESCRIPTION
## Summary
Inline sync-status under the data-foot + the auth toast at the top were two separate mechanisms with different styling and lifecycles. Collapse them into one floating banner anchored at the top of the viewport — visible regardless of scroll, consistent for every status moment.

\`\`\`js
showStatus(html, { kind: 'info' | 'success' | 'error' | 'progress', persistent, dwellMs });
\`\`\`

- **info / success**: ink background, paper text, mono uppercase. Auto-dismisses (default 2.2 s).
- **error**: oxblood background.
- **progress**: ink with a pulsing oxblood dot on the left, persistent.
- Numerals wrap in \`<em>\` for an oxblood pill treatment so '<em>17</em> remaining' pops.

Migrations: auth toast, sync progress, completion, error, all routed through it. Inline \`.sync-status\` element + styles deleted.

Also fixes the misleading 'Opening Strava…' label — now reads 'Connecting to Strava…' since cookie auto-approval may skip Strava's UI entirely.

## Test plan
- [ ] Connect Strava → button reads 'Connecting to Strava…' with dots.
- [ ] Land back from OAuth → top banner shows 'Connected to Strava' for ~2 s.
- [ ] Click Sync → banner shows progress count with pulsing dot.
- [ ] Sync done → banner flips to success, dwells ~3.5 s, fades.
- [ ] Disconnect → banner shows 'Disconnected from Strava'.