### PR TITLE
Connect status in the toast + fix double dots on the button

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -193,14 +193,16 @@ async function handleDisconnect() {
 // cookie auto-approves the flow, the user never actually sees
 // Strava's UI — the redirect bounces back almost instantly. So the
 // label says 'Connecting' rather than 'Opening Strava' to be honest
-// in both cases.
+// in both cases. Also surface the same message in the floating top
+// banner so the status reads consistently with sync / disconnect.
 function beginStravaConnect(btn) {
   if (btn) {
     btn.disabled = true;
     btn.classList.add('is-loading');
     btn.dataset.originalText = btn.textContent;
-    btn.textContent = 'Connecting to Strava…';
+    btn.textContent = 'Connecting to Strava ';
   }
+  showStatus('Connecting to Strava', { kind: 'progress', persistent: true });
   setTimeout(() => window.location.assign(authorizeUrl('/')), 60);
 }
 


### PR DESCRIPTION
## Summary
Two adjustments noticed during live testing.

- **Double dots** on the Connect button: JS was setting 'Connecting to Strava…' (literal ellipsis) while the .is-loading::after CSS already animated a · / ·· / ··· sequence. Drop the literal ellipsis; the animation is the only dots.
- **Toast consistency**: also surface the 'Connecting to Strava' state in the floating banner so it reads the same as sync / auth / disconnect. Persistent kind, progress-style with the pulsing oxblood dot. Lives until the navigation tears the page down.

## Test plan
- [ ] Click Connect — button reads 'Connecting to Strava' with a single animated dot sequence (no double).
- [ ] Floating banner appears with the same message + pulsing dot.