### PR TITLE
Drop 'another' from the Upload archive label

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -663,7 +663,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
         <p class="data-sources__line">
           <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached.</span>
           <span class="data-sources__actions">
-            <button type="button" class="link-button" id="upload-another">Upload another</button>
+            <button type="button" class="link-button" id="upload-another">Upload archive</button>
             <button type="button" class="link-button" id="clear-cache">Clear cache</button>
           </span>
         </p>


### PR DESCRIPTION
## Summary
'Upload another' assumed prior archive upload. With Strava sync as a peer ingest path, a user can have cached data without ever having uploaded an archive — the 'another' reads false. Use 'Upload archive' across the board.

## Test plan
- [ ] Data-screen colophon Archive row reads 'Upload archive' instead of 'Upload another'.