### PR TITLE
Fix scope error on chart's All-time tab label

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1299,7 +1299,7 @@ function renderPredictBlock() {
             : `<div class="curve-window-tabs" role="tablist">
                 <button type="button" data-window="last30" role="tab">Last 30d</button>
                 <button type="button" data-window="last90" role="tab" class="is-active">Last 90d</button>
-                <button type="button" data-window="allTime" role="tab">${allTimeLabel(activityMmps)}</button>
+                <button type="button" data-window="allTime" role="tab">${allTimeLabel(currentActivities)}</button>
               </div>`
           }
         </header>


### PR DESCRIPTION
## Summary
\`renderPredictBlock\` referenced \`activityMmps\` for the All-time chart tab, but that parameter only lives in \`renderCurves\`. Use \`currentActivities\` (module-scoped, populated by \`renderCurves\` before calling \`renderPredictBlock\`).

\`Cu @ app.min.js:3 — cache hydrate failed ReferenceError: activityMmps is not defined\`

## Test plan
- [ ] Page hydrates without console error.
- [ ] Chart tab shows 'All-time' or 'Since [Mon YYYY]'.