### PR TITLE
Even MMP columns + drop double hairline + quieter connect button

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -451,12 +451,24 @@ main {
 
 .mmp-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   font-family: var(--mono);
   font-size: 0.92rem;
   font-variant-numeric: tabular-nums;
   margin-top: 0.5rem;
 }
+/* Fixed layout + nth-child widths so the three data columns stay
+   evenly distributed regardless of header label length (e.g. the
+   dynamic 'Since Mon YYYY' wider than 'All-time'). */
+.mmp-table th:nth-child(1),
+.mmp-table td:nth-child(1) { width: 8rem; }
+.mmp-table th:nth-child(2),
+.mmp-table td:nth-child(2),
+.mmp-table th:nth-child(3),
+.mmp-table td:nth-child(3),
+.mmp-table th:nth-child(4),
+.mmp-table td:nth-child(4) { width: calc((100% - 8rem) / 3); }
 .mmp-table th,
 .mmp-table td {
   padding: 0.6rem 1rem;
@@ -745,9 +757,10 @@ body[data-app-state="manual"] #manual-mode {
    no animations, no department marks — utility row, not magazine
    spread. */
 .data-sources {
-  margin-top: 1.75rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--hair);
+  /* The table already ends in its own hairline border-bottom, so we
+     skip the border-top here to avoid two parallel rules. */
+  margin-top: 1.5rem;
+  padding-top: 0;
   display: grid;
   row-gap: 0.55rem;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -196,11 +196,12 @@ async function handleDisconnect() {
 // in both cases. Also surface the same message in the floating top
 // banner so the status reads consistently with sync / disconnect.
 function beginStravaConnect(btn) {
+  // The status banner carries the 'Connecting to Strava' message;
+  // the button just dims + adds an animated ellipsis via .is-loading.
+  // Avoids saying the same thing in two places.
   if (btn) {
     btn.disabled = true;
     btn.classList.add('is-loading');
-    btn.dataset.originalText = btn.textContent;
-    btn.textContent = 'Connecting to Strava ';
   }
   showStatus('Connecting to Strava', { kind: 'progress', persistent: true });
   setTimeout(() => window.location.assign(authorizeUrl('/')), 60);


### PR DESCRIPTION
## Summary
Three quick fixes from screenshot feedback:

- **MMP columns weren't evenly distributed** because 'Since Nov 2025' was wider than 'All-time'. \`table-layout: fixed\` + explicit per-column widths via nth-child so all three data columns are equal regardless of header length.
- **Double hairline** above the data-sources block. The table already ends in its own hairline border-bottom; the data-sources block was adding another. Drop the border-top.
- **Connect button text + toast were saying the same thing**. Button now stays at its original label; status banner is the single source of 'Connecting to Strava'. Button just disables + animates dots.

## Test plan
- [ ] MMP columns visually evenly distributed.
- [ ] One hairline between table and ARCHIVE row, not two.
- [ ] Click Connect — button label unchanged, dims with animated dots, toast appears at top.