### PR TITLE
Drop athlete id from the connect toast

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -103,7 +103,7 @@ async function consumeAuthHash() {
   }
   if (parsed.session && parsed.athleteId) {
     await saveSession({ session: parsed.session, athleteId: parsed.athleteId });
-    showAuthToast(`Connected to Strava · athlete ${parsed.athleteId}`);
+    showAuthToast('Connected to Strava');
   }
 }
 


### PR DESCRIPTION
Toast now reads just 'Connected to Strava' — the id wasn't earning its keep, same way it's been removed from the data-source row and elsewhere.