### PR TITLE
Restore the pulsing dot on progress toasts

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -350,7 +350,29 @@ main {
 }
 .status-banner--success  { background: var(--ink); }
 .status-banner--error    { background: var(--oxblood); }
-.status-banner--progress { background: var(--ink); }
+.status-banner--progress {
+  background: var(--ink);
+  /* Pulsing oxblood dot reads as 'still working' so the user knows
+     the toast isn't a final state. Only progress kind gets the
+     decoration; success / error are terminal and stay plain. */
+  padding-left: 2.1rem;
+}
+.status-banner--progress::before {
+  content: '';
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--oxblood);
+  transform: translate(0, -50%);
+  animation: status-pulse 1400ms ease-in-out infinite;
+}
+@keyframes status-pulse {
+  0%, 100% { opacity: 0.45; transform: translate(0, -50%) scale(0.85); }
+  50%      { opacity: 1;    transform: translate(0, -50%) scale(1.15); }
+}
 .progress {
   margin: 1.25rem 0 0;
   display: flex;


### PR DESCRIPTION
## Summary
Reverts the part of the prior PR that stripped the dot. The pulse on progress kinds reads as 'still working' and helps differentiate in-progress states from terminal ones (auth toast, sync complete, error). Success and error remain plain.

## Test plan
- [ ] Connecting / syncing show pulsing oxblood dot on the left.
- [ ] Auth / sync-complete / error stay plain.