### PR TITLE
Show 'Cache cleared' as a toast

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1375,7 +1375,7 @@ async function handleClearCache() {
   resultsEl.innerHTML = '';
   currentActivities = [];
   setAppState('onboarding');
-  setProgress(`Cache cleared. ${await activityCount()} activities remaining.`);
+  showStatus('Cache cleared', { kind: 'success', dwellMs: 2200 });
 }
 
 function setProgress(msg) {


### PR DESCRIPTION
Routes the cache-clear confirmation through the floating status banner instead of the legacy progress slot. Drops the trailing 'N activities remaining' detail since the count is always 0 right after a clear.