### PR TITLE
Rename Archive row label to Local

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -659,7 +659,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     </table>
     <aside class="data-sources" aria-label="Data sources">
       <section class="data-sources__row">
-        <span class="data-sources__label">Archive</span>
+        <span class="data-sources__label">Local</span>
         <p class="data-sources__line">
           <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached · ${latestActivityLabel(activityMmps)}</span>
           <span class="data-sources__actions">


### PR DESCRIPTION
Avoids overloading 'archive' (the data-sources row) with 'archive' (the literal Strava zip the Upload button consumes). 'Local' accurately reflects what's in the row regardless of source — uploads AND sync — and contrasts cleanly with the remote Strava row.