### PR TITLE
Data-sources: numbered labels + status/actions split

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -743,29 +743,39 @@ body[data-app-state="manual"] #manual-mode {
   row-gap: 0.55rem;
 }
 .data-sources__row {
+  /* Three columns now: the numbered label, the journalistic status,
+     and the action-verb apparatus pushed to the right edge so the
+     eye gets a clean status | actions split instead of one mixed
+     line. */
   display: grid;
-  grid-template-columns: 5.5rem 1fr;
+  grid-template-columns: 7rem 1fr auto;
   align-items: baseline;
-  column-gap: 1rem;
+  column-gap: 1.4rem;
 }
 .data-sources__label {
   font-family: var(--mono);
-  font-size: 0.7rem;
+  font-size: 0.72rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.data-sources__label-num {
+  color: var(--ink-soft);
+  margin-right: 0.45rem;
+}
+.data-sources__label-sep {
+  color: var(--hair-strong);
+  margin-right: 0.45rem;
 }
 .data-sources__line {
   margin: 0;
   font-family: var(--serif);
   font-style: italic;
-  font-size: 0.95rem;
+  font-size: 0.98rem;
   line-height: 1.5;
   color: var(--ink-soft);
   font-variation-settings: "opsz" 24;
-}
-.data-sources__status {
-  margin-right: 0.8rem;
 }
 .data-sources__status em {
   font-style: normal;
@@ -777,12 +787,23 @@ body[data-app-state="manual"] #manual-mode {
 .data-sources__actions {
   display: inline-flex;
   align-items: baseline;
-  gap: 1.1rem;
+  gap: 1rem;
+  /* Quieter than the status by default; oxblood on hover (handled
+     by the .link-button base style). */
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
-@media (max-width: 600px) {
+.data-sources__actions .link-button {
+  color: var(--ink-soft);
+}
+@media (max-width: 720px) {
   .data-sources__row {
     grid-template-columns: 1fr;
-    row-gap: 0.25rem;
+    row-gap: 0.4rem;
+  }
+  .data-sources__actions {
+    justify-content: flex-start;
   }
 }
 .results-foot--manual {

--- a/src/app.js
+++ b/src/app.js
@@ -659,29 +659,29 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     </table>
     <aside class="data-sources" aria-label="Data sources">
       <section class="data-sources__row">
-        <span class="data-sources__label">Local</span>
-        <p class="data-sources__line">
-          <span class="data-sources__status">${activityMmps.length.toLocaleString()} activities cached · ${latestActivityLabel(activityMmps)}</span>
-          <span class="data-sources__actions">
-            <button type="button" class="link-button" id="upload-another">Upload archive</button>
-            <button type="button" class="link-button" id="clear-cache">Clear cache</button>
-          </span>
-        </p>
+        <span class="data-sources__label">
+          <span class="data-sources__label-num">01</span><span class="data-sources__label-sep">/</span>Local
+        </span>
+        <p class="data-sources__line data-sources__status">${activityMmps.length.toLocaleString()} activities cached · ${latestActivityLabel(activityMmps)}</p>
+        <span class="data-sources__actions">
+          <button type="button" class="link-button" id="upload-another">Upload archive</button>
+          <button type="button" class="link-button" id="clear-cache">Clear cache</button>
+        </span>
       </section>
       <section class="data-sources__row">
-        <span class="data-sources__label">Strava</span>
-        <p class="data-sources__line">
-          ${currentSettings.stravaSession
-            ? `<span class="data-sources__status">Connected.</span>
-               <span class="data-sources__actions">
-                 <button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
-                 <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>
-               </span>`
-            : `<span class="data-sources__status">Sync the last 180 days from your Strava account — no archive download required.</span>
-               <span class="data-sources__actions">
-                 <button type="button" class="link-button" id="results-foot-connect">Connect</button>
-               </span>`}
-        </p>
+        <span class="data-sources__label">
+          <span class="data-sources__label-num">02</span><span class="data-sources__label-sep">/</span>Strava
+        </span>
+        ${currentSettings.stravaSession
+          ? `<p class="data-sources__line data-sources__status">Connected.</p>
+             <span class="data-sources__actions">
+               <button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
+               <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>
+             </span>`
+          : `<p class="data-sources__line data-sources__status">Sync the last 180 days from your Strava account — no archive download required.</p>
+             <span class="data-sources__actions">
+               <button type="button" class="link-button" id="results-foot-connect">Connect</button>
+             </span>`}
       </section>
     </aside>
     ${renderPredictBlock()}


### PR DESCRIPTION
## Summary
The data-sources rows had status + actions on the same line with similar weight, so the eye couldn't cleanly read 'fact / verb.' Two refinements:

- **Number the labels** ('01 / LOCAL', '02 / STRAVA') to mirror the onboarding steps. Anchors the floating mono caps in the same editorial rhythm as '01 / Request', '02 / Drop'.
- **Split status from actions**. Three-column grid: numbered label · italic status sentence · actions pushed to the right edge. Status reads as the headline of each row; actions read as a quiet apparatus (smaller mono caps, ink-soft, oxblood on hover).

Mobile breakpoint moves to 720 px and stacks the three pieces vertically.

## Test plan
- [ ] Both rows show numbered labels with '/' separator.
- [ ] Status sentence sits to the right of the label; actions push to the right edge.
- [ ] Hover an action — color lifts oxblood.
- [ ] At narrow widths, label/status/actions stack vertically.