### PR TITLE
Drop numbered labels for an em-dash dateline leader

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -743,41 +743,40 @@ body[data-app-state="manual"] #manual-mode {
   row-gap: 0.55rem;
 }
 .data-sources__row {
-  /* Three columns now: the numbered label, the journalistic status,
-     and the action-verb apparatus pushed to the right edge so the
-     eye gets a clean status | actions split instead of one mixed
-     line. */
+  /* Two-column grid: the journalistic status sentence on the left
+     (with an oxblood em-dash leader as a small editorial flourish)
+     and the action-verb apparatus pushed to the right edge. */
   display: grid;
-  grid-template-columns: 7rem 1fr auto;
+  grid-template-columns: 1fr auto;
   align-items: baseline;
-  column-gap: 1.4rem;
-}
-.data-sources__label {
-  font-family: var(--mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-}
-.data-sources__label-num {
-  color: var(--ink-soft);
-  margin-right: 0.45rem;
-}
-.data-sources__label-sep {
-  color: var(--hair-strong);
-  margin-right: 0.45rem;
+  column-gap: 1.6rem;
 }
 .data-sources__line {
   margin: 0;
   font-family: var(--serif);
   font-style: italic;
-  font-size: 0.98rem;
+  font-size: 1rem;
   line-height: 1.5;
   color: var(--ink-soft);
   font-variation-settings: "opsz" 24;
+  position: relative;
+  padding-left: 1.4rem;
 }
-.data-sources__status em {
+/* Editorial dateline em-dash. Earns its keep as a single typographic
+   mark anchoring each row — the kind of leading flourish you'd see
+   at the top of a magazine column or under a pull quote. */
+.data-sources__line::before {
+  content: '\2014';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--oxblood);
+  font-style: normal;
+  font-weight: 500;
+  font-family: var(--serif);
+  font-variation-settings: "opsz" 24;
+}
+.data-sources__line em {
   font-style: normal;
   font-family: var(--mono);
   font-size: 0.88em;
@@ -788,8 +787,6 @@ body[data-app-state="manual"] #manual-mode {
   display: inline-flex;
   align-items: baseline;
   gap: 1rem;
-  /* Quieter than the status by default; oxblood on hover (handled
-     by the .link-button base style). */
   font-size: 0.72rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -800,10 +797,11 @@ body[data-app-state="manual"] #manual-mode {
 @media (max-width: 720px) {
   .data-sources__row {
     grid-template-columns: 1fr;
-    row-gap: 0.4rem;
+    row-gap: 0.45rem;
   }
   .data-sources__actions {
     justify-content: flex-start;
+    padding-left: 1.4rem; /* align with the post-em-dash text above */
   }
 }
 .results-foot--manual {

--- a/src/app.js
+++ b/src/app.js
@@ -659,26 +659,20 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     </table>
     <aside class="data-sources" aria-label="Data sources">
       <section class="data-sources__row">
-        <span class="data-sources__label">
-          <span class="data-sources__label-num">01</span><span class="data-sources__label-sep">/</span>Local
-        </span>
-        <p class="data-sources__line data-sources__status">${activityMmps.length.toLocaleString()} activities cached · ${latestActivityLabel(activityMmps)}</p>
+        <p class="data-sources__line">${activityMmps.length.toLocaleString()} activities cached locally · ${latestActivityLabel(activityMmps)}</p>
         <span class="data-sources__actions">
           <button type="button" class="link-button" id="upload-another">Upload archive</button>
           <button type="button" class="link-button" id="clear-cache">Clear cache</button>
         </span>
       </section>
       <section class="data-sources__row">
-        <span class="data-sources__label">
-          <span class="data-sources__label-num">02</span><span class="data-sources__label-sep">/</span>Strava
-        </span>
         ${currentSettings.stravaSession
-          ? `<p class="data-sources__line data-sources__status">Connected.</p>
+          ? `<p class="data-sources__line">Connected to Strava.</p>
              <span class="data-sources__actions">
                <button type="button" class="link-button" id="results-foot-sync">Sync 180 days</button>
                <button type="button" class="link-button" id="results-foot-disconnect">Disconnect</button>
              </span>`
-          : `<p class="data-sources__line data-sources__status">Sync the last 180 days from your Strava account — no archive download required.</p>
+          : `<p class="data-sources__line">Sync the last 180 days from Strava — no archive download required.</p>
              <span class="data-sources__actions">
                <button type="button" class="link-button" id="results-foot-connect">Connect</button>
              </span>`}


### PR DESCRIPTION
## Summary
Replaces the '01 / LOCAL' / '02 / STRAVA' labels with a single typographic mark — a leading oxblood em-dash on each row. Reads as an editorial dateline / pull-quote leader. The status sentences absorb the category in plain prose:

— **3,006 activities cached locally · last ride yesterday**          UPLOAD ARCHIVE · CLEAR CACHE
— **Connected to Strava.**                                            SYNC 180 DAYS · DISCONNECT

Or when not connected:

— Sync the last 180 days from Strava — no archive download required.   CONNECT

Right-aligned action verbs stay (you confirmed those work). Mobile breakpoint stacks the apparatus under the prose but keeps the em-dash anchor.

## Test plan
- [ ] Each row begins with an oxblood em-dash; no LOCAL / STRAVA labels.
- [ ] Status sentence reads naturally with the category embedded.
- [ ] Action links still right-aligned, oxblood on hover.
- [ ] Mobile: rows stack with em-dash leader and indented action group.