### PR TITLE
Fix mobile overflow of floating status banner [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -336,6 +336,23 @@ main {
   z-index: 1000;
   pointer-events: none;
   white-space: nowrap;
+  max-width: calc(100vw - 2rem);
+}
+@media (max-width: 480px) {
+  .status-banner {
+    top: 0;
+    left: 0;
+    right: 0;
+    max-width: none;
+    white-space: normal;
+    text-align: center;
+    line-height: 1.4;
+    transform: translate(0, -0.4rem);
+    box-shadow: 0 6px 18px rgba(26, 22, 18, 0.25);
+  }
+  .status-banner.is-visible {
+    transform: translate(0, 0);
+  }
 }
 .status-banner.is-visible {
   opacity: 1;


### PR DESCRIPTION
## Summary
- Floating status banner had `white-space: nowrap` with no max-width, so longer messages rendered wider than narrow viewports (eg 481px wide on a 375px screen).
- Cap `max-width: calc(100vw - 2rem)` on all viewports.
- On viewports ≤480px, pin the toast to the top edge edge-to-edge with allowed wrapping, so multi-line messages stay readable and don't get clipped to a 50%-width sliver caused by `left:50%` + auto-width.

## Test plan
- [ ] Verify desktop banner is unchanged (centered, single-line).
- [ ] Verify on a 375px viewport: validation toast renders full-width across the top, wraps gracefully, no horizontal overflow.