### PR TITLE
Reflow fit-stats grid to 2 columns on narrow viewports [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1497,9 +1497,13 @@ body[data-app-state="manual"] #manual-mode {
 }
 
 @media (max-width: 720px) {
-  .fit-stats { grid-template-columns: repeat(2, 1fr); }
+  .fit-stats {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .fit-stats > div { border-right: var(--rule-soft); }
   .fit-stats > div:nth-child(2n) { border-right: none; }
-  .fit-stats > div:nth-child(-n+2) { border-bottom: var(--rule-soft); }
+  .fit-stats > div:nth-child(n+3) { border-top: var(--rule-soft); }
 }
 
 /* ARTICLE PAGES */


### PR DESCRIPTION
## Summary
- The `@media (max-width: 720px)` rule set `grid-template-columns: repeat(2, 1fr)` but didn't reset `grid-auto-flow: column` from the desktop rule, so the six stat cells (CP / W' / eFTP / Form / Fatigue k / Fit) kept flowing column-first into one cramped row at 375px.
- Reset `grid-auto-flow: row`, re-apply right borders on odd-index cells (so column rules show between pairs), and add `border-top` on cells from the second row down so the 2x3 grid reads cleanly.

## Test plan
- [ ] Verify desktop fit-stats still renders as a single horizontal row of 6 cells.
- [ ] At 375px, confirm fit-stats lays out as a 2 column x 3 row grid with crisp internal rules and readable label/value pairs.