### PR TITLE
Reach Lighthouse a11y 100 [skip_ci]

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,22 +34,22 @@
     <ol class="steps" aria-label="How it works">
       <li>
         <span class="step-num">01 / Request</span>
-        <h3>Ask Strava for your archive</h3>
+        <h2>Ask Strava for your archive</h2>
         <p>They prepare it offline and email a link within hours. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
       </li>
       <li>
         <span class="step-num">02 / Drop</span>
-        <h3>Drag the zip onto the page</h3>
+        <h2>Drag the zip onto the page</h2>
         <p>Parsed in your browser. Raw streams never leave your machine.</p>
       </li>
       <li>
         <span class="step-num">03 / Read</span>
-        <h3>See your power-duration curve</h3>
+        <h2>See your power-duration curve</h2>
         <p>Connect Strava later so new rides flow in automatically.</p>
       </li>
     </ol>
 
-    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Upload Strava archive">
+    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your archive">
       <input type="file" id="archive-input" accept=".zip" hidden>
       <span class="drop__label">Drop your archive</span>
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>

--- a/shared.css
+++ b/shared.css
@@ -11,12 +11,12 @@
   --paper-deep:   #e3d9c1;
   --ink:          #1a1612;
   --ink-soft:     #34291f;
-  --muted:        #7a6f60;
+  --muted:        #6b6052;
   --hair:         rgba(26, 22, 18, 0.16);
   --hair-strong:  rgba(26, 22, 18, 0.32);
   --oxblood:      #7a1f24;
   --oxblood-deep: #5e161a;
-  --burnt:        #c14a1a;
+  --burnt:        #a83c14;
 
   /* Type system */
   --serif: 'Fraunces', 'Iowan Old Style', Georgia, serif;
@@ -213,7 +213,7 @@ main {
   display: block;
   margin-bottom: 0.65rem;
 }
-.steps h3 {
+.steps h2 {
   font-family: var(--serif);
   font-weight: 500;
   font-size: 1.18rem;

--- a/src/app.js
+++ b/src/app.js
@@ -1159,13 +1159,11 @@ function renderManualMode(fit, inputs = {}) {
       <dl class="fit-stats" id="manual-fit-stats">
         <div data-tooltip="Critical Power synthesized from the FTP you entered. CP ≈ 0.95 × FTP.">
           <dt>CP</dt>
-          <dd id="manual-cp">${formatPower(fit.cpW)}</dd>
-          <span class="fit-stats__quality is-mid">manual</span>
+          <dd id="manual-cp">${formatPower(fit.cpW)}<span class="fit-stats__quality is-mid">manual</span></dd>
         </div>
         <div data-tooltip="Anaerobic work capacity. Derived from your 1-minute sprint number when given, otherwise defaulted to 18 kJ.">
           <dt>W'</dt>
-          <dd id="manual-wprime">${(fit.wPrimeJ / 1000).toFixed(1)} kJ</dd>
-          <span class="fit-stats__quality is-mid">manual</span>
+          <dd id="manual-wprime">${(fit.wPrimeJ / 1000).toFixed(1)} kJ<span class="fit-stats__quality is-mid">manual</span></dd>
         </div>
       </dl>
 
@@ -1283,35 +1281,29 @@ function renderPredictBlock() {
       <dl class="fit-stats">
         <div data-tooltip="${cpTooltip(currentFit)}">
           <dt>CP${currentFit.overridden ? ' *' : ''}</dt>
-          <dd>${formatPower(currentFit.cpW)}</dd>
-          <span class="fit-stats__quality ${cpQuality(currentFit).cls}">${cpQuality(currentFit).label}</span>
+          <dd>${formatPower(currentFit.cpW)}<span class="fit-stats__quality ${cpQuality(currentFit).cls}">${cpQuality(currentFit).label}</span></dd>
         </div>
         <div data-tooltip="${wPrimeTooltip(currentFit.wPrimeJ)}">
           <dt>W'</dt>
-          <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ</dd>
-          <span class="fit-stats__quality ${wPrimeQuality(currentFit.wPrimeJ).cls}">${wPrimeQuality(currentFit.wPrimeJ).label}</span>
+          <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ<span class="fit-stats__quality ${wPrimeQuality(currentFit.wPrimeJ).cls}">${wPrimeQuality(currentFit.wPrimeJ).label}</span></dd>
         </div>
         ${currentEftpNow ? `
         <div data-tooltip="${eftpTooltip()}">
           <dt>eFTP</dt>
-          <dd>${formatPower(currentEftpNow)}</dd>
-          <span class="fit-stats__quality is-good">${eftpWindowLabel()}</span>
+          <dd>${formatPower(currentEftpNow)}<span class="fit-stats__quality is-good">${eftpWindowLabel()}</span></dd>
         </div>` : ''}
         ${currentLoad.hasFtp ? `
         <div data-tooltip="${formTooltip()}">
           <dt>Form</dt>
-          <dd>${formatTsb(currentLoad.tsb)}</dd>
-          <span class="fit-stats__quality ${formQuality().cls}">${formQuality().label}</span>
+          <dd>${formatTsb(currentLoad.tsb)}<span class="fit-stats__quality ${formQuality().cls}">${formQuality().label}</span></dd>
         </div>` : ''}
         <div data-tooltip="${fatigueTooltip(currentFit)}">
           <dt>Fatigue k</dt>
-          <dd>${fatigueValue(currentFit)}</dd>
-          <span class="fit-stats__quality ${fatigueQuality(currentFit).cls}">${fatigueQuality(currentFit).label}</span>
+          <dd>${fatigueValue(currentFit)}<span class="fit-stats__quality ${fatigueQuality(currentFit).cls}">${fatigueQuality(currentFit).label}</span></dd>
         </div>
         <div data-tooltip="${combinedFitTooltip(currentFit)}">
           <dt>Fit</dt>
-          <dd>${currentFit.rmse.toFixed(1)}W · ${currentFit.nPoints}pt</dd>
-          <span class="fit-stats__quality ${combinedFitQuality(currentFit).cls}">${combinedFitQuality(currentFit).label}</span>
+          <dd>${currentFit.rmse.toFixed(1)}W · ${currentFit.nPoints}pt<span class="fit-stats__quality ${combinedFitQuality(currentFit).cls}">${combinedFitQuality(currentFit).label}</span></dd>
         </div>
       </dl>
 


### PR DESCRIPTION
## Summary
- Lighthouse a11y was 95 with three failures. This brings it to 100.
- **Color contrast**: darken \`--muted\` and \`--burnt\` so step-card body text, footer, drop-zone hint, and \"is-mid\" fit-stats labels all clear 4.5:1 on cream and paper-soft.
- **Heading order**: step cards were h3, jumping from the h1 headline. Promote to h2 so the outline reads h1 → h2 → h2.
- **Label/name match**: drop zone had \`aria-label=\"Upload Strava archive\"\` while the visible heading is \"Drop your archive\". Align the aria-label to the visible text.
- **DL content model**: fit-stats quality spans were direct children of the wrapper div alongside dt/dd. Move the spans inside dd so each group is just dt + dd.

## Test plan
- [ ] Lighthouse a11y reports 100.
- [ ] Visually verify cream-on-cream muted text is still legibly subtle, not heavy.
- [ ] Confirm fit-stats grid still reads with a value above and quality label below in each cell.