### PR TITLE
Clarify that curve window tabs are display-only [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -887,6 +887,14 @@ body[data-app-state="manual"] #manual-mode {
   color: var(--oxblood);
   letter-spacing: 0.04em;
 }
+.curve-chart-note {
+  margin: 0 0 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+}
 
 .curve-window-tabs {
   display: inline-flex;

--- a/src/app.js
+++ b/src/app.js
@@ -1093,10 +1093,14 @@ function wireCurveChart() {
   const container = document.getElementById('curve-chart');
   if (!container || !currentFit) return;
   const tabs = document.querySelectorAll('[data-window]');
+  const fitWindowLabel = (currentSettings.dateFrom || currentSettings.dateTo)
+    ? 'custom range'
+    : 'last 90 days';
   const draw = (key) => {
     renderCurveChart(container, {
       mmp: currentMmpByWindow[key] || {},
       fit: currentFit,
+      fitWindowLabel,
     });
     tabs.forEach((t) => t.classList.toggle('is-active', t.dataset.window === key));
   };
@@ -1325,6 +1329,7 @@ function renderPredictBlock() {
               </div>`
           }
         </header>
+        <p class="curve-chart-note">Display window only · prediction uses the fit above</p>
         <div id="curve-chart" class="curve-chart"></div>
       </div>
 

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -36,7 +36,7 @@ const STANDARD_TICKS = [
   86400,                   // 24h
 ];
 
-export function renderCurveChart(container, { mmp, fit }) {
+export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 90 days' }) {
   if (!container) return;
   container.innerHTML = '';
   if (!fit) {
@@ -146,7 +146,7 @@ export function renderCurveChart(container, { mmp, fit }) {
         value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
       },
       {
-        label: 'CP fit (3-20 min)',
+        label: `CP fit · ${fitWindowLabel}`,
         stroke: ink,
         width: 1.5,
         points: { show: false },


### PR DESCRIPTION
## Summary
The Last 30d / Last 90d / Since … tabs above the chart looked like they could drive the prediction, but they only re-window the plotted MMP dots. The fit (and therefore Predict) stays locked to the 90-day effort-filtered window unless a custom range is set in the override.

- Mono-caps note under the tabs: \"Display window only · prediction uses the fit above\".
- Legend label renamed from \"CP fit (3-20 min)\" to \"CP fit · last 90 days\" (or \"custom range\" when an override is active), so the fit window is named on the chart itself.

## Test plan
- [ ] Default state: curve header reads \"Display window only ...\" and the legend says \"CP fit · last 90 days\".
- [ ] With a custom range set in the override panel, the legend says \"CP fit · custom range\".
- [ ] Tab switching still re-renders only the dots, not the fit line.