### PR TITLE
Move 'display only' clarification into a tooltip [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -887,13 +887,40 @@ body[data-app-state="manual"] #manual-mode {
   color: var(--oxblood);
   letter-spacing: 0.04em;
 }
-.curve-chart-note {
-  margin: 0 0 0.75rem;
-  font-family: var(--mono);
-  font-size: 0.66rem;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  color: var(--muted);
+.curve-window-tabs[data-tooltip] {
+  position: relative;
+  cursor: help;
+}
+.curve-window-tabs[data-tooltip]:hover::after,
+.curve-window-tabs[data-tooltip]:focus-within::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  max-width: 22rem;
+  z-index: 10;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0.55rem 0.7rem;
+  box-shadow: 0 6px 16px rgba(26, 22, 18, 0.18);
+  white-space: normal;
+  pointer-events: none;
+}
+.curve-window-tabs[data-tooltip]:hover::before,
+.curve-window-tabs[data-tooltip]:focus-within::before {
+  content: "";
+  position: absolute;
+  top: 100%;
+  right: 1.2rem;
+  border: 5px solid transparent;
+  border-bottom-color: var(--ink);
+  z-index: 11;
 }
 
 .curve-window-tabs {

--- a/src/app.js
+++ b/src/app.js
@@ -1322,14 +1322,13 @@ function renderPredictBlock() {
           <span class="curve-chart-title">Power-duration curve</span>
           ${(currentSettings.dateFrom || currentSettings.dateTo)
             ? `<span class="curve-range-label">Range: ${currentSettings.dateFrom || '…'} → ${currentSettings.dateTo || '…'}</span>`
-            : `<div class="curve-window-tabs" role="tablist">
+            : `<div class="curve-window-tabs" role="tablist" data-tooltip="Display window only — switching tabs only re-windows the plotted MMP dots. The prediction always uses the fit shown above.">
                 <button type="button" data-window="last30" role="tab">Last 30d</button>
                 <button type="button" data-window="last90" role="tab" class="is-active">Last 90d</button>
                 <button type="button" data-window="allTime" role="tab">${allTimeLabel(currentActivities)}</button>
               </div>`
           }
         </header>
-        <p class="curve-chart-note">Display window only · prediction uses the fit above</p>
         <div id="curve-chart" class="curve-chart"></div>
       </div>
 


### PR DESCRIPTION
## Summary
The visible mono-caps caption beneath the curve tabs landed on its own row to the left of the tabs and read awkwardly. Carry the same explanation as a hover/focus tooltip on the tablist itself.

The legend still names the fit window (\"CP fit · last 90 days\" / \"custom range\"), so the chart speaks for itself; the tooltip is there for the moment a user wonders whether the tabs change the prediction.

## Test plan
- [ ] Hover the curve tabs: tooltip appears below with \"Display window only — switching tabs only re-windows the plotted MMP dots. The prediction always uses the fit shown above.\"
- [ ] Tab through the tabs: tooltip reveals on focus.
- [ ] No standalone caption row above the chart.