### PR TITLE
Use the shared tooltip on the MMP table [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -47,12 +47,17 @@ html {
   position: relative;
   cursor: help;
 }
+a[data-tooltip],
+button[data-tooltip] {
+  cursor: pointer;
+}
 [data-tooltip]:hover::after,
 [data-tooltip]:focus-within::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 6px);
   left: 0;
+  width: max-content;
   max-width: 22rem;
   z-index: 10;
   background: var(--ink);

--- a/src/app.js
+++ b/src/app.js
@@ -656,7 +656,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
           <th>Duration</th>
           <th>Last 30d</th>
           <th class="featured">Last 90d</th>
-          <th title="Best across the entire local cache. Earlier rides may not be present if you only synced a recent window.">${allTimeLabel(activityMmps)}</th>
+          <th data-tooltip="Best across the entire local cache. Earlier rides may not be present if you only synced a recent window.">${allTimeLabel(activityMmps)}</th>
         </tr>
       </thead>
       <tbody>${rows}</tbody>
@@ -777,10 +777,10 @@ function renderMmpCell(owner) {
     ? new Date(owner.startTime).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
     : null;
   if (!owner.stravaId) {
-    return date ? `<span title="${date}">${watts}</span>` : watts;
+    return date ? `<span data-tooltip="${date}">${watts}</span>` : watts;
   }
-  const title = date ? `${date} · open on Strava` : 'Open this activity on Strava';
-  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" title="${title}">${watts}</a>`;
+  const tip = date ? `${date} · open on Strava` : 'Open this activity on Strava';
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" data-tooltip="${tip}">${watts}</a>`;
 }
 
 // eFTP is computed from a 90-day window ending at the most recent


### PR DESCRIPTION
## Summary
The MMP table linked each watts cell to the matching Strava activity using a native \`title\` attribute, which renders as the OS yellow tooltip — visually inconsistent with the rest of the app's hover callouts. Same story on the \"Since X\" column header.

Convert both to \`data-tooltip\` so they pick up the shared ink-on-cream tooltip rule landed in #184.

Two small adjustments to make the shared rule work on inline links:
- \`width: max-content\` keeps the tooltip on a single line when the carrier is a narrow inline element (each link is ~44px wide).
- \`a[data-tooltip]\` and \`button[data-tooltip]\` keep their pointer cursor instead of inheriting the default \`help\` cursor.

## Test plan
- [ ] Hover any MMP-table watts link: ink-on-cream tooltip with \"<date> · open on Strava\".
- [ ] Hover the \"Since X\" column header: same callout style with the cache-coverage caveat.
- [ ] Cursor remains pointer on the links, help on the column header.