### PR TITLE
Add hover tooltip to the power-duration curve [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1008,6 +1008,35 @@ body[data-app-state="manual"] #manual-mode {
   box-shadow: none !important;
   transition: transform 80ms ease-out;
 }
+.curve-hover-tip {
+  position: absolute;
+  top: 8px;
+  z-index: 5;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  letter-spacing: 0;
+  text-transform: none;
+  padding: 0.55rem 0.7rem;
+  box-shadow: 0 6px 16px rgba(26, 22, 18, 0.18);
+  pointer-events: none;
+  white-space: nowrap;
+}
+.curve-hover-tip strong {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--paper);
+}
+.curve-hover-tip__date {
+  color: rgba(244, 238, 226, 0.65);
+  font-size: 0.72rem;
+}
 
 /* OVERRIDE PANEL */
 

--- a/src/app.js
+++ b/src/app.js
@@ -513,6 +513,7 @@ let currentFit = null;
 let currentEftpNow = null;
 let currentLoad = { ctl: 0, atl: 0, tsb: 0, hasFtp: false };
 let currentMmpByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
+let currentMmpOwnersByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   currentActivities = activityMmps;
@@ -543,6 +544,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // is set; otherwise it switches between the last30/last90/all-time
   // tabs. Filled in below once we know the fit's input set.
   currentMmpByWindow = { last30, last90, allTime, range: {} };
+  currentMmpOwnersByWindow = { last30: last30Owners, last90: last90Owners, allTime: allTimeOwners, range: {} };
 
   // Effort-quality filter: drop activities whose IF (avg / FTP)
   // falls below the threshold so low-effort base rides don't anchor
@@ -566,6 +568,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // observed efforts in range still appear as dots).
   if (dateFromMs || dateToMs) {
     currentMmpByWindow.range = rollingBest(filtered);
+    currentMmpOwnersByWindow.range = rollingBestWithOwners(filtered);
   }
 
   // Drift-normalize for the all-time fallback so an old peak ridden
@@ -1099,6 +1102,7 @@ function wireCurveChart() {
   const draw = (key) => {
     renderCurveChart(container, {
       mmp: currentMmpByWindow[key] || {},
+      mmpOwners: currentMmpOwnersByWindow[key] || {},
       fit: currentFit,
       fitWindowLabel,
     });

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -36,7 +36,7 @@ const STANDARD_TICKS = [
   86400,                   // 24h
 ];
 
-export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 90 days' }) {
+export function renderCurveChart(container, { mmp, mmpOwners = {}, fit, fitWindowLabel = 'last 90 days' }) {
   if (!container) return;
   container.innerHTML = '';
   if (!fit) {
@@ -165,25 +165,65 @@ export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 9
       drag: { x: false, y: false },
       x: false,
       y: false,
-      // One tracer dot that follows the fitted curve as the cursor
-      // moves. We enable cursor.points only on the line series (2 =
-      // fit, 3 = extrapolation) and only when that series has a
-      // non-null value at the snapped x. The observed-MMP series (1)
-      // gets no separate marker — when the cursor is at a recorded
-      // duration, the line tracer naturally lands on top of the
-      // existing oxblood dot, giving the "lock onto a point" feel
-      // without doubling up markers.
-      // Cursor markers on every series; uPlot suppresses rendering
-      // when the underlying data value is null, so the line tracer
-      // only shows along the fit and extrapolation segments and the
-      // observed-MMP marker only shows at recorded durations. All
-      // visual styling lives in CSS (.u-cursor-pt) — uPlot's
-      // fill/stroke options weren't applying reliably here.
       points: { size: 7 },
     },
     legend: {
       show: true,
       live: true,
+    },
+    hooks: {
+      ready: [
+        (u) => {
+          const tip = document.createElement('div');
+          tip.className = 'curve-hover-tip';
+          tip.hidden = true;
+          u.over.appendChild(tip);
+          u.over.style.position = u.over.style.position || 'relative';
+        },
+      ],
+      setCursor: [
+        (u) => {
+          const tip = u.over.querySelector('.curve-hover-tip');
+          if (!tip) return;
+          const idx = u.cursor.idx;
+          const left = u.cursor.left;
+          if (idx == null || left == null || left < 0) {
+            tip.hidden = true;
+            return;
+          }
+          const xVal = u.data[0][idx];
+          const obs = u.data[1][idx];
+          const insideY = u.data[2][idx];
+          const outsideY = u.data[3][idx];
+          const fitY = insideY ?? outsideY;
+          if (fitY == null && obs == null) {
+            tip.hidden = true;
+            return;
+          }
+          const lines = [`<strong>${formatDurationTick(xVal)}</strong>`];
+          if (obs != null) {
+            const owner = mmpOwners[xVal];
+            const date = owner && Number.isFinite(owner.startTime)
+              ? new Date(owner.startTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+              : null;
+            lines.push(date
+              ? `Observed: ${Math.round(obs)} W <span class="curve-hover-tip__date">· ${date}</span>`
+              : `Observed: ${Math.round(obs)} W`);
+          }
+          if (fitY != null) {
+            const label = outsideY != null ? 'Extrapolation' : 'Fit';
+            lines.push(`${label}: ${Math.round(fitY)} W`);
+          }
+          tip.innerHTML = lines.join('<br>');
+          tip.hidden = false;
+          // Anchor at cursor x; let CSS flip across the midline so the
+          // tooltip never spills past the right edge of the plot area.
+          const plotW = u.bbox.width / window.devicePixelRatio;
+          const flip = left > plotW * 0.6;
+          tip.style.left = flip ? 'auto' : `${left + 12}px`;
+          tip.style.right = flip ? `${plotW - left + 12}px` : 'auto';
+        },
+      ],
     },
   };
 


### PR DESCRIPTION
## Summary
The legend strip under the chart already shows live values when you hover, but it sits far from the cursor and you have to look down to read it. Add a near-cursor tooltip that reports:

- Duration (mono-caps header)
- Observed: <power> W · <date> — when there's a recorded MMP at that duration, the date is the ride that set it
- Fit: <power> W — when the cursor is inside the 3-20 min fitting window
- Extrapolation: <power> W — when the cursor is past the window ceiling

The callout uses the same ink-on-cream style as the rest of the app's tooltips. It flips to the left of the cursor when the cursor is past the plot's right 40% so it never spills outside the chart.

To get the dates, app.js now tracks \`rollingBestWithOwners\` per window in \`currentMmpOwnersByWindow\` and threads the active one through to the chart as \`mmpOwners\`.

## Test plan
- [ ] Hover over an observed dot: tooltip shows duration, observed power + date, and fit value.
- [ ] Hover where there's no dot: tooltip shows duration + fit (or extrapolation).
- [ ] Hover near the right edge: tooltip flips to anchor on the cursor's left so it stays in view.
- [ ] Switch between Last 30d / Last 90d / Since X tabs: dates correctly reflect the active window.