### PR TITLE
Fix curve tooltip anchoring outside the chart [skip_ci]

### DIFF
--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -178,7 +178,6 @@ export function renderCurveChart(container, { mmp, mmpOwners = {}, fit, fitWindo
           tip.className = 'curve-hover-tip';
           tip.hidden = true;
           u.over.appendChild(tip);
-          u.over.style.position = u.over.style.position || 'relative';
         },
       ],
       setCursor: [


### PR DESCRIPTION
## Summary
Reported that the new curve hover tooltip was landing somewhere on the page rather than on the chart.

Root cause: my ready hook set \`u.over.style.position = 'relative'\` to make the tooltip's absolute positioning anchor to it. uPlot already positions \`u.over\` as \`absolute\` to overlay the canvas; my override demoted it out of that overlay stack and onto the page flow, taking the tooltip with it.

\`position: absolute\` itself counts as a positioned-ancestor for absolute children, so just dropping my override is enough — the tooltip anchors to \`u.over\` correctly.

## Test plan
- [ ] Hover the curve: tooltip appears near the cursor inside the plot area.
- [ ] Switch tabs (Last 30d / Last 90d / Since X): tooltip continues to anchor correctly.