### PR TITLE
Revert chart hover tooltip [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1008,35 +1008,6 @@ body[data-app-state="manual"] #manual-mode {
   box-shadow: none !important;
   transition: transform 80ms ease-out;
 }
-.curve-hover-tip {
-  position: absolute;
-  top: 8px;
-  z-index: 5;
-  background: var(--ink);
-  color: var(--paper);
-  font-family: var(--sans);
-  font-weight: 400;
-  font-size: 0.78rem;
-  line-height: 1.45;
-  letter-spacing: 0;
-  text-transform: none;
-  padding: 0.55rem 0.7rem;
-  box-shadow: 0 6px 16px rgba(26, 22, 18, 0.18);
-  pointer-events: none;
-  white-space: nowrap;
-}
-.curve-hover-tip strong {
-  font-family: var(--mono);
-  font-size: 0.72rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--paper);
-}
-.curve-hover-tip__date {
-  color: rgba(244, 238, 226, 0.65);
-  font-size: 0.72rem;
-}
 
 /* OVERRIDE PANEL */
 

--- a/src/app.js
+++ b/src/app.js
@@ -513,7 +513,6 @@ let currentFit = null;
 let currentEftpNow = null;
 let currentLoad = { ctl: 0, atl: 0, tsb: 0, hasFtp: false };
 let currentMmpByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
-let currentMmpOwnersByWindow = { last30: {}, last90: {}, allTime: {}, range: {} };
 
 function renderCurves(activityMmps, { fromCache = false } = {}) {
   currentActivities = activityMmps;
@@ -544,7 +543,6 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // is set; otherwise it switches between the last30/last90/all-time
   // tabs. Filled in below once we know the fit's input set.
   currentMmpByWindow = { last30, last90, allTime, range: {} };
-  currentMmpOwnersByWindow = { last30: last30Owners, last90: last90Owners, allTime: allTimeOwners, range: {} };
 
   // Effort-quality filter: drop activities whose IF (avg / FTP)
   // falls below the threshold so low-effort base rides don't anchor
@@ -568,7 +566,6 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // observed efforts in range still appear as dots).
   if (dateFromMs || dateToMs) {
     currentMmpByWindow.range = rollingBest(filtered);
-    currentMmpOwnersByWindow.range = rollingBestWithOwners(filtered);
   }
 
   // Drift-normalize for the all-time fallback so an old peak ridden
@@ -1102,7 +1099,6 @@ function wireCurveChart() {
   const draw = (key) => {
     renderCurveChart(container, {
       mmp: currentMmpByWindow[key] || {},
-      mmpOwners: currentMmpOwnersByWindow[key] || {},
       fit: currentFit,
       fitWindowLabel,
     });

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -36,7 +36,7 @@ const STANDARD_TICKS = [
   86400,                   // 24h
 ];
 
-export function renderCurveChart(container, { mmp, mmpOwners = {}, fit, fitWindowLabel = 'last 90 days' }) {
+export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 90 days' }) {
   if (!container) return;
   container.innerHTML = '';
   if (!fit) {
@@ -170,59 +170,6 @@ export function renderCurveChart(container, { mmp, mmpOwners = {}, fit, fitWindo
     legend: {
       show: true,
       live: true,
-    },
-    hooks: {
-      ready: [
-        (u) => {
-          const tip = document.createElement('div');
-          tip.className = 'curve-hover-tip';
-          tip.hidden = true;
-          u.over.appendChild(tip);
-        },
-      ],
-      setCursor: [
-        (u) => {
-          const tip = u.over.querySelector('.curve-hover-tip');
-          if (!tip) return;
-          const idx = u.cursor.idx;
-          const left = u.cursor.left;
-          if (idx == null || left == null || left < 0) {
-            tip.hidden = true;
-            return;
-          }
-          const xVal = u.data[0][idx];
-          const obs = u.data[1][idx];
-          const insideY = u.data[2][idx];
-          const outsideY = u.data[3][idx];
-          const fitY = insideY ?? outsideY;
-          if (fitY == null && obs == null) {
-            tip.hidden = true;
-            return;
-          }
-          const lines = [`<strong>${formatDurationTick(xVal)}</strong>`];
-          if (obs != null) {
-            const owner = mmpOwners[xVal];
-            const date = owner && Number.isFinite(owner.startTime)
-              ? new Date(owner.startTime).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
-              : null;
-            lines.push(date
-              ? `Observed: ${Math.round(obs)} W <span class="curve-hover-tip__date">· ${date}</span>`
-              : `Observed: ${Math.round(obs)} W`);
-          }
-          if (fitY != null) {
-            const label = outsideY != null ? 'Extrapolation' : 'Fit';
-            lines.push(`${label}: ${Math.round(fitY)} W`);
-          }
-          tip.innerHTML = lines.join('<br>');
-          tip.hidden = false;
-          // Anchor at cursor x; let CSS flip across the midline so the
-          // tooltip never spills past the right edge of the plot area.
-          const plotW = u.bbox.width / window.devicePixelRatio;
-          const flip = left > plotW * 0.6;
-          tip.style.left = flip ? 'auto' : `${left + 12}px`;
-          tip.style.right = flip ? `${plotW - left + 12}px` : 'auto';
-        },
-      ],
     },
   };
 


### PR DESCRIPTION
Per use, the chart hover tooltip didn't read well and the data it surfaced (duration + observed/fit values) duplicated what the live legend already shows. Removing it. Reverts #186 and #187.