### PR TITLE
Stabilize chart legend cell widths [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -991,6 +991,14 @@ body[data-app-state="manual"] #manual-mode {
   border-radius: 50%;
   margin-right: 0.4em;
 }
+/* Reserve a stable width for each value cell so the legend stops
+   reflowing as the cursor moves between observed dots and gaps. */
+.curve-chart .u-legend .u-value {
+  display: inline-block;
+  min-width: 4.5em;
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+}
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }
 
 /* Cursor tracer dots — one per series at the snapped x. Rendered


### PR DESCRIPTION
## Summary
The uPlot legend below the chart was reflowing horizontally as the cursor crossed observed dots: \"—\" is much narrower than \"318 W\", so each time the observed series flipped between a value and a dash, every cell to its right slid. Pin \`.u-value\` to \`display: inline-block\` with \`min-width: 4.5em\` (fits \"999 W\" or \"—\") and \`font-variant-numeric: tabular-nums\` so the legend keeps a stable footprint as the cursor moves.

## Test plan
- [ ] Drag the cursor across the chart: legend cells stay at the same x positions.
- [ ] Switch tabs (Last 30d / Last 90d / Since X): no jitter.