### PR TITLE
Refine chart legend layout — center, right-align, tighter [skip_ci]

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -982,8 +982,8 @@ body[data-app-state="manual"] #manual-mode {
   font-family: var(--mono);
   font-size: 0.78rem;
   color: var(--ink-soft);
-  text-align: left;
-  padding-top: 0.4rem;
+  text-align: center;
+  padding-top: 0.7rem;
 }
 .curve-chart .u-legend .u-marker {
   width: 10px;
@@ -995,8 +995,8 @@ body[data-app-state="manual"] #manual-mode {
    reflowing as the cursor moves between observed dots and gaps. */
 .curve-chart .u-legend .u-value {
   display: inline-block;
-  min-width: 4.5em;
-  text-align: left;
+  min-width: 4.2em;
+  text-align: right;
   font-variant-numeric: tabular-nums;
 }
 .curve-chart .u-legend tr.u-off > * { opacity: 0.4; }


### PR DESCRIPTION
## Summary
The legend below the curve was reading as scattered fragments — left-aligned values with a 4.5em reservation left dead air to the right of every dash. Three small moves consolidate it into a single composed strip:

- Center the legend table (\`.u-legend { text-align: center }\`).
- Right-align the value cells (\`.u-value { text-align: right }\`). With \`tabular-nums\` already in place, both \"318 W\" and \"—\" pin to the same right edge, so gaps move *between* cells where they read as deliberate rhythm.
- Tighten \`min-width\` from 4.5em to 4.2em — fits a 3-digit watt value exactly, no slack.
- Bump \`padding-top\` from 0.4rem to 0.7rem so it breathes against the x-axis labels.

## Test plan
- [ ] Drag the cursor across the chart: legend stays put, no horizontal jitter.
- [ ] Strip reads as a single centered line beneath the chart.