### PR TITLE
Anchor W' on longer history when recent data lacks short efforts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -603,6 +603,38 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
     ? { ...primaryFit, fallback: false }
     : (fallbackFit ? { ...fallbackFit, fallback: true } : null);
 
+  // W' is a physiologically stable anaerobic ceiling that doesn't drop
+  // the way CP does between training blocks. When the recent window
+  // lacks a hard sub-3-min effort, the regression's W' caves in even
+  // though the rider's actual capacity hasn't changed. The drift-
+  // normalized longer-history fit anchors W' to the real ceiling.
+  // Borrow it only when it's materially larger (≥ 1.3×) and the primary
+  // result wasn't a fallback or override — keeps the primary CP
+  // (recent fitness) but lifts W' (and the coupled τ / pMax shape) off
+  // a misleading recent-window floor. τ and pMax come along because
+  // they're physically tied to W' through τ = W' / (pMax − CP); using
+  // the recent τ with a lifted W' would predict unphysically high
+  // short-duration power.
+  if (
+    currentFit
+    && !currentFit.fallback
+    && !currentFit.overridden
+    && fallbackFit
+    && fallbackFit.wPrimeJ >= currentFit.wPrimeJ * 1.3
+  ) {
+    const recentWPrimeJ = currentFit.wPrimeJ;
+    currentFit = {
+      ...currentFit,
+      wPrimeJ: fallbackFit.wPrimeJ,
+      tauS: fallbackFit.tauS ?? currentFit.tauS,
+      pMaxW: Number.isFinite(fallbackFit.tauS)
+        ? currentFit.cpW + fallbackFit.wPrimeJ / fallbackFit.tauS
+        : currentFit.pMaxW,
+      wPrimeSource: 'history',
+      wPrimeRecentJ: recentWPrimeJ,
+    };
+  }
+
   // Apply CP override on top of the fit (W' stays from the underlying
   // fit so the curve shape is data-derived, not a hand-set hyperbola).
   if (currentFit && Number.isFinite(currentSettings.cpOverrideW)) {
@@ -753,14 +785,21 @@ function cpTooltip(fit) {
   }
   return 'CP came from a normal regression on the active window (last 90 days or your custom range).';
 }
-function wPrimeQuality(wPrimeJ) {
-  const kJ = wPrimeJ / 1000;
+function wPrimeQuality(fit) {
+  if (fit?.wPrimeSource === 'history') return { label: 'history', cls: 'is-mid' };
+  const kJ = (fit?.wPrimeJ ?? 0) / 1000;
   if (kJ < 8)  return { label: 'low',       cls: 'is-mid'  };
   if (kJ < 25) return { label: 'typical',   cls: 'is-good' };
   if (kJ < 40) return { label: 'high',      cls: 'is-good' };
   return            { label: 'very high', cls: 'is-mid'  };
 }
-function wPrimeTooltip(wPrimeJ) {
+function wPrimeTooltip(fit) {
+  if (fit?.wPrimeSource === 'history') {
+    const recentKJ = (fit.wPrimeRecentJ / 1000).toFixed(1);
+    return 'Anaerobic work capacity above CP. The recent window lacked a hard sub-3-min effort '
+         + `(recent fit gave ${recentKJ} kJ), so W' is anchored on your longer training history `
+         + 'where the anaerobic ceiling is visible. CP still tracks recent fitness.';
+  }
   return 'Anaerobic work capacity above CP. Trained cyclists typically sit in the 10-25 kJ range; '
        + 'sprinters and track riders push higher. Very high values from a 2-param fit can also signal '
        + 'a steep short-duration MMP relative to the threshold end — sanity-check against your sprint efforts.';
@@ -1291,9 +1330,9 @@ function renderPredictBlock() {
           <dt>CP${currentFit.overridden ? ' *' : ''}</dt>
           <dd>${formatPower(currentFit.cpW)}<span class="fit-stats__quality ${cpQuality(currentFit).cls}">${cpQuality(currentFit).label}</span></dd>
         </div>
-        <div data-tooltip="${wPrimeTooltip(currentFit.wPrimeJ)}">
+        <div data-tooltip="${wPrimeTooltip(currentFit)}">
           <dt>W'</dt>
-          <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ<span class="fit-stats__quality ${wPrimeQuality(currentFit.wPrimeJ).cls}">${wPrimeQuality(currentFit.wPrimeJ).label}</span></dd>
+          <dd>${(currentFit.wPrimeJ / 1000).toFixed(1)} kJ<span class="fit-stats__quality ${wPrimeQuality(currentFit).cls}">${wPrimeQuality(currentFit).label}</span></dd>
         </div>
         ${currentEftpNow ? `
         <div data-tooltip="${eftpTooltip()}">

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -16,12 +16,14 @@
 
 export const DEFAULT_FIT_RANGE = { minS: 180, maxS: 1200 };
 
-// 3-parameter (Morton) range can extend further down because the
-// pMax term tames the short-end behavior the 2-param hyperbola
-// can't represent. Lower bound 90s keeps the fit in W' territory:
-// below ~60s, PCr and neuromuscular contributions dominate and can
-// pull CP upward if the long-duration curve is relatively flat.
-export const DEFAULT_FIT_RANGE_3P = { minS: 90, maxS: 1200 };
+// 3-parameter (Morton) range extends further down than the 2-param
+// model because the pMax term explicitly tames the short-end behavior
+// the 2-param hyperbola can't represent. 30s is the practical floor —
+// below that, neuromuscular contributions still dominate, and even the
+// 3-param fit can't separate them from W'. Keeping 30s in range gives
+// the optimizer enough short-end leverage to constrain W' when the
+// 5-20 min portion of the curve is unusually flat.
+export const DEFAULT_FIT_RANGE_3P = { minS: 30, maxS: 1200 };
 
 // Convert an MMP map ({60: 350, 300: 280, ...}) to an array of points.
 export function mmpToPoints(mmp) {
@@ -123,17 +125,29 @@ export function fitCp3(points, range = DEFAULT_FIT_RANGE_3P, opts = {}) {
   // solution where CP exceeds the observed 20-min MMP (physically impossible).
   const minPowerInRange = Math.min(...filtered.map((p) => p.powerW));
 
+  // τ grid bounds: τ = W'/(pMax − CP). Trained cyclists typically sit
+  // in the 10-40 s range. A solution that pins at either extreme is
+  // almost certainly the optimizer absorbing model mismatch into the
+  // pMax term rather than a real fit — reject those even if SSE is
+  // low. pMax above 2200 W on a non-track-sprinter is the same tell.
+  const TAU_MIN = 1, TAU_MAX = 90, TAU_STEP = 0.5;
+  const PMAX_MAX = 2200;
+
   let best = null;
-  for (let tau = 1; tau <= 90; tau += 0.5) {
+  for (let tau = TAU_MIN; tau <= TAU_MAX; tau += TAU_STEP) {
     const fit = fitLinearWithTau(filtered, tau);
     if (!fit) continue;
     if (fit.cpW < 50 || fit.cpW > 600) continue;
     if (fit.cpW >= minPowerInRange) continue;
     if (fit.wPrimeJ < 1000 || fit.wPrimeJ > 60000) continue;
-    if (fit.pMaxW < fit.cpW + 100 || fit.pMaxW > 2500) continue;
+    if (fit.pMaxW < fit.cpW + 100 || fit.pMaxW > PMAX_MAX) continue;
     if (!best || fit.sse < best.sse) best = { ...fit, tauS: tau };
   }
   if (!best) return null;
+  // Final degeneracy check: τ pinned at the grid edge means the
+  // optimizer wanted to keep going. The fit isn't trustworthy — let
+  // the caller fall back to the 2-param hyperbola.
+  if (best.tauS <= TAU_MIN || best.tauS >= TAU_MAX) return null;
 
   const n = filtered.length;
   const rmse = Math.sqrt(best.sse / n);

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -206,6 +206,74 @@ describe('fitCp3', () => {
     const expected = fit.cpW + fit.wPrimeJ / (60 + fit.tauS);
     expect(at60.powerW).toBeCloseTo(expected, 4);
   });
+
+  it('rejects fits whose CP exceeds the minimum observed power in range', () => {
+    // Real bug from production: a steep short-end curve combined with a
+    // flat threshold region pulled CP above the observed 20-min MMP, which
+    // is physically impossible (CP is the long-duration asymptote and must
+    // sit below every effort in the regression window).
+    // Constructed so the unconstrained optimum would push CP > 317:
+    const points = [
+      { durationS: 30, powerW: 600 },
+      { durationS: 60, powerW: 470 },
+      { durationS: 120, powerW: 380 },
+      { durationS: 300, powerW: 322 },
+      { durationS: 600, powerW: 320 },
+      { durationS: 900, powerW: 318 },
+      { durationS: 1200, powerW: 317 },
+    ];
+    const fit = fitCp3(points);
+    if (fit) expect(fit.cpW).toBeLessThan(317);
+  });
+
+  it('returns null when the best τ pins at the grid boundary', () => {
+    // Flat 90-day data with no sub-2-min coverage. Without short-end
+    // leverage the 3-param fit's τ collapses to the grid floor and
+    // pMax rails — a degenerate solution. Better to return null and
+    // let the caller fall back to the 2-param hyperbola.
+    const points = [
+      { durationS: 120, powerW: 322 },
+      { durationS: 240, powerW: 320 },
+      { durationS: 480, powerW: 319 },
+      { durationS: 720, powerW: 318 },
+      { durationS: 900, powerW: 317 },
+      { durationS: 1200, powerW: 316 },
+    ];
+    const fit = fitCp3(points);
+    // Either we cleanly reject (preferred), or — if some τ in [2, 89]
+    // happens to satisfy all constraints — the resulting τ must be off
+    // the rails and pMax must be physiological.
+    if (fit) {
+      expect(fit.tauS).toBeGreaterThan(1);
+      expect(fit.tauS).toBeLessThan(90);
+      expect(fit.pMaxW).toBeLessThanOrEqual(2200);
+    }
+  });
+
+  it('preserves W\' on data with adequate short-end coverage', () => {
+    // Same flat threshold cluster from the regression case above, but
+    // with realistic 30-90 s coverage that gives the optimizer real W'
+    // information. The fit should recover a sane W' (well above the
+    // "low" 8 kJ threshold) and a physiological τ.
+    const points = [
+      { durationS: 30, powerW: 515 },
+      { durationS: 60, powerW: 435 },
+      { durationS: 90, powerW: 418 },
+      { durationS: 120, powerW: 393 },
+      { durationS: 180, powerW: 351 },
+      { durationS: 300, powerW: 328 },
+      { durationS: 600, powerW: 324 },
+      { durationS: 900, powerW: 319 },
+      { durationS: 1200, powerW: 314 },
+    ];
+    const fit = fitCp3(points);
+    expect(fit).not.toBeNull();
+    expect(fit.cpW).toBeLessThan(314);
+    expect(fit.wPrimeJ).toBeGreaterThan(8_000);
+    expect(fit.tauS).toBeGreaterThan(1);
+    expect(fit.tauS).toBeLessThan(90);
+    expect(fit.pMaxW).toBeLessThanOrEqual(2200);
+  });
 });
 
 describe('fitFatigueK', () => {


### PR DESCRIPTION
## Summary

- Reverted the 90 s lower bound on the 3-param CP fit and added two degeneracy guards (τ-at-grid-edge, pMax cap 2200 W). The 90 s floor stripped the short-end leverage the pMax term needs, causing τ to collapse and W' to cave on otherwise normal data.
- When the drift-normalized longer-history fit's W' is ≥ 1.3× the recent fit's W', lift W', τ, and pMax from history while keeping CP from the recent fit. W' is a physiologically stable anaerobic ceiling; recent flat data shouldn't make it disappear.
- New "history" pill on the W' stat and tooltip surfacing the recent-window value for context. Four new tests cover the original CP-above-observed case, τ-boundary rejection, and W' recovery with adequate short-end coverage.

On my own data this moves W' from 7.9 kJ ("low") to 24.8 kJ ("history"), which matches what the all-time sub-3-min powers actually imply.

## Test plan

- [ ] All 130 tests pass (`npx vitest run`)
- [ ] Build is clean (`node build.js`)
- [ ] Refresh the app — W' on the 90-day fit shows a sensible value with the "history" pill if recent data is anaerobically thin
- [ ] Hover the W' stat — tooltip explains the composite and lists the recent-window W'
- [ ] Switch to the all-time fit (no history to borrow from) — W' uses the regular quality label
- [ ] Predictions at short durations (5-10 min) come out in a sensible range relative to recent MMP