### PR TITLE
Fix top toasts rendering off-screen on phones

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -397,6 +397,10 @@ main {
   white-space: nowrap;
   max-width: calc(100vw - 2rem);
 }
+.status-banner.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
 @media (max-width: 480px) {
   .status-banner {
     top: 0;
@@ -412,10 +416,6 @@ main {
   .status-banner.is-visible {
     transform: translate(0, 0);
   }
-}
-.status-banner.is-visible {
-  opacity: 1;
-  transform: translate(-50%, 0);
 }
 .status-banner em {
   font-style: normal;


### PR DESCRIPTION
## Summary
- Mobile (`max-width: 480px`) override for `.status-banner.is-visible` was being clobbered by the general rule below it (same specificity, later in source) — so on phones the banner had `left: 0` plus `translate(-50%, 0)` and half of it slid off the left edge.
- Reordered so the base `.is-visible` rule comes first and the mobile media query overrides it.

## Test plan
- [ ] Open the site on an iPhone (or 480px-wide viewport) and trigger a toast (e.g. sync). Confirm it's centered and fully visible at the top.
- [ ] Desktop view still centers the toast as before.