### PR TITLE
Flag MMP cells whose owner ride was added in the most recent sync

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -786,6 +786,23 @@ body[data-app-state="manual"] #manual-mode {
   border-bottom-color: var(--oxblood);
 }
 
+/* "NEW" badge — flags an MMP cell whose owner ride was added in the
+   most recent Strava sync. Reuses the editorial oxblood-on-paper pill
+   style we already use for inline emphasis in status banners. */
+.mmp-cell__new {
+  display: inline-block;
+  margin-left: 0.4rem;
+  padding: 0.05rem 0.4rem;
+  background: var(--oxblood);
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  vertical-align: 0.1em;
+}
+
 
 .results-foot {
   display: flex;

--- a/src/app.js
+++ b/src/app.js
@@ -265,6 +265,15 @@ async function triggerStravaSync() {
       if (!(await hasActivity(a.startTime))) fresh.push(a);
     }
     if (fresh.length) await saveActivities(fresh);
+    // Record the Strava IDs introduced by this sync so the MMP table
+    // can flag cells whose owner activity is new this sync. Cleared
+    // on the next sync (even one that adds zero rides), so the badge
+    // reflects the *most recent* sync only.
+    currentSettings = {
+      ...currentSettings,
+      lastSyncNewIds: fresh.map((a) => a.stravaId).filter((id) => id != null && id !== ''),
+    };
+    await saveSettings(currentSettings);
     const all = await loadActivities();
     renderCurves(all);
     const noun = fresh.length === 1 ? 'ride' : 'rides';
@@ -654,14 +663,15 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   const ftpForLoad = currentFit?.cpW ? currentFit.cpW / 0.95 : null;
   currentLoad = computeLoadSeries(activityMmps, ftpForLoad);
 
+  const newSyncIds = new Set(currentSettings.lastSyncNewIds || []);
   const rows = DURATIONS_S
     .filter((d) => allTime[d] !== undefined)
     .map((d) => `
       <tr>
         <td>${formatDuration(d)}</td>
-        <td>${renderMmpCell(last30Owners[d])}</td>
-        <td class="featured">${renderMmpCell(last90Owners[d])}</td>
-        <td>${renderMmpCell(allTimeOwners[d])}</td>
+        <td>${renderMmpCell(last30Owners[d], newSyncIds)}</td>
+        <td class="featured">${renderMmpCell(last90Owners[d], newSyncIds)}</td>
+        <td>${renderMmpCell(allTimeOwners[d], newSyncIds)}</td>
       </tr>`)
     .join('');
 
@@ -806,17 +816,21 @@ function wPrimeTooltip(fit) {
 // filename, which is Strava's upload ID and points to a different
 // public activity. Cells without a resolved ID (legacy cache or an
 // archive without activities.csv) render as plain text.
-function renderMmpCell(owner) {
+function renderMmpCell(owner, newSyncIds) {
   if (!owner || typeof owner.value !== 'number') return '—';
   const watts = formatPower(owner.value);
   const date = Number.isFinite(owner.startTime)
     ? new Date(owner.startTime).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
     : null;
+  const isNew = newSyncIds && owner.stravaId && newSyncIds.has(owner.stravaId);
+  const badge = isNew
+    ? ' <span class="mmp-cell__new" data-tooltip="Set by a ride added in the most recent sync">NEW</span>'
+    : '';
   if (!owner.stravaId) {
-    return date ? `<span data-tooltip="${date}">${watts}</span>` : watts;
+    return date ? `<span data-tooltip="${date}">${watts}</span>${badge}` : `${watts}${badge}`;
   }
   const tip = date ? `${date} · open on Strava` : 'Open this activity on Strava';
-  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" data-tooltip="${tip}">${watts}</a>`;
+  return `<a class="mmp-link" href="https://www.strava.com/activities/${owner.stravaId}" target="_blank" rel="noopener" data-tooltip="${tip}">${watts}</a>${badge}`;
 }
 
 // eFTP is computed from a 90-day window ending at the most recent


### PR DESCRIPTION
## Summary
- After each Strava sync, persist the new activities' Strava IDs to settings as `lastSyncNewIds`.
- In the MMP table, if a cell's owner activity is in that set, render a small oxblood `NEW` badge next to the watts. Rolling-best only updates when beaten, so a new owner genuinely means the sync produced a new peak in that window.
- The set is overwritten on the next sync (even a zero-rides sync), so the badge always reflects the most recent sync only.

## Test plan
- [ ] Sync 180 days from Strava with rides that beat existing peaks. Confirm those cells show `NEW`.
- [ ] Sync again with nothing new. Badges disappear.
- [ ] Hover the badge — tooltip reads `Set by a ride added in the most recent sync`.
- [ ] Mobile view — badge wraps cleanly, table still readable.