### PR TITLE
Bump actions/configure-pages from v4 to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - run: npm test
       - run: npm run build
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .


### PR DESCRIPTION
## Summary
- GitHub's codeload archive for `actions/configure-pages@v4` started returning 404, blocking every Pages deploy (#194, #195 silently failed to deploy).
- Bump to v5 — current major, drop-in for our call site (no inputs).

## Test plan
- [ ] Watch the merge run go green end-to-end.
- [ ] Confirm the live site picks up #194 (mobile toast) and #195 (NEW badge).