### PR TITLE
Prompt to reconnect when a Strava session expires (401)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
 import {
   parseAuthHash, clearAuthHash, loadSession, saveSession, clearSession, authorizeUrl,
-  syncRecent, fetchSyncedActivities,
+  syncRecent, fetchSyncedActivities, UnauthenticatedError,
 } from './strava-session.js';
 
 const dropZone = document.getElementById('archive-drop');
@@ -311,8 +311,39 @@ async function triggerStravaSync() {
     showStatus(completion, { kind: 'success', dwellMs: 3500 });
   } catch (err) {
     console.error('strava sync failed', err);
+    // A 401 means our browser session token is gone server-side (KV
+    // TTL lapsed or evicted) — there's nothing to refresh, the user
+    // has to re-OAuth. Drop the dead session so the UI flips back to
+    // the Connect state, then prompt a reconnect instead of leaving a
+    // generic error over a session that will keep failing.
+    if (err instanceof UnauthenticatedError || err?.unauthenticated) {
+      await handleExpiredSession();
+      return;
+    }
     showStatus(`Strava sync failed: ${err.message || err}`, { kind: 'error', dwellMs: 5000 });
   }
+}
+
+// Tear down a session the worker no longer recognizes and nudge the
+// user back through the connect flow. Clears the stale token, refreshes
+// every Strava UI surface to its disconnected state, and surfaces a
+// persistent reconnect prompt whose button reuses beginStravaConnect.
+async function handleExpiredSession() {
+  await clearSession();
+  currentSettings = (await loadSettings()) || {};
+  // refreshStravaUi handles the landing-page data-source surface;
+  // renderCurves re-renders the results footer. Both gate the
+  // Connected/Connect toggle on the now-cleared session, same as the
+  // Disconnect handler does.
+  await refreshStravaUi();
+  renderCurves(currentActivities, { fromCache: true });
+  showStatus(
+    `Strava session expired — <button type="button" class="link-button" id="reconnect-strava-btn">reconnect</button> to sync.`,
+    { kind: 'error', persistent: true },
+  );
+  document.getElementById('reconnect-strava-btn')?.addEventListener('click', (e) => {
+    beginStravaConnect(e.currentTarget);
+  });
 }
 
 async function handleArchive(file) {

--- a/src/strava-session.js
+++ b/src/strava-session.js
@@ -11,6 +11,21 @@ import { loadSettings, saveSettings } from './storage.js';
 
 export const API_BASE = 'https://power-predict-api.iammikec.workers.dev';
 
+// Thrown when the worker rejects our browser session token (HTTP 401,
+// `{ error: 'unauthenticated' }`). The opaque session lives in KV with
+// a 30-day TTL and can be evicted earlier, so a 401 here means the
+// session is genuinely gone server-side — there's nothing to refresh,
+// the user has to re-OAuth. Callers catch this specifically to clear
+// the stale local session and prompt a reconnect, rather than showing
+// it as a generic transport failure.
+export class UnauthenticatedError extends Error {
+  constructor(message = 'session expired') {
+    super(message);
+    this.name = 'UnauthenticatedError';
+    this.unauthenticated = true;
+  }
+}
+
 // Read window.location.hash, return { session, athleteId, error }
 // when any auth params are present. Caller decides what to do —
 // success path stores them; error path surfaces to the user.
@@ -87,6 +102,7 @@ export async function syncRecent({ session, days = 180, knownIds = [], onProgres
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
+      if (res.status === 401) throw new UnauthenticatedError(`sync failed: 401 ${text}`);
       throw new Error(`sync failed: ${res.status} ${text}`);
     }
     const slice = await res.json();
@@ -115,6 +131,7 @@ export async function fetchSyncedActivities(session) {
   const res = await fetch(`${API_BASE}/activities/recent?session=${encodeURIComponent(session)}`);
   if (!res.ok) {
     const text = await res.text().catch(() => '');
+    if (res.status === 401) throw new UnauthenticatedError(`activities load failed: 401 ${text}`);
     throw new Error(`activities load failed: ${res.status} ${text}`);
   }
   const body = await res.json();

--- a/tests/strava-session.test.js
+++ b/tests/strava-session.test.js
@@ -1,10 +1,20 @@
 import 'fake-indexeddb/auto';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   parseAuthHash, authorizeUrl, API_BASE,
   loadSession, saveSession, clearSession,
+  syncRecent, fetchSyncedActivities, UnauthenticatedError,
 } from '../src/strava-session.js';
 import { saveSettings } from '../src/storage.js';
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
 
 describe('parseAuthHash', () => {
   it('returns null for empty / missing hash', () => {
@@ -68,5 +78,32 @@ describe('session persistence', () => {
     const { loadSettings: load } = await import('../src/storage.js');
     const s = await load();
     expect(s.cpOverrideW).toBe(280);
+  });
+});
+
+describe('401 handling', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('syncRecent throws UnauthenticatedError on a 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: 'unauthenticated' })));
+    await expect(syncRecent({ session: 'dead' })).rejects.toBeInstanceOf(UnauthenticatedError);
+  });
+
+  it('syncRecent throws a plain Error on other failures', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(500, { error: 'boom' })));
+    const err = await syncRecent({ session: 'tok' }).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.unauthenticated).toBeUndefined();
+  });
+
+  it('fetchSyncedActivities throws UnauthenticatedError on a 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: 'unauthenticated' })));
+    await expect(fetchSyncedActivities('dead')).rejects.toBeInstanceOf(UnauthenticatedError);
+  });
+
+  it('a thrown UnauthenticatedError carries the unauthenticated flag', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(401, { error: 'unauthenticated' })));
+    const err = await fetchSyncedActivities('dead').catch((e) => e);
+    expect(err.unauthenticated).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Several iOS UI tests that mock rows on the lolomo (billboards, Local Moments, Downloads For You, ROAR, continue watching) have been failing at 27–67% rates over the last ~11 days. The common cause: each one pinned the GPS holdback (AB 68296 cell 2) but NOT the Phoenix IA / Vertical Video Productization holdback (AB 79360 cell 2 — "Old IA, No Vertical Video"). Accounts randomly allocated to a Phoenix IA cell render the ContentBar layout, which has no standard billboard, no `genre-*` buttons for Local Moments, and no `row-downloadsForYou` ScrollView, so the tests time out finding those elements.

## What this does

- Adds `allocateLegacyLolomoHoldbacks()` to `NflxCIToolProtocol` (in `platform/LegoLand/protocols/NflxCIToolProtocol+Default.swift`), which allocates both AB 68296 cell 2 and AB 79360 cell 2 in one call.
- Replaces individual `allocate(to: (test: 68296, cell: 2))` invocations at mocked-row test sites with calls to the new helper. Also adds the helper to `test_ProfileManagement` (which previously had no holdback at all but uses `MockGpsRow.makeMockGPSCallSplashScreen`).

Tests touched span Bond, Core, Discover, and Explore team folders:
- `Argo/ArgoUITests/DVXBondTeam/ScreenshotTests/DownloadsForYouRowScreenshotTests.swift`
- `Argo/ArgoUITests/DVXBondTeam/UITests/MyDownloadsTests.swift`
- `Argo/ArgoUITests/DVXCoreTeam/ScreenshotTests/GeneralScreenshotTests.swift`
- `Argo/ArgoUITests/DVXCoreTeam/UITests/MockTests.swift`
- `Argo/ArgoUITests/DVXDiscoverTeam/ScreenshotTests/Lolomo/LolomoScreenshotTests.swift`
- `Argo/ArgoUITests/DVXExploreTeam/ScreenshotTests/MyProfileScreenshotTests.swift`
- `Argo/ArgoUITests/Utils/Applitools/ApplitoolsTest.swift` (two mixin helpers: `mockKidsLolomoAndBillboard`, `mockAdultLolomoAndBillboard`)

## Evidence (recent ~11 days, iOS team)

| Test | Fail rate | Failure signature |
|---|---|---|
| `test_LocalMomentsApplitools` | 8/13 (62%) | `"genre-…" Button does not exist` |
| `testCWMenuAvailable` | 4/6 (67%) | `"row-continueWatching" ScrollView does not exist` |
| `test_LocalMomentsAfricaDay` | 13/28 (46%) | `"genre-…" Button does not exist` |
| `test_LocalMoments` | 42/92 (46%) | `"genre-…" Button does not exist` |
| `testExtraExtraExtraLargeRow` | 5/12 (42%) | `"row-downloadsForYou" ScrollView does not exist` |
| `test_LocalMomentsAAPIS` | 11/28 (39%) | `"genre-…" Button does not exist` |
| `test_LocalMomentsKoreanEntertainment` | 11/29 (38%) | `"genre-…" Button does not exist` |
| `testDownloadsForYouRowSettingsAction` | 30/84 (36%) | `"row-downloadsForYou" ScrollView does not exist` |
| `test_GPSMock_Billboard` | 8/27 (30%) | `lolomo.billboard.exists` timeout |
| `test_OUIScreenshotBillboardStandardApplitools` | 3/11 (27%) | `lolomo.billboard.exists` timeout |

Triage HOT: https://hot.prod.netflix.net/runs/6a182ed7a7333cf7b8e2ec6c?team=ios&tab=HTTP+Log&httpLogExpandedRows=2,2 — failing run on build 31578 / main. The AX hierarchy at the failure timestamp shows the Phoenix IA ContentBar layout (`aroMenuItem-Series`, `aroMenuItem-Movies`, `aroSubGenreButton-withGenre`, bottom `homeTab` / `videoFeedTab` / `searchButton` / `profileTab`) with no `billboard-play` button. The mocked GPS POST returned 204 — the mock was installed; the layout just doesn't render it.

## Cell choice

AB 79360 cell layout (per Ablaze):
- Cell 1: Production Experience (= current rollout state)
- Cell 2: Old IA, No Vertical Video ← **picked — strictly legacy lolomo**
- Cell 3: Phoenix IA, Vertical Video
- Cell 4: Phoenix IA, No Vertical Video
- Cell 5: (Optional) Old IA, Vertical Video

## Out of scope

- `test_MosaicMock_Combined` (uses `Mock.makePageOverride`) passes 19/21 — that mocking path empirically does survive Phoenix IA, so adding the holdback there would be speculative.

## Test plan

- [ ] CI build on this PR confirms compile against the Xcode 26.5 toolchain (local Xcode 26.2 hits a Swift 6.3 issue in NetflixConcurrency unrelated to this change).
- [ ] Meeseeks N× verification batch on the touched tests once a build artifact is available.
- [ ] Keep as draft until verification finishes.
