### PR TITLE
Make the reconnect link visible and clickable on the error banner

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -427,6 +427,20 @@ main {
 .status-banner--success  { background: var(--ink); }
 .status-banner--error    { background: var(--oxblood); }
 .status-banner--progress { background: var(--ink); }
+/* The banner itself ignores pointer events so transient toasts don't
+   trap clicks on the page behind them, but an embedded action (e.g.
+   the reconnect link on an expired-session error) has to be clickable
+   and legible against the dark banner — the default oxblood link color
+   would vanish into the oxblood error background. */
+.status-banner .link-button {
+  pointer-events: auto;
+  color: var(--paper);
+  border-bottom-color: var(--paper);
+}
+.status-banner .link-button:hover {
+  color: var(--paper);
+  border-bottom-color: transparent;
+}
 /* Animated trailing ellipsis on progress toasts — reads as 'still
    working' on its own, so we don't also need the leading pulse dot. */
 .status-banner--progress::after {


### PR DESCRIPTION
## Summary

The reconnect link on the "Strava session expired" error banner (added in #198) was invisible and unclickable in production:

- `.link-button` is colored `var(--oxblood)`, which vanishes against the oxblood error-banner background.
- `.status-banner` sets `pointer-events: none` (so transient toasts don't trap page clicks), which also blocked the embedded button.

This adds a scoped rule so `.status-banner .link-button` is paper-colored, paper-underlined, and `pointer-events: auto` — legible and clickable. The banner surface itself keeps `pointer-events: none`, so only the action is hit-testable; page clicks behind transient toasts are not re-trapped.

CSS-only change.

## Test plan

- [x] `node build.js` succeeds; rule present in `dist/app.min.css`
- [ ] Expired-session error banner shows a visible "reconnect" link
- [ ] Clicking it starts the Strava connect flow
