### PR TITLE
Retry transient Strava 5xx and show a calm message; force OAuth consent

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
 import {
   parseAuthHash, clearAuthHash, loadSession, saveSession, clearSession, authorizeUrl,
-  syncRecent, fetchSyncedActivities, UnauthenticatedError,
+  syncRecent, fetchSyncedActivities, UnauthenticatedError, StravaUnavailableError,
 } from './strava-session.js';
 
 const dropZone = document.getElementById('archive-drop');
@@ -318,6 +318,14 @@ async function triggerStravaSync() {
     // generic error over a session that will keep failing.
     if (err instanceof UnauthenticatedError || err?.unauthenticated) {
       await handleExpiredSession();
+      return;
+    }
+    // A 5xx is almost always Strava erroring server-side (a generic
+    // {"message":"error"}) that outlasted the worker's retries — not
+    // something the user can act on beyond waiting. Show a calm,
+    // actionable line instead of the raw nested error body.
+    if (err instanceof StravaUnavailableError || err?.stravaUnavailable) {
+      showStatus('Strava is temporarily unavailable — try again in a few minutes.', { kind: 'error', dwellMs: 6000 });
       return;
     }
     showStatus(`Strava sync failed: ${err.message || err}`, { kind: 'error', dwellMs: 5000 });

--- a/src/strava-session.js
+++ b/src/strava-session.js
@@ -26,6 +26,18 @@ export class UnauthenticatedError extends Error {
   }
 }
 
+// Thrown when the worker returns a 5xx — almost always because Strava
+// itself returned a transient server error ({"message":"error"}) that
+// outlasted the worker's retries. The caller surfaces a calm "try
+// again in a few minutes" rather than dumping the nested error body.
+export class StravaUnavailableError extends Error {
+  constructor(message = 'strava temporarily unavailable') {
+    super(message);
+    this.name = 'StravaUnavailableError';
+    this.stravaUnavailable = true;
+  }
+}
+
 // Read window.location.hash, return { session, athleteId, error }
 // when any auth params are present. Caller decides what to do —
 // success path stores them; error path surfaces to the user.
@@ -103,6 +115,7 @@ export async function syncRecent({ session, days = 180, knownIds = [], onProgres
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       if (res.status === 401) throw new UnauthenticatedError(`sync failed: 401 ${text}`);
+      if (res.status >= 500) throw new StravaUnavailableError(`sync failed: ${res.status} ${text}`);
       throw new Error(`sync failed: ${res.status} ${text}`);
     }
     const slice = await res.json();
@@ -132,6 +145,7 @@ export async function fetchSyncedActivities(session) {
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     if (res.status === 401) throw new UnauthenticatedError(`activities load failed: 401 ${text}`);
+    if (res.status >= 500) throw new StravaUnavailableError(`activities load failed: ${res.status} ${text}`);
     throw new Error(`activities load failed: ${res.status} ${text}`);
   }
   const body = await res.json();

--- a/tests/strava-api.test.js
+++ b/tests/strava-api.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { listActivitiesAfter, fetchPowerStream } from '../worker/strava-api.js';
+
+// No-op sleep so the backoff doesn't actually wait during tests.
+const noSleep = { sleep: async () => {} };
+
+function jsonRes(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('listActivitiesAfter retry', () => {
+  it('retries a 500 and succeeds when Strava recovers', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      if (calls < 3) return jsonRes(500, { message: 'error' });
+      return jsonRes(200, []); // empty page -> loop breaks
+    };
+    const out = await listActivitiesAfter(
+      { accessToken: 't', afterEpoch: 0 },
+      fetchImpl,
+      noSleep,
+    );
+    expect(calls).toBe(3); // two 500s, then a 200
+    expect(out).toEqual([]);
+  });
+
+  it('throws after exhausting retries on a persistent 500', async () => {
+    let calls = 0;
+    const fetchImpl = async () => { calls += 1; return jsonRes(500, { message: 'error' }); };
+    await expect(
+      listActivitiesAfter({ accessToken: 't', afterEpoch: 0 }, fetchImpl, { ...noSleep, retries: 3 }),
+    ).rejects.toThrow(/strava list activities 500/);
+    expect(calls).toBe(4); // initial + 3 retries
+  });
+
+  it('does not retry a 4xx', async () => {
+    let calls = 0;
+    const fetchImpl = async () => { calls += 1; return jsonRes(401, { message: 'Authorization Error' }); };
+    await expect(
+      listActivitiesAfter({ accessToken: 't', afterEpoch: 0 }, fetchImpl, noSleep),
+    ).rejects.toThrow(/strava list activities 401/);
+    expect(calls).toBe(1); // no retry
+  });
+});
+
+describe('fetchPowerStream retry', () => {
+  it('retries a 503 then returns the watts stream', async () => {
+    let calls = 0;
+    const fetchImpl = async () => {
+      calls += 1;
+      if (calls < 2) return jsonRes(503, { message: 'error' });
+      return jsonRes(200, { watts: { data: [100, 200, 300] } });
+    };
+    const out = await fetchPowerStream({ accessToken: 't', activityId: 1 }, fetchImpl, noSleep);
+    expect(calls).toBe(2);
+    expect(out).toEqual([100, 200, 300]);
+  });
+
+  it('still short-circuits a 404 to null without retrying', async () => {
+    let calls = 0;
+    const fetchImpl = async () => { calls += 1; return jsonRes(404, {}); };
+    const out = await fetchPowerStream({ accessToken: 't', activityId: 1 }, fetchImpl, noSleep);
+    expect(out).toBeNull();
+    expect(calls).toBe(1);
+  });
+});

--- a/tests/strava-oauth.test.js
+++ b/tests/strava-oauth.test.js
@@ -21,6 +21,20 @@ describe('buildAuthorizeUrl', () => {
     expect(url.searchParams.get('scope')).toBe('read,activity:read_all');
     expect(url.searchParams.get('response_type')).toBe('code');
   });
+
+  it("forces the consent screen by default so users can re-grant scope", () => {
+    const url = new URL(buildAuthorizeUrl({
+      clientId: '1', redirectUri: 'https://x/cb', state: 's', scope: 'read',
+    }));
+    expect(url.searchParams.get('approval_prompt')).toBe('force');
+  });
+
+  it('honors an explicit approvalPrompt override', () => {
+    const url = new URL(buildAuthorizeUrl({
+      clientId: '1', redirectUri: 'https://x/cb', state: 's', scope: 'read', approvalPrompt: 'auto',
+    }));
+    expect(url.searchParams.get('approval_prompt')).toBe('auto');
+  });
 });
 
 describe('exchangeCodeForTokens', () => {

--- a/tests/strava-session.test.js
+++ b/tests/strava-session.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   parseAuthHash, authorizeUrl, API_BASE,
   loadSession, saveSession, clearSession,
-  syncRecent, fetchSyncedActivities, UnauthenticatedError,
+  syncRecent, fetchSyncedActivities, UnauthenticatedError, StravaUnavailableError,
 } from '../src/strava-session.js';
 import { saveSettings } from '../src/storage.js';
 
@@ -89,11 +89,25 @@ describe('401 handling', () => {
     await expect(syncRecent({ session: 'dead' })).rejects.toBeInstanceOf(UnauthenticatedError);
   });
 
-  it('syncRecent throws a plain Error on other failures', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(500, { error: 'boom' })));
+  it('syncRecent throws StravaUnavailableError on a 5xx', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(500, { error: 'strava list activities 500' })));
+    const err = await syncRecent({ session: 'tok' }).catch((e) => e);
+    expect(err).toBeInstanceOf(StravaUnavailableError);
+    expect(err.stravaUnavailable).toBe(true);
+    expect(err.unauthenticated).toBeUndefined();
+  });
+
+  it('fetchSyncedActivities throws StravaUnavailableError on a 503', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(503, { error: 'unavailable' })));
+    await expect(fetchSyncedActivities('tok')).rejects.toBeInstanceOf(StravaUnavailableError);
+  });
+
+  it('syncRecent throws a plain Error on a 4xx that is not 401', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(400, { error: 'bad json' })));
     const err = await syncRecent({ session: 'tok' }).catch((e) => e);
     expect(err).toBeInstanceOf(Error);
     expect(err.unauthenticated).toBeUndefined();
+    expect(err.stravaUnavailable).toBeUndefined();
   });
 
   it('fetchSyncedActivities throws UnauthenticatedError on a 401', async () => {

--- a/worker/strava-api.js
+++ b/worker/strava-api.js
@@ -5,19 +5,44 @@
 
 const STRAVA_API = 'https://www.strava.com/api/v3';
 
+// Strava intermittently returns generic 5xx ({"message":"error"}) and
+// rate-limit 429s that clear on a retry. Retry those a few times with
+// exponential backoff so a transient blip on one page doesn't fail the
+// whole sync. Non-retryable statuses (and the final attempt) return as-
+// is for the caller to handle. `sleep` is injectable so tests don't
+// actually wait.
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+async function fetchWithRetry(
+  fetchImpl,
+  url,
+  init,
+  { retries = 3, baseDelayMs = 500, sleep = (ms) => new Promise((r) => setTimeout(r, ms)) } = {},
+) {
+  let attempt = 0;
+  while (true) {
+    const res = await fetchImpl(url, init);
+    if (res.ok || !RETRYABLE_STATUS.has(res.status) || attempt >= retries) return res;
+    attempt += 1;
+    // 500ms, 1s, 2s — bounded; Strava's blips are usually sub-second.
+    await sleep(baseDelayMs * 2 ** (attempt - 1));
+  }
+}
+
 // List activities the athlete recorded after `afterEpoch` (unix s).
 // Strava paginates per_page (max 200). We page until an empty page or
 // the requested cap is reached.
 export async function listActivitiesAfter(
   { accessToken, afterEpoch, perPage = 200, maxPages = 5 },
   fetchImpl = fetch,
+  retryOpts = {},
 ) {
   const out = [];
   for (let page = 1; page <= maxPages; page++) {
     const url = `${STRAVA_API}/athlete/activities?after=${afterEpoch}&per_page=${perPage}&page=${page}`;
-    const res = await fetchImpl(url, {
+    const res = await fetchWithRetry(fetchImpl, url, {
       headers: { Authorization: `Bearer ${accessToken}` },
-    });
+    }, retryOpts);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`strava list activities ${res.status}: ${text}`);
@@ -36,11 +61,12 @@ export async function listActivitiesAfter(
 export async function fetchPowerStream(
   { accessToken, activityId },
   fetchImpl = fetch,
+  retryOpts = {},
 ) {
   const url = `${STRAVA_API}/activities/${activityId}/streams?keys=watts&key_by_type=true`;
-  const res = await fetchImpl(url, {
+  const res = await fetchWithRetry(fetchImpl, url, {
     headers: { Authorization: `Bearer ${accessToken}` },
-  });
+  }, retryOpts);
   if (res.status === 404) return null;
   if (!res.ok) {
     const text = await res.text().catch(() => '');

--- a/worker/strava-oauth.js
+++ b/worker/strava-oauth.js
@@ -8,12 +8,19 @@ const STRAVA_TOKEN = 'https://www.strava.com/oauth/token';
 // Build the redirect URL we send the user to when they click
 // "Connect Strava." Strava round-trips state back to our callback
 // so we can defeat CSRF and resume a frontend return path.
-export function buildAuthorizeUrl({ clientId, redirectUri, state, scope }) {
+//
+// approvalPrompt defaults to 'force' so the consent screen is shown
+// every time. With 'auto', Strava silently re-approves an already-
+// authorized app with whatever scopes it was last granted — so a user
+// who accidentally unchecked the activity permission can never re-grant
+// it by reconnecting; they'd be stuck with a read-only token that 500s
+// on every activity list. Forcing the prompt lets them fix it.
+export function buildAuthorizeUrl({ clientId, redirectUri, state, scope, approvalPrompt = 'force' }) {
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     response_type: 'code',
-    approval_prompt: 'auto',
+    approval_prompt: approvalPrompt,
     scope,
     state,
   });


### PR DESCRIPTION
## Summary

A sync hit `500 {"message":"error"}` from Strava. We reproduced it directly against the Strava API with the worker's own (valid, fresh) token: even `/athlete` — which needs no scope and touches no activity data — returned 500. So it's a transient Strava-side server error, not our code, not OAuth scope, not the user's data. An *invalid* token, by contrast, returns a clean 401. This PR makes the app ride out that class of failure instead of dumping a nested error body.

### Changes

1. **Retry transient Strava 5xx** (`worker/strava-api.js`) — new `fetchWithRetry` retries on 429/500/502/503/504 with exponential backoff (500ms → 1s → 2s, 3 retries) in `listActivitiesAfter` and `fetchPowerStream`. A one-off Strava blip now self-recovers instead of failing the whole sync. `sleep` is injectable so tests don't wait.
2. **Calm user message** (`src/strava-session.js`, `src/app.js`) — a worker 5xx now throws `StravaUnavailableError`, and the sync handler shows *"Strava is temporarily unavailable — try again in a few minutes"* instead of the raw nested JSON. The existing 401 → reconnect path is unchanged.
3. **Force OAuth consent** (`worker/strava-oauth.js`) — `approval_prompt` now defaults to `'force'` (was `'auto'`). With `auto`, Strava silently re-approves an already-connected app with whatever scopes it last had, so a user who dropped a scope could never re-grant it by reconnecting. **UX note:** this means the Strava consent screen now appears on *every* connect, including happy-path reconnects — an intentional tradeoff so scope is always re-grantable.

### Note on the original incident
None of this *fixes* the live Strava 500 — only Strava's side recovering does — but the retry absorbs transient blips and the message stops the scary error dump.

## Test plan

- [x] `npx vitest run` — 143 pass (was 134); new `tests/strava-api.test.js` covers retry success/exhaustion/no-retry-on-4xx and the 404→null short-circuit
- [x] `node build.js` succeeds
- [ ] During a Strava 5xx, sync shows the calm message (not nested JSON)
- [ ] Reconnect shows the Strava consent screen
