### PR TITLE
Trigger worker deploy on worker/ module changes

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'worker.js'
+      - 'worker/**'
       - 'wrangler.toml'
       - 'migrations/**'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

The Cloudflare Worker deploy workflow only triggered on `worker.js`, `wrangler.toml`, and `migrations/**`. But `worker.js` imports its logic from the `worker/` directory (`worker/strava-api.js`, `worker/strava-oauth.js`, `worker/sync.js`), so **changes to those modules never triggered a deploy** — worker logic silently failed to ship. This adds `worker/**` to the path filter.

Discovered while shipping the Strava 5xx retry (#200): that PR's worker changes didn't auto-deploy and had to be pushed manually with `wrangler deploy`.

**Heads up (out of scope here):** the deploy-worker workflow has *also* been failing at the `cloudflare/wrangler-action` step since 2026-04-30 (npx exit 1 — likely an expired/missing `CLOUDFLARE_API_TOKEN` secret). This PR makes it *trigger* on the right paths, but the action itself may still fail until that secret is refreshed. Worker deploys have been happening manually in the meantime.

## Test plan

- [x] YAML parses; `worker/**` glob matches the imported modules
- [ ] A future PR touching `worker/*.js` triggers the deploy workflow
