### PR TITLE
Bump worker-deploy actions off Node 20 and use repo-pinned wrangler

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -21,7 +21,7 @@ jobs:
           cache: npm
       # Install so wrangler-action picks up the repo-pinned wrangler
       # (devDependencies) instead of falling back to its own bundled
-      # version — keeps CI deploys on the same wrangler we run locally.
+      # version. Keeps CI deploys on the same wrangler we run locally.
       - run: npm ci
       - uses: cloudflare/wrangler-action@v4
         with:

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -14,8 +14,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cloudflare/wrangler-action@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      # Install so wrangler-action picks up the repo-pinned wrangler
+      # (devDependencies) instead of falling back to its own bundled
+      # version — keeps CI deploys on the same wrangler we run locally.
+      - run: npm ci
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Hygiene follow-up to the worker-deploy CI fix. Two issues the green run surfaced:

1. The workflow ran on **deprecated Node 20** actions (`actions/checkout@v4`, `cloudflare/wrangler-action@v3`) — GitHub forces these to Node 24 on June 16, 2026.
2. `wrangler-action` fell back to its **own bundled wrangler (3.90.0)** because the workflow never installed the repo's deps, despite the repo pinning `wrangler ^4.87.0`.

### Changes
- Bump `actions/checkout` → v6, add `actions/setup-node@v6` (Node 22 + npm cache).
- Add `npm ci` so `wrangler-action` uses the repo-pinned wrangler 4.x instead of its bundled version — CI now deploys with the same wrangler we run locally.
- Bump `cloudflare/wrangler-action` → v4.

## Test plan

- [x] YAML valid; action majors current (checkout v6, setup-node v6, wrangler-action v4)
- [x] `package-lock.json` present so `npm ci` resolves wrangler 4.87.0
- [ ] Next run (auto on merge, since this touches a watched path) deploys green on Node 24 + wrangler 4.x
