### PR TITLE
Clarify the power-duration fit line is a model, not observed data

### DIFF
--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -146,7 +146,7 @@ export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 9
         value: (_u, v) => (v == null ? '—' : `${Math.round(v)} W`),
       },
       {
-        label: `CP fit · ${fitWindowLabel}`,
+        label: `CP model · fit to ${fitWindowLabel}`,
         stroke: ink,
         width: 1.5,
         points: { show: false },


### PR DESCRIPTION
## Summary

The power-duration curve's live legend labeled the fit series `CP fit · last 90 days`, which read as if it were observed data sharing the same window banner as the observed-MMP table. Hovering at 30s showed `688 W` under that entry while the table's observed best 30s was `537 W` — two numbers under "last 90 days" that look like the same measurement but aren't.

That 688 W is the fitted **CP model** prediction at 30s. Because a 3-param Morton fit succeeded, the fit window extends down to 30s (`DEFAULT_FIT_RANGE_3P.minS = 30`), and the model can sit well above the rider's actual short-duration peak.

This relabels the series to `CP model · fit to <window>` so the value reads as a prediction, not an observed effort. Display-only change; no fitting or data logic touched.

## Test plan

- [ ] Load the app with a fit that uses the 3-param model; hover the curve and confirm the fit entry now reads `CP model · fit to last 90 days`
- [ ] Confirm the observed-MMP legend entry and table values are unchanged
- [ ] With a custom date range set, confirm the label reads `CP model · fit to custom range`