### PR TITLE
Fit fatigue k from effort-filtered MMP, not raw rolling-best

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -718,8 +718,17 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // Personal fatigue exponent fitted from long-duration MMP. Replaces
   // the default Riegel k = 0.10 at predict time when enough 20-min-to-
   // 4-hr points exist. Falls back to the default otherwise.
+  //
+  // Use the same effort-quality-filtered set the CP regression uses,
+  // NOT the raw rolling-best. Long-duration "bests" are usually sub-
+  // maximal — endurance rides ridden at endurance pace, not all-out
+  // 3-4h tests. Feeding those raw points to the slope fit reports a
+  // catastrophic decay (k pinned at the 0.20 rail) that reflects ride
+  // selection, not physiology. Filtering by IF drops the easy long
+  // rides; if too few hard long efforts remain, fitFatigueK returns
+  // null and we fall back to the gentler default 0.10.
   if (currentFit) {
-    const fatigueSource = currentFit.fallback ? fallbackObserved : primaryObserved;
+    const fatigueSource = currentFit.fallback ? fallbackPoints : primaryPoints;
     currentFit = { ...currentFit, fatigue: fitFatigueK(fatigueSource) };
   }
 


### PR DESCRIPTION
## Summary

The personal Riegel fatigue exponent `k` (which sets how the power-duration tail decays past 20 min) was being fit from the **raw** long-duration rolling-best, while the CP regression uses an **effort-quality-filtered** set (`minIF` drops easy base rides).

For a rider without all-out 3–4h tests in their file, raw long-duration "bests" are sub-maximal endurance rides. That makes the 20m→4h decline look catastrophic — observed here as raw `k = 0.26`, slammed into the 0.20 plausibility rail, producing an extrapolation tail that falls off harder than the curve's trend suggests. The clamp was masking contaminated input rather than reflecting physiology.

This points the fatigue source at the same effort-filtered MMP the CP fit already uses (`primaryPoints` / `fallbackPoints`), so easy long rides no longer define fatigue resistance. When too few hard long efforts survive the filter, `fitFatigueK` returns `null` and prediction falls back to the gentler default `k = 0.10` — which is honest about the absence of maximal long-duration data.

Display/model-input change only; no fitting math touched.

## Test plan

- [x] `npx vitest run` — 143 passed
- [ ] Load the app: the fatigue exponent readout should drop from `0.26 clamped` to either a fitted value in the 0.04–0.20 range (badge "N pts") or `default` (0.10)
- [ ] Confirm the extrapolation tail past 20m is gentler / no longer pinned to the steep rail
- [ ] Confirm observed-MMP dots and the CP curve (≤20m) are unchanged