### PR TITLE
Discard clamped fatigue k; use default decay instead of the rail

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ import {
   loadSettings,
   saveSettings,
 } from './storage.js';
-import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints } from './cpfit.js';
+import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints, DEFAULT_DECAY } from './cpfit.js';
 import { parseDuration } from './duration.js';
 import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
@@ -1015,26 +1015,34 @@ function formTooltip() {
 // Fatigue k: personal Riegel exponent fitted from 20-min-to-4-hr MMP.
 // When data is too sparse to fit, predictions fall back to k = 0.10 —
 // we show that here too so the cell isn't ever blank.
+// A clamped fit is discarded for prediction (see wirePredictForm /
+// renderCurveChart), so the readout reports the default k that's
+// actually in use — never the implausible rail value.
+function usesDefaultK(fit) {
+  return !fit.fatigue || fit.fatigue.clamped;
+}
 function fatigueValue(fit) {
-  const k = fit.fatigue?.k ?? 0.10;
+  const k = usesDefaultK(fit) ? DEFAULT_DECAY.k : fit.fatigue.k;
   return k.toFixed(2);
 }
 function fatigueQuality(fit) {
-  if (!fit.fatigue) return { label: 'default', cls: 'is-mid' };
-  if (fit.fatigue.clamped) return { label: 'clamped', cls: 'is-mid' };
+  if (usesDefaultK(fit)) return { label: 'default', cls: 'is-mid' };
   return { label: `${fit.fatigue.nPoints} pts`, cls: 'is-good' };
 }
 function fatigueTooltip(fit) {
-  if (!fit.fatigue) {
+  const def = DEFAULT_DECAY.k.toFixed(2);
+  if (usesDefaultK(fit)) {
+    const why = fit.fatigue
+      ? `Your long-duration data implied k = ${fit.fatigue.kRaw.toFixed(2)}, outside the `
+        + '0.04–0.20 plausible range — almost always sub-maximal long efforts rather than '
+        + 'real fatigue resistance, so it’s discarded. '
+      : 'Need 3+ MMP points between 20 min and 4 h to fit a personal value. ';
     return 'Riegel fatigue exponent k governs how predicted power decays past 20 min: '
-         + 'P(t) = P_anchor × (t_anchor / t)^k. Need 3+ MMP points between 20 min and 4 h '
-         + 'to fit a personal value; falling back to the cycling default 0.10.';
+         + `P(t) = P_anchor × (t_anchor / t)^k. ${why}`
+         + `Using the cycling default ${def}.`;
   }
-  const note = fit.fatigue.clamped
-    ? ` Raw fit was ${fit.fatigue.kRaw.toFixed(2)}, clamped into the 0.04–0.20 plausible range.`
-    : '';
   return `Personal Riegel fatigue exponent fitted from ${fit.fatigue.nPoints} long-duration MMP points `
-       + `(20 min – 4 h). Lower k = better endurance fall-off. Cycling default is 0.10.${note}`;
+       + `(20 min – 4 h). Lower k = better endurance fall-off. Cycling default is ${def}.`;
 }
 
 // Combined fit-quality summary: pick whichever of RMSE / points is
@@ -1483,7 +1491,12 @@ function wirePredictForm() {
       out.innerHTML = `<p class="predict-output__error">Couldn't parse that. Try "45m", "1h30m", or "90s".</p>`;
       return;
     }
-    const decayOpt = currentFit.fatigue ? { decay: { k: currentFit.fatigue.k } } : {};
+    // A clamped fatigue fit is physically implausible — almost always
+    // sub-maximal long efforts, not real fatigue resistance — so we
+    // discard it and let predictPower fall back to its default k.
+    const decayOpt = (currentFit.fatigue && !currentFit.fatigue.clamped)
+      ? { decay: { k: currentFit.fatigue.k } }
+      : {};
     const raw = predictPower(currentFit, seconds, decayOpt);
     if (!raw) {
       out.hidden = false;

--- a/src/curve-chart.js
+++ b/src/curve-chart.js
@@ -78,7 +78,10 @@ export function renderCurveChart(container, { mmp, fit, fitWindowLabel = 'last 9
   // Solid inside the fit window, dashed outside; both series share
   // d == DEFAULT_DECAY.fromS so the visual transition is seamless.
   const lineOpts = { useObservedAnchors: false };
-  if (fit.fatigue) lineOpts.decay = { k: fit.fatigue.k };
+  // Skip a clamped fatigue fit — its rail value reflects implausible
+  // (usually sub-maximal) long-duration data, not real fatigue. Let
+  // predictPower fall back to its gentler default k instead.
+  if (fit.fatigue && !fit.fatigue.clamped) lineOpts.decay = { k: fit.fatigue.k };
   const insideSeries = xs.map((d) => {
     if (d < fit.range.minS || d > DEFAULT_DECAY.fromS) return null;
     const out = predictPower(fit, d, lineOpts);


### PR DESCRIPTION
## Summary

A *clamped* Riegel fatigue exponent (raw `k` outside the 0.04–0.20 plausible range) signals physically implausible long-duration data — almost always sub-maximal long efforts (a 3–4h training ride is never an all-out test), not real fatigue resistance. The model was still using the **clamped rail value (0.20)** anyway, producing an extrapolation tail far steeper than the rider's curve trend warrants.

Real-world trigger: a rider with raw `k ≈ 0.27` (clamped to 0.20) saw the curve "fall off a cliff" past 20 min, well below where their power-duration trend pointed.

This discards clamped fits for prediction:
- The **curve** (`curve-chart.js`) and the **predict form** (`app.js`) now fall back to `predictPower`'s default `k` (0.10) when `fit.fatigue.clamped` is true.
- The fit-stats readout reports the default actually in use (badge `default`) via a new `usesDefaultK(fit)` helper, and the tooltip still surfaces the rejected raw value so the diagnostic isn't lost.

Note: activity-level effort filtering (PR #204) can't fix this on its own — a long tempo ride clears the average-IF gate yet still isn't a maximal long-duration effort, so the steep points survive. Discarding the clamped fit is the honest fallback until genuinely maximal long-duration data exists.

## Test plan

- [x] `npx vitest run` — 143 passed (on the byte-identical commit)
- [ ] Load the app with a clamped fatigue fit: readout shows `0.10` with badge `default` (tooltip notes the rejected raw value)
- [ ] Extrapolation tail past 20m is visibly gentler, tracking the curve trend
- [ ] CP curve (≤20m) and observed dots unchanged
- [ ] A non-clamped personal fit still shows its fitted `k` with the `N pts` badge