### PR TITLE
Reframe the intro as sync-first, archive as fallback

### DIFF
--- a/docs/superpowers/plans/2026-06-02-sync-first-intro.md
+++ b/docs/superpowers/plans/2026-06-02-sync-first-intro.md
@@ -1,0 +1,319 @@
+# Sync-first Intro Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reframe the landing page so connecting/syncing Strava is the recommended primary path and the archive download is the optional fallback — in copy, DOM order, and visual weight.
+
+**Architecture:** Pure presentation change. Rewrite the three "How it works" steps, move the Strava Connect panel above the archive drop zone, swap their visual weight in CSS, and make the Connect panel render visible by default (it is currently `hidden` until JS runs). No prediction, sync, auth, or parsing logic changes.
+
+**Tech Stack:** Static `index.html`, `shared.css`, vanilla JS in `src/app.js`. Tests run with `npx vitest` (pure-logic suites; no DOM tests in this repo).
+
+**Branch:** `sync-first-intro` (already created; spec committed there).
+
+**Test strategy note:** This repo has no DOM/jsdom tests — its suites test pure functions. This change is copy + CSS + markup order, so verification is done in a browser (visual) plus keeping `npx vitest` green as a regression guard. Do **not** add a one-off jsdom test against project convention.
+
+---
+
+## File Structure
+
+- `index.html` — the three step `<li>`s, the order of `#strava-data-source` vs `#archive-drop`, and the Connect panel's default (non-hidden) markup.
+- `shared.css` — visual-weight swap (promote `.data-sources--inline`, demote `#archive-drop`) and entrance-animation delay order.
+- `src/app.js` — verified to need **no logic change**: `refreshStravaUi()` already rebuilds the panel's status + actions on load, so it refines the new static default rather than revealing it. (Task 4 confirms this.)
+
+---
+
+## Task 1: Rewrite the three steps to sync-first copy
+
+**Files:**
+- Modify: `index.html:34-50`
+
+- [ ] **Step 1: Replace the `<ol class="steps">` block**
+
+Replace this exact block:
+
+```html
+    <ol class="steps" aria-label="How it works">
+      <li>
+        <span class="step-num">01 / Request</span>
+        <h2>Ask Strava for your archive</h2>
+        <p>They prepare it offline and email a link within hours. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
+      </li>
+      <li>
+        <span class="step-num">02 / Drop</span>
+        <h2>Drag the zip onto the page</h2>
+        <p>Parsed in your browser. Raw streams never leave your machine.</p>
+      </li>
+      <li>
+        <span class="step-num">03 / Read</span>
+        <h2>See your power-duration curve</h2>
+        <p>Connect Strava later so new rides flow in automatically.</p>
+      </li>
+    </ol>
+```
+
+with:
+
+```html
+    <ol class="steps" aria-label="How it works">
+      <li>
+        <span class="step-num">01 / Connect</span>
+        <h2>Connect your Strava</h2>
+        <p>Authorize once and we sync your last 180 days. No download, no waiting.</p>
+      </li>
+      <li>
+        <span class="step-num">02 / Read</span>
+        <h2>See your power-duration curve</h2>
+        <p>Recent rides weighted heaviest, so it reflects current fitness.</p>
+      </li>
+      <li>
+        <span class="step-num">03 / Extend</span>
+        <h2>Want your full history?</h2>
+        <p>Download your Strava archive and drop the zip in. Parsed in your browser; raw streams never leave your machine. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
+      </li>
+    </ol>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add index.html
+git commit -m "Reframe intro steps to lead with Strava sync"
+```
+
+---
+
+## Task 2: Reorder surfaces and make the Connect panel visible by default
+
+**Files:**
+- Modify: `index.html:52-66`
+
+Today the `#archive-drop` zone (line 52) renders before the `#strava-data-source` aside (line 58), and the aside is `hidden` until JS un-hides it. We move the aside above the drop, remove `hidden`, and seed the disconnected default (status sentence + Connect button) so the lead CTA is present before JS runs.
+
+- [ ] **Step 1: Replace the drop + aside block**
+
+Replace this exact block:
+
+```html
+    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your archive">
+      <input type="file" id="archive-input" accept=".zip" hidden>
+      <span class="drop__label">Drop your archive</span>
+      <span class="drop__hint">strava_export_*.zip · or click to browse</span>
+    </div>
+
+    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source" hidden>
+      <section class="data-sources__row">
+        <span class="data-sources__label">Strava</span>
+        <p class="data-sources__line">
+          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
+          <span class="data-sources__actions" id="strava-status-actions"></span>
+        </p>
+      </section>
+    </aside>
+```
+
+with (aside first, no `hidden`, static Connect button seeded; drop second):
+
+```html
+    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source">
+      <section class="data-sources__row">
+        <span class="data-sources__label">Strava</span>
+        <p class="data-sources__line">
+          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
+          <span class="data-sources__actions" id="strava-status-actions"><button type="button" class="link-button" id="strava-connect-btn">Connect</button></span>
+        </p>
+      </section>
+    </aside>
+
+    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your archive">
+      <input type="file" id="archive-input" accept=".zip" hidden>
+      <span class="drop__label">Drop your archive</span>
+      <span class="drop__hint">strava_export_*.zip · or click to browse</span>
+    </div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add index.html
+git commit -m "Lead with the Strava Connect panel above the archive drop"
+```
+
+---
+
+## Task 3: Swap visual weight and fix animation order in CSS
+
+**Files:**
+- Modify: `shared.css:359-363` (the `.data-sources--inline` block — promote to a bracketed card)
+- Modify: `shared.css:299-308` (the `.drop` block — demote to a quieter affordance)
+- Modify: `shared.css:1734-1738` (entrance-animation delays — new order)
+
+The promoted Connect panel reuses the drop zone's corner-bracket visual language so it reads as the primary call to action; the drop zone shrinks and loses its brackets so it reads as the understated fallback below it.
+
+- [ ] **Step 1: Promote the Connect panel — replace the `.data-sources--inline` block**
+
+Replace:
+
+```css
+.data-sources--inline {
+  margin: 1rem 0 0;
+  padding: 0.6rem 0;
+  border-top: 0;
+}
+```
+
+with:
+
+```css
+/* On the onboarding screen this is the PRIMARY call to action, so it
+   takes the prominent bracketed-card treatment the drop zone used to
+   own. The internal row layout (label · status · actions) is unchanged. */
+.data-sources--inline {
+  position: relative;
+  margin: 1.5rem 0 0;
+  padding: clamp(1.75rem, 4vw, 2.5rem) 2rem;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair-strong);
+  border-top: 1px solid var(--hair-strong);
+}
+.data-sources--inline::before, .data-sources--inline::after {
+  content: "";
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--ink);
+}
+.data-sources--inline::before {
+  top: -1px; left: -1px;
+  border-right: none; border-bottom: none;
+}
+.data-sources--inline::after {
+  bottom: -1px; right: -1px;
+  border-left: none; border-top: none;
+}
+```
+
+- [ ] **Step 2: Demote the drop zone — replace the `.drop` block**
+
+Replace:
+
+```css
+.drop {
+  position: relative;
+  margin: 1.5rem 0 0;
+  padding: clamp(2.5rem, 6vw, 4rem) 2rem;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair-strong);
+  text-align: center;
+  cursor: pointer;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+.drop::before, .drop::after {
+  content: "";
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--ink);
+  transition: border-color 200ms ease, width 200ms ease, height 200ms ease;
+}
+```
+
+with (compact, no corner brackets — the brackets now belong to the Connect card):
+
+```css
+.drop {
+  position: relative;
+  margin: 0.75rem 0 0;
+  padding: 1.25rem 2rem;
+  background: var(--paper-soft);
+  border: 1px dashed var(--hair-strong);
+  text-align: center;
+  cursor: pointer;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+```
+
+Note: the existing `.drop::before, .drop::after` corner-bracket rules are removed by this replacement. The hover/focus rules at `.drop:hover, .drop.is-active, .drop:focus-visible` (background + border-color) still apply and keep the drop feeling interactive. The bracket-growth hover rules (`.drop:hover::before` …) now target nothing, which is harmless, but remove them in the next step for cleanliness.
+
+- [ ] **Step 3: Remove the now-dead bracket-hover rules**
+
+Delete this block (currently `shared.css:329-334`):
+
+```css
+.drop:hover::before, .drop:hover::after,
+.drop.is-active::before, .drop.is-active::after,
+.drop:focus-visible::before, .drop:focus-visible::after {
+  border-color: var(--oxblood);
+  width: 22px; height: 22px;
+}
+```
+
+- [ ] **Step 4: Reorder entrance-animation delays**
+
+The cascade should now flow steps → Connect panel → drop → manual. Replace:
+
+```css
+.drop              { animation-delay: 880ms; }
+#strava-data-source { animation-delay: 940ms; }
+.manual-mode       { animation-delay: 1000ms; }
+```
+
+with:
+
+```css
+#strava-data-source { animation-delay: 880ms; }
+.drop              { animation-delay: 940ms; }
+.manual-mode       { animation-delay: 1000ms; }
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared.css
+git commit -m "Swap visual weight: Connect panel primary, drop zone secondary"
+```
+
+---
+
+## Task 4: Confirm app.js needs no change, then verify in the browser
+
+**Files:**
+- Read-only check: `src/app.js:179-208` (`refreshStravaUi`)
+
+- [ ] **Step 1: Confirm `refreshStravaUi` refines the new default**
+
+Read `src/app.js:179-208`. Confirm it (a) sets `stravaDataSourceEl.hidden = false` — now a no-op since the panel is already visible, harmless; (b) rebuilds `#strava-status-text` and `#strava-status-actions` for both the connected and disconnected branches, re-wiring the Connect button listener. This means the static Connect button from Task 2 is correctly replaced and bound on load. No edit required. If any of these are not true, stop and re-evaluate before changing logic.
+
+- [ ] **Step 2: Run the test suite (regression guard)**
+
+Run: `npx vitest run`
+Expected: PASS — all existing suites green. No new tests added; this confirms the presentation change broke no imported logic.
+
+- [ ] **Step 3: Serve and visually verify the onboarding screen**
+
+Run: `python3 -m http.server 8000` (from repo root), then open `http://localhost:8000/` in a browser (or use the `verify`/chrome-devtools tooling).
+
+Verify, disconnected (no Strava session):
+- Steps read 01 / Connect → 02 / Read → 03 / Extend.
+- The Strava Connect panel renders **first** and **prominent** (bracketed card) with the "Sync the last 180 days … no archive download required." line and a working **Connect** button — no flash or empty gap on load.
+- The archive drop zone renders **below**, visibly quieter (compact, dashed border, no corner brackets), still clickable/hover-reactive.
+- Entrance animation cascades top-to-bottom without the Connect panel popping in late.
+
+- [ ] **Step 4: Verify the connected and results states**
+
+- With a stored session (connect once via the button), the panel refines to "Connected · Sync 180 days / Disconnect".
+- After data loads (`data-app-state="data"`), the steps, Connect panel, and drop zone all hide as before (existing `shared.css:579` rule covers `#strava-data-source`).
+
+- [ ] **Step 5: Final commit if any tuning was needed**
+
+If Step 3/4 required CSS value tweaks (padding, spacing), commit them:
+
+```bash
+git add shared.css index.html
+git commit -m "Tune sync-first intro spacing"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 steps copy → Task 1. §2 DOM order → Task 2. §3 visual swap → Task 3 (steps 1-3). §4 no-flash default → Task 2 (remove `hidden` + static default) and Task 4 step 1. §5 housekeeping (animation delays, data-state hide already covered) → Task 3 step 4 + Task 4 step 4. All sections mapped.
+- **Placeholders:** none — every code step shows full before/after.
+- **Consistency:** element ids (`#strava-data-source`, `#archive-drop`, `#strava-status-actions`, `#strava-connect-btn`), class (`.data-sources--inline`, `.drop`), and CSS var names (`--paper-soft`, `--hair-strong`, `--ink`) match the live source read during planning.

--- a/docs/superpowers/specs/2026-06-02-sync-first-intro-design.md
+++ b/docs/superpowers/specs/2026-06-02-sync-first-intro-design.md
@@ -1,0 +1,100 @@
+# Sync-first intro — design
+
+## Problem
+
+The landing page's "How it works" steps lead with **01 / Request — Ask Strava
+for your archive**, framing the offline archive download (prepared over hours,
+emailed as a link) as the primary way in. Syncing only appears as a step-03
+afterthought ("Connect Strava later so new rides flow in automatically").
+
+This is misleading. Syncing is the faster path, needs no download or waiting,
+and pulls the recent rides the prediction weights most heavily. The product
+already supports sync as a first-class entry point — `refreshStravaUi()` runs
+on load (`src/app.js:91`) and renders a Connect panel with "Sync the last 180
+days from your Strava account — no archive download required." Only the intro
+copy and visual order lag behind, steering people toward the slower path.
+
+## Goal
+
+Reframe the intro so connecting and syncing Strava is the recommended primary
+path, and the archive download is presented as an optional way to extend with
+full history. The change is copy + layout only; no prediction/model logic is
+touched.
+
+## Design
+
+### 1. Steps copy (`index.html`)
+
+Rewrite the three steps from archive-first to sync-first:
+
+| | Now | Proposed |
+|---|---|---|
+| 01 | **Request** — Ask Strava for your archive. They prepare it offline and email a link within hours. | **Connect** — Connect your Strava. Authorize once and we sync your last 180 days. No download, no waiting. |
+| 02 | **Drop** — Drag the zip onto the page. Parsed in your browser. Raw streams never leave your machine. | **Read** — See your power-duration curve. Recent rides weighted heaviest, so it reflects current fitness. |
+| 03 | **Read** — See your power-duration curve. Connect Strava later so new rides flow in automatically. | **Extend** *(optional)* — Want your full history? Download your Strava archive and drop the zip in. Parsed in your browser; raw streams never leave your machine. [Step-by-step](docs/strava-archive-guide.html) |
+
+The privacy point ("parsed in your browser / raw streams never leave your
+machine") moves onto the new archive/extend step so it is not lost. Editorial
+voice (terse `NN / Word` step labels, italic serif headings) is preserved.
+
+### 2. DOM order (`index.html`)
+
+Move the `#strava-data-source` Connect panel above the `#archive-drop` zone so
+the visual order matches the new step order. The archive drop becomes the
+secondary/fallback surface beneath it.
+
+### 3. Visual weight swap (`shared.css`)
+
+Today the drop zone is a prominent bracketed box and the Strava panel
+(`.data-sources--inline`) is deliberately quiet. Reordering DOM alone leaves the
+loud box dominating below the quiet panel, which undercuts sync-first.
+
+Swap the visual weight: give the Connect panel the prominent corner-bracket
+treatment the drop zone uses today (reuse the `.drop` visual language), and
+demote the archive drop to a quieter affordance below it. The Connect panel
+becomes the eye-catching primary call to action; the drop zone reads as the
+understated fallback.
+
+### 4. No-flash default state (`index.html` + `src/app.js`)
+
+The Connect panel is currently `hidden` in markup and un-hidden by
+`refreshStravaUi()` after JS runs. As the new lead element this would cause a
+gap/flash on load.
+
+Fix: make the disconnected state ("Connect" + "Sync the last 180 days … no
+archive download required") the **static default in the HTML** (panel visible,
+not `hidden`). `refreshStravaUi()` keeps its current job: refine to the
+"Connected · Sync 180 days / Disconnect" state when a stored session exists,
+otherwise leave the disconnected default in place. The already-connected case
+may briefly show the disconnected default before JS refines it; this is an
+acceptable, minor transition and matches how the panel already behaves.
+
+### 5. Housekeeping (`shared.css`)
+
+- Adjust the entrance-animation delays (`shared.css:1734–1737`) to the new
+  element order so the staggered fade-in still cascades top-to-bottom.
+- The `body[data-app-state="data"]` rule already hides `#strava-data-source`
+  (`shared.css:579`), so the results screen is unaffected by the reorder.
+
+## Scope / files
+
+- `index.html` — steps copy, element order, static default for the Connect panel.
+- `shared.css` — visual-weight swap (promote Connect panel, demote drop zone),
+  animation-delay order.
+- `src/app.js` — minor adjustment to `refreshStravaUi()` so it refines rather
+  than reveals the now-default-visible panel.
+
+Out of scope: prediction/model logic, sync/auth behavior, the archive parsing
+pipeline, the manual-entry (FTP/CP) disclosure.
+
+## Testing
+
+- Onboarding screen (no session): Connect panel renders first and prominent on
+  load with no flash/gap; archive drop renders below as the quieter fallback.
+- Onboarding screen (stored session): panel refines to the Connected state with
+  Sync/Disconnect actions.
+- Results screen (`data-app-state="data"`): steps, Connect panel, and drop zone
+  all hidden as before.
+- Step copy reads sync-first; archive guide link still resolves.
+- Existing test suite (`npx vitest`) stays green — no JS logic paths changed
+  beyond the panel default.

--- a/index.html
+++ b/index.html
@@ -33,19 +33,19 @@
 
     <ol class="steps" aria-label="How it works">
       <li>
-        <span class="step-num">01 / Request</span>
-        <h2>Ask Strava for your archive</h2>
-        <p>They prepare it offline and email a link within hours. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
+        <span class="step-num">01 / Connect</span>
+        <h2>Connect your Strava</h2>
+        <p>Authorize once and we sync your last 180 days. No download, no waiting.</p>
       </li>
       <li>
-        <span class="step-num">02 / Drop</span>
-        <h2>Drag the zip onto the page</h2>
-        <p>Parsed in your browser. Raw streams never leave your machine.</p>
-      </li>
-      <li>
-        <span class="step-num">03 / Read</span>
+        <span class="step-num">02 / Read</span>
         <h2>See your power-duration curve</h2>
-        <p>Connect Strava later so new rides flow in automatically.</p>
+        <p>Recent rides weighted heaviest, so it reflects current fitness.</p>
+      </li>
+      <li>
+        <span class="step-num">03 / Extend</span>
+        <h2>Want your full history?</h2>
+        <p>Download your Strava archive and drop the zip in. Parsed in your browser; raw streams never leave your machine. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
       </li>
     </ol>
 

--- a/index.html
+++ b/index.html
@@ -49,21 +49,21 @@
       </li>
     </ol>
 
+    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source">
+      <section class="data-sources__row">
+        <span class="data-sources__label">Strava</span>
+        <p class="data-sources__line">
+          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
+          <span class="data-sources__actions" id="strava-status-actions"><button type="button" class="link-button" id="strava-connect-btn">Connect</button></span>
+        </p>
+      </section>
+    </aside>
+
     <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your archive">
       <input type="file" id="archive-input" accept=".zip" hidden>
       <span class="drop__label">Drop your archive</span>
       <span class="drop__hint">strava_export_*.zip · or click to browse</span>
     </div>
-
-    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source" hidden>
-      <section class="data-sources__row">
-        <span class="data-sources__label">Strava</span>
-        <p class="data-sources__line">
-          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
-          <span class="data-sources__actions" id="strava-status-actions"></span>
-        </p>
-      </section>
-    </aside>
 
     <details id="manual-mode" class="manual-mode">
       <summary id="manual-mode-summary">Predict from FTP or CP</summary>

--- a/shared.css
+++ b/shared.css
@@ -306,14 +306,6 @@ main {
   cursor: pointer;
   transition: background 200ms ease, border-color 200ms ease;
 }
-.drop::before {
-  top: -1px; left: -1px;
-  border-right: none; border-bottom: none;
-}
-.drop::after {
-  bottom: -1px; right: -1px;
-  border-left: none; border-top: none;
-}
 .drop:hover, .drop.is-active, .drop:focus-visible {
   background: var(--paper);
   border-color: var(--oxblood);

--- a/shared.css
+++ b/shared.css
@@ -327,24 +327,17 @@ main {
   letter-spacing: 0.06em;
 }
 
-/* Strava connect / connected blocks. Sit between the drop zone and
-   the manual-mode disclosure on the onboarding screen. Quiet styling
-   — the affordance is the button label, not a colored bar. */
-/* Inline data-sources block (top-of-page strava entry on the
-   onboarding/manual screens). Same row layout as the data-screen
-   colophon, but no top border / extra margin since it sits inline
-   between the drop zone and the manual disclosure rather than at
-   the foot of a results section. */
-/* On the onboarding screen this is the PRIMARY call to action, so it
+/* Inline data-sources block: the top-of-page Strava entry on the
+   onboarding/manual screens. This is the PRIMARY call to action, so it
    takes the prominent bracketed-card treatment the drop zone used to
-   own. The internal row layout (label · status · actions) is unchanged. */
+   own, sitting above the drop zone and the manual disclosure. The
+   internal row layout (label · status · actions) is unchanged. */
 .data-sources--inline {
   position: relative;
   margin: 1.5rem 0 0;
   padding: clamp(1.75rem, 4vw, 2.5rem) 2rem;
   background: var(--paper-soft);
   border: 1px solid var(--hair-strong);
-  border-top: 1px solid var(--hair-strong);
 }
 .data-sources--inline::before, .data-sources--inline::after {
   content: "";

--- a/shared.css
+++ b/shared.css
@@ -298,20 +298,13 @@ main {
 
 .drop {
   position: relative;
-  margin: 1.5rem 0 0;
-  padding: clamp(2.5rem, 6vw, 4rem) 2rem;
+  margin: 0.75rem 0 0;
+  padding: 1.25rem 2rem;
   background: var(--paper-soft);
-  border: 1px solid var(--hair-strong);
+  border: 1px dashed var(--hair-strong);
   text-align: center;
   cursor: pointer;
   transition: background 200ms ease, border-color 200ms ease;
-}
-.drop::before, .drop::after {
-  content: "";
-  position: absolute;
-  width: 14px; height: 14px;
-  border: 1px solid var(--ink);
-  transition: border-color 200ms ease, width 200ms ease, height 200ms ease;
 }
 .drop::before {
   top: -1px; left: -1px;
@@ -325,12 +318,6 @@ main {
   background: var(--paper);
   border-color: var(--oxblood);
   outline: none;
-}
-.drop:hover::before, .drop:hover::after,
-.drop.is-active::before, .drop.is-active::after,
-.drop:focus-visible::before, .drop:focus-visible::after {
-  border-color: var(--oxblood);
-  width: 22px; height: 22px;
 }
 .drop__label {
   font-family: var(--serif);
@@ -356,10 +343,30 @@ main {
    colophon, but no top border / extra margin since it sits inline
    between the drop zone and the manual disclosure rather than at
    the foot of a results section. */
+/* On the onboarding screen this is the PRIMARY call to action, so it
+   takes the prominent bracketed-card treatment the drop zone used to
+   own. The internal row layout (label · status · actions) is unchanged. */
 .data-sources--inline {
-  margin: 1rem 0 0;
-  padding: 0.6rem 0;
-  border-top: 0;
+  position: relative;
+  margin: 1.5rem 0 0;
+  padding: clamp(1.75rem, 4vw, 2.5rem) 2rem;
+  background: var(--paper-soft);
+  border: 1px solid var(--hair-strong);
+  border-top: 1px solid var(--hair-strong);
+}
+.data-sources--inline::before, .data-sources--inline::after {
+  content: "";
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--ink);
+}
+.data-sources--inline::before {
+  top: -1px; left: -1px;
+  border-right: none; border-bottom: none;
+}
+.data-sources--inline::after {
+  bottom: -1px; right: -1px;
+  border-left: none; border-top: none;
 }
 /* Loading state on link buttons: the floating status banner
    carries the message + pulsing marker, so the button just dims
@@ -1734,8 +1741,8 @@ body[data-app-state="manual"] #manual-mode {
 .steps > li:nth-child(1) { animation-delay: 540ms; }
 .steps > li:nth-child(2) { animation-delay: 640ms; }
 .steps > li:nth-child(3) { animation-delay: 740ms; }
-.drop              { animation-delay: 880ms; }
-#strava-data-source { animation-delay: 940ms; }
+#strava-data-source { animation-delay: 880ms; }
+.drop              { animation-delay: 940ms; }
 .manual-mode       { animation-delay: 1000ms; }
 
 #results[data-revealed] {


### PR DESCRIPTION
## Summary
- The landing page's "How it works" steps led with **Ask Strava for your archive** (the slow, email-a-link path) and treated syncing as a step-03 afterthought, even though sync is faster, needs no download, and pulls the recent rides the prediction weights most heavily.
- Rewrote the three steps to lead with Strava: **01 / Connect → 02 / Read → 03 / Extend** (archive download is now the optional "want your full history?" fallback, keeping the in-browser-parsing privacy note).
- Moved the Strava Connect panel above the archive drop zone and gave it the prominent bracketed-card treatment; demoted the drop zone to a quieter dashed, compact affordance. Reordered the entrance-animation delays to match.
- Seeded the Connect panel's disconnected state (status line + Connect button) as the static default so it no longer renders `hidden` and flashes in after JS; `refreshStravaUi()` still refines it to the connected state when a session exists (no JS logic change).

Design spec and plan: `docs/superpowers/specs/2026-06-02-sync-first-intro-design.md`, `docs/superpowers/plans/2026-06-02-sync-first-intro.md`.

## Test Plan
- [x] `npx vitest run` — 143/143 pass (no logic touched)
- [x] Built `dist/` and loaded onboarding screen: steps read Connect/Read/Extend; Connect panel renders first and prominent with a working Connect button and no flash; drop zone is the quieter fallback below
- [ ] Connected state: after authorizing, the panel refines to "Connected · Sync 180 days / Disconnect"
- [ ] Results state (`data-app-state="data"`): steps, Connect panel, and drop zone all hide as before