### PR TITLE
Raise default fatigue k from 0.10 to 0.15

### DIFF
--- a/docs/methodology.html
+++ b/docs/methodology.html
@@ -117,7 +117,7 @@
 
     <p>The anchor is whichever is later: your longest observed MMP point, or the 20-minute model prediction. Anchoring at real data when available means a 12-hour forecast is grounded in your actual 4-hour or 6-hour ride, not extrapolated all the way from the CP fit.</p>
 
-    <p>The fatigue exponent <em>k</em> defaults to 0.10. Skiba publishes 0.07, which fits the 1&ndash;4 hour range; observed pro and amateur ultra-endurance data falls off faster than that, more like 0.10 in the 8&ndash;24 hour range. Defaulting higher avoids the trap of ultra predictions reading too close to CP.</p>
+    <p>The fatigue exponent <em>k</em> defaults to 0.15. Skiba publishes 0.07, which fits the 1&ndash;4 hour range; observed pro and amateur ultra-endurance data falls off faster than that. A gentle default leaves long-duration predictions too optimistic, so Power Predict defaults <em>k</em> to 0.15 &mdash; a firmer falloff partway to the 0.20 fatigue clamp &mdash; which avoids the trap of ultra predictions reading too close to CP.</p>
 
     <p>When your archive contains at least three MMP points between 20 minutes and 4 hours, Power Predict fits a <strong>personal</strong> <em>k</em> by linear regression on log&minus;log MMP data: log <em>P</em> = <em>a</em> &minus; <em>k</em> &middot; log <em>t</em>. The fitted value replaces the default at predict time, both in the chart's fatigue line and in the predict form. The result is clamped to the 0.04&ndash;0.20 envelope to ignore degenerate fits driven by a single low-effort long ride. The Fatigue&nbsp;k stat in the predict block reports which value is in use and how many points it was fitted on.</p>
 

--- a/src/app.js
+++ b/src/app.js
@@ -716,7 +716,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   }
 
   // Personal fatigue exponent fitted from long-duration MMP. Replaces
-  // the default Riegel k = 0.10 at predict time when enough 20-min-to-
+  // the default Riegel k = 0.15 at predict time when enough 20-min-to-
   // 4-hr points exist. Falls back to the default otherwise.
   //
   // Use the same effort-quality-filtered set the CP regression uses,
@@ -726,7 +726,7 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   // catastrophic decay (k pinned at the 0.20 rail) that reflects ride
   // selection, not physiology. Filtering by IF drops the easy long
   // rides; if too few hard long efforts remain, fitFatigueK returns
-  // null and we fall back to the gentler default 0.10.
+  // null and we fall back to the default 0.15.
   if (currentFit) {
     const fatigueSource = currentFit.fallback ? fallbackPoints : primaryPoints;
     currentFit = { ...currentFit, fatigue: fitFatigueK(fatigueSource) };
@@ -1013,7 +1013,7 @@ function formTooltip() {
 }
 
 // Fatigue k: personal Riegel exponent fitted from 20-min-to-4-hr MMP.
-// When data is too sparse to fit, predictions fall back to k = 0.10 —
+// When data is too sparse to fit, predictions fall back to k = 0.15 —
 // we show that here too so the cell isn't ever blank.
 // A clamped fit is discarded for prediction (see wirePredictForm /
 // renderCurveChart), so the readout reports the default k that's

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -205,8 +205,10 @@ function fitLinearWithTau(points, tau) {
 // Empirically, single-k Riegel underpredicts decay for ultra-endurance
 // durations. Skiba publishes k = 0.07 for cycling, which matches Coggan
 // well in the 1-4h range; beyond that, observed pro/amateur profiles
-// fall off faster, more like k ≈ 0.10. Default is 0.10 here so 12h+
-// predictions land in the 65-75% CP range observed in practice.
+// fall off faster. A gentle default (≈0.10) leaves long-duration
+// predictions too optimistic, so the default is k = 0.15 — a firmer
+// falloff partway to the 0.20 fatigue clamp — which better tracks
+// sustained 6-12h+ power in practice.
 //
 // When a longer-duration MMP point exists in the user's data than the
 // fitting window's ceiling, predictPower anchors the decay at *that
@@ -220,7 +222,7 @@ function fitLinearWithTau(points, tau) {
 //   - Pinot & Grappe, "The Record Power Profile" (2011)
 export const DEFAULT_DECAY = {
   fromS: 1200,  // top of standard CP fitting window (20 min)
-  k: 0.10,
+  k: 0.15,
 };
 
 // Fit a personal Riegel exponent from MMP points in the long-duration
@@ -288,7 +290,7 @@ export function predictPower(fit, durationS, opts = {}) {
   // default 20 min — otherwise decay starting at 20 min drags the
   // 60-min prediction below the user's stated FTP. Inside 60 min
   // the calibrated hyperbola handles things on its own.
-  const manualDecayDefault = { fromS: 3600, k: 0.10 };
+  const manualDecayDefault = { fromS: 3600, k: 0.15 };
   let decay;
   if (opts.decay === false) {
     decay = null;

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -58,10 +58,10 @@ describe('predictPower', () => {
     const out = predictPower(fit, 3600); // 60 min
     // anchor at 20 min (no longer-duration data on this fit):
     //   anchor power = 280 + 22000/1200 = 298.33
-    //   decay factor = (1200/3600)^0.10 ≈ 0.8959
-    //   expected = 298.33 × 0.8959 ≈ 267.3
+    //   decay factor = (1200/3600)^0.15 ≈ 0.8480
+    //   expected = 298.33 × 0.8480 ≈ 253.0
     expect(out.decayed).toBe(true);
-    expect(out.powerW).toBeCloseTo(298.333 * (1200 / 3600) ** 0.10, 2);
+    expect(out.powerW).toBeCloseTo(298.333 * (1200 / 3600) ** 0.15, 2);
     expect(out.powerW).toBeLessThan(fit.cpW);
   });
 
@@ -72,7 +72,7 @@ describe('predictPower', () => {
       { durationS: 3600, powerW: 200 }, // low-effort 1h base ride
     ]);
     const lowOut = predictPower(fitLowLong, 7200);
-    const expectedThresholdAnchored = (280 + 22000 / 1200) * (1200 / 7200) ** 0.10;
+    const expectedThresholdAnchored = (280 + 22000 / 1200) * (1200 / 7200) ** 0.15;
     expect(lowOut.powerW).toBeCloseTo(expectedThresholdAnchored, 2);
 
     // Case B: long observed MMP EXCEEDS model — anchor on it.
@@ -81,7 +81,7 @@ describe('predictPower', () => {
       { durationS: 3600, powerW: 290 }, // genuinely strong 1h
     ]);
     const highOut = predictPower(fitHighLong, 7200);
-    expect(highOut.powerW).toBeCloseTo(290 * (3600 / 7200) ** 0.10, 2);
+    expect(highOut.powerW).toBeCloseTo(290 * (3600 / 7200) ** 0.15, 2);
   });
 
   it('never predicts below a real observation at the same duration', () => {
@@ -107,11 +107,11 @@ describe('predictPower', () => {
     ]);
     const out = predictPower(lowFit, 3600);
     // Should anchor at (2700, 242) and decay to 3600.
-    expect(out.powerW).toBeCloseTo(242 * (2700 / 3600) ** 0.10, 1);
+    expect(out.powerW).toBeCloseTo(242 * (2700 / 3600) ** 0.15, 1);
   });
 
   it('respects an explicit decay override', () => {
-    const aggressive = predictPower(fit, 7200, { decay: { fromS: 600, k: 0.15 } });
+    const aggressive = predictPower(fit, 7200, { decay: { fromS: 600, k: 0.20 } });
     const standard = predictPower(fit, 7200);
     expect(aggressive.powerW).toBeLessThan(standard.powerW);
   });

--- a/tests/manual.test.js
+++ b/tests/manual.test.js
@@ -29,13 +29,13 @@ describe('synthesizeFit', () => {
 
   it('decays past 60 min, anchored at FTP', () => {
     const fit = synthesizeFit({ ftpW: 280 });
-    // 2 h: 280 × (3600/7200)^0.10 ≈ 280 × 0.9330 ≈ 261.2
+    // 2 h: 280 × (3600/7200)^0.15 ≈ 280 × 0.9012 ≈ 252.3
     const at2h = predictPower(fit, 7200);
-    expect(at2h.powerW).toBeCloseTo(280 * (3600 / 7200) ** 0.10, 2);
+    expect(at2h.powerW).toBeCloseTo(280 * (3600 / 7200) ** 0.15, 2);
     // 4 h: deeper decay, well below FTP.
     const at4h = predictPower(fit, 14400);
     expect(at4h.powerW).toBeLessThan(280);
-    expect(at4h.powerW).toBeCloseTo(280 * (3600 / 14400) ** 0.10, 2);
+    expect(at4h.powerW).toBeCloseTo(280 * (3600 / 14400) ** 0.15, 2);
   });
 
   it('derives W\' from a 1-min sprint via the 2-param hyperbola seed', () => {


### PR DESCRIPTION
## Summary
- Raised the default Riegel fatigue exponent **k from 0.10 to 0.15** for a firmer long-duration power falloff. A gentle 0.10 left long-duration / ultra predictions too optimistic (reading too close to CP); 0.15 sits partway to the 0.20 fatigue clamp.
- Changed both `DEFAULT_DECAY.k` and the manual-mode `manualDecayDefault.k` in `src/cpfit.js`, so the new default applies to the normal long-tail extrapolation, the clamped-fit fallback, and manual (FTP/CP) mode.
- The personal fitted-k path and the 0.04–0.20 clamp envelope are unchanged. Updated hard-coded test expectations, the methodology doc, and code comments to match.

## Test Plan
- [x] `npx vitest run` — 143/143 pass (cpfit + manual expectations recomputed for k=0.15)
- [ ] Spot-check a real profile: long-duration (4h+) predictions sit a bit lower than before; 20-min and shorter are unaffected