### PR TITLE
Drop the Strava panel box; make archive a quiet fallback line

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,10 +59,11 @@
       </section>
     </aside>
 
-    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your archive">
+    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your Strava archive zip, or click to browse">
       <input type="file" id="archive-input" accept=".zip" hidden>
-      <span class="drop__label">Drop your archive</span>
-      <span class="drop__hint">strava_export_*.zip · or click to browse</span>
+      <span class="drop__label">or drop your full Strava archive</span>
+      <span class="drop__hint">.zip · or click to browse</span>
+      <span class="drop__arrow" aria-hidden="true">→</span>
     </div>
 
     <details id="manual-mode" class="manual-mode">

--- a/shared.css
+++ b/shared.css
@@ -296,62 +296,50 @@ main {
 
 /* DROP */
 
+/* Archive fallback: a quiet "or drop your full archive" sub-line under
+   the Strava strip, not a box. Still the drag-and-drop / click-to-browse
+   target — the visual weight just steps down so syncing reads primary.
+   Indented 1.4rem to align under the Strava status sentence above. */
 .drop {
-  position: relative;
-  margin: 0.75rem 0 0;
-  padding: 1.25rem 2rem;
-  background: var(--paper-soft);
-  border: 1px dashed var(--hair-strong);
-  text-align: center;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0.35rem 0 0;
+  padding: 0 0 0 1.4rem;
   cursor: pointer;
-  transition: background 200ms ease, border-color 200ms ease;
+  color: var(--muted);
+  transition: color 200ms ease;
 }
 .drop:hover, .drop.is-active, .drop:focus-visible {
-  background: var(--paper);
-  border-color: var(--oxblood);
+  color: var(--oxblood);
   outline: none;
 }
 .drop__label {
   font-family: var(--serif);
   font-style: italic;
-  font-size: clamp(1.25rem, 2.5vw, 1.6rem);
-  font-variation-settings: "opsz" 72, "SOFT" 100;
-  display: block;
-  color: var(--ink);
-  margin-bottom: 0.6rem;
+  font-size: 0.98rem;
+  font-variation-settings: "opsz" 24;
+  color: inherit;
 }
 .drop__hint {
   font-family: var(--mono);
-  font-size: 0.74rem;
+  font-size: 0.72rem;
   color: var(--muted);
-  letter-spacing: 0.06em;
+  letter-spacing: 0.04em;
+}
+.drop__arrow {
+  font-family: var(--mono);
+  color: inherit;
 }
 
 /* Inline data-sources block: the top-of-page Strava entry on the
-   onboarding/manual screens. This is the PRIMARY call to action, so it
-   takes the prominent bracketed-card treatment the drop zone used to
-   own, sitting above the drop zone and the manual disclosure. The
-   internal row layout (label · status · actions) is unchanged. */
+   onboarding/manual screens. A quiet inline strip (label · status ·
+   actions) — it reads primary by sitting first and being heavier than
+   the lighter archive fallback line below it, not by a box. */
 .data-sources--inline {
-  position: relative;
-  margin: 1.5rem 0 0;
-  padding: clamp(1.75rem, 4vw, 2.5rem) 2rem;
-  background: var(--paper-soft);
-  border: 1px solid var(--hair-strong);
-}
-.data-sources--inline::before, .data-sources--inline::after {
-  content: "";
-  position: absolute;
-  width: 14px; height: 14px;
-  border: 1px solid var(--ink);
-}
-.data-sources--inline::before {
-  top: -1px; left: -1px;
-  border-right: none; border-bottom: none;
-}
-.data-sources--inline::after {
-  bottom: -1px; right: -1px;
-  border-left: none; border-top: none;
+  margin: 1rem 0 0;
+  padding: 0.6rem 0;
+  border-top: 0;
 }
 /* Loading state on link buttons: the floating status banner
    carries the message + pulsing marker, so the button just dims


### PR DESCRIPTION
## Summary
- Follow-up to #206: the Strava panel had been given a bracketed-card "box" that read like an empty input field. This removes that box.
- `.data-sources--inline` reverts to a quiet inline strip; the archive drop zone (`#archive-drop`) becomes a quiet single muted sub-line — "or drop your full Strava archive .zip · or click to browse →" — instead of a large bracketed box.
- Sync still reads primary by sitting first and being heavier; the archive reads as a lighter fallback below it. Same `#archive-drop` element and handlers, so drag/drop + click-to-browse are unchanged.

## Test Plan
- [x] `npx vitest run` — 143/143 (no logic touched)
- [x] Built `dist/` and viewed onboarding screen: clean strip + quiet archive line, no box; drag/drop and click-to-browse still work
- [ ] Results state (`data-app-state="data"`) still hides both surfaces