### PR TITLE
Redesign onboarding: inline Connect/Upload actions into the step cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@
         <span class="step-num">01 / Connect</span>
         <h2>Connect your Strava</h2>
         <p>Authorize once and we sync your last 180 days. No download, no waiting.</p>
+        <div id="strava-data-source" class="step-action" aria-label="Strava data source">
+          <span id="strava-status-text"></span>
+          <span id="strava-status-actions"><button type="button" class="link-button" id="strava-connect-btn">Connect</button></span>
+        </div>
       </li>
       <li>
         <span class="step-num">02 / Read</span>
@@ -45,26 +49,13 @@
       <li>
         <span class="step-num">03 / Extend</span>
         <h2>Want your full history?</h2>
-        <p>Download your Strava archive and drop the zip in. Parsed in your browser; raw streams never leave your machine. <a href="docs/strava-archive-guide.html">Step-by-step</a></p>
+        <p><a href="docs/strava-archive-guide.html">Download your Strava archive and drop the zip in.</a> Parsed in your browser; raw streams never leave your machine.</p>
+        <div id="archive-drop" class="step-action" role="button" tabindex="0" aria-label="Upload your Strava archive zip, or drop it here">
+          <input type="file" id="archive-input" accept=".zip" hidden>
+          <span class="link-button">Upload .zip</span>
+        </div>
       </li>
     </ol>
-
-    <aside id="strava-data-source" class="data-sources data-sources--inline" aria-label="Strava data source">
-      <section class="data-sources__row">
-        <span class="data-sources__label">Strava</span>
-        <p class="data-sources__line">
-          <span class="data-sources__status" id="strava-status-text">Sync the last 180 days from your Strava account — no archive download required.</span>
-          <span class="data-sources__actions" id="strava-status-actions"><button type="button" class="link-button" id="strava-connect-btn">Connect</button></span>
-        </p>
-      </section>
-    </aside>
-
-    <div id="archive-drop" class="drop" tabindex="0" role="button" aria-label="Drop your Strava archive zip, or click to browse">
-      <input type="file" id="archive-input" accept=".zip" hidden>
-      <span class="drop__label">or drop your full Strava archive</span>
-      <span class="drop__hint">.zip · or click to browse</span>
-      <span class="drop__arrow" aria-hidden="true">→</span>
-    </div>
 
     <details id="manual-mode" class="manual-mode">
       <summary id="manual-mode-summary">Predict from FTP or CP</summary>

--- a/shared.css
+++ b/shared.css
@@ -286,60 +286,58 @@ main {
   color: var(--muted);
   line-height: 1.5;
 }
+/* In-step links read as part of the explanatory body text, not as a
+   red action — only the link-button actions (CONNECT / UPLOAD .ZIP)
+   carry oxblood. So the body link inherits the muted body colour with a
+   quiet hairline underline. */
 .steps a {
-  color: var(--oxblood);
+  color: inherit;
   text-decoration: none;
-  border-bottom: 1px solid var(--oxblood);
-  white-space: nowrap;
+  border-bottom: 1px solid var(--hair-strong);
 }
-.steps a:hover { color: var(--oxblood-deep); border-bottom-color: var(--oxblood-deep); }
+.steps a:hover { color: var(--ink-soft); border-bottom-color: var(--ink-soft); }
 
 /* DROP */
 
-/* Archive fallback: a quiet "or drop your full archive" sub-line under
-   the Strava strip, not a box. Still the drag-and-drop / click-to-browse
-   target — the visual weight just steps down so syncing reads primary.
-   Indented 1.4rem to align under the Strava status sentence above. */
-.drop {
+/* Step-cell action: the CONNECT / Upload action lives inside the
+   relevant step (01 Connect, 03 Extend), under the explanatory copy,
+   rather than as a separate row. The step copy carries the detail, so
+   the action is just the link-button (plus a "Connected." status in the
+   Strava case). */
+.step-action {
+  margin-top: 0.85rem;
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.5rem;
-  margin: 0.35rem 0 0;
-  padding: 0 0 0 1.4rem;
-  cursor: pointer;
-  color: var(--muted);
-  transition: color 200ms ease;
-}
-.drop:hover, .drop.is-active, .drop:focus-visible {
-  color: var(--oxblood);
-  outline: none;
-}
-.drop__label {
-  font-family: var(--serif);
+  gap: 0.75rem;
   font-style: italic;
-  font-size: 0.98rem;
-  font-variation-settings: "opsz" 24;
-  color: inherit;
-}
-.drop__hint {
-  font-family: var(--mono);
-  font-size: 0.72rem;
+  font-family: var(--serif);
+  font-size: 0.94rem;
   color: var(--muted);
-  letter-spacing: 0.04em;
 }
-.drop__arrow {
-  font-family: var(--mono);
-  color: inherit;
+/* No status sentence in the disconnected Strava state — drop the empty
+   span so it doesn't open a gap before the Connect button. */
+#strava-status-text:empty {
+  display: none;
 }
-
-/* Inline data-sources block: the top-of-page Strava entry on the
-   onboarding/manual screens. A quiet inline strip (label · status ·
-   actions) — it reads primary by sitting first and being heavier than
-   the lighter archive fallback line below it, not by a box. */
-.data-sources--inline {
-  margin: 1rem 0 0;
-  padding: 0.6rem 0;
-  border-top: 0;
+/* Space the connected-state Sync / Disconnect buttons within the row. */
+#strava-status-actions {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+#archive-drop.step-action {
+  cursor: pointer;
+}
+#archive-drop:hover .link-button,
+#archive-drop.is-active .link-button,
+#archive-drop:focus-visible .link-button {
+  color: var(--oxblood-deep);
+  border-bottom-color: var(--oxblood-deep);
+}
+#archive-drop:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 3px;
 }
 /* Loading state on link buttons: the floating status banner
    carries the message + pulsing marker, so the button just dims
@@ -1702,8 +1700,6 @@ body[data-app-state="manual"] #manual-mode {
 
 .lede > *,
 .steps > li,
-.drop,
-#strava-data-source,
 .manual-mode {
   opacity: 0;
   animation: rise 720ms cubic-bezier(.2, .8, .2, 1) forwards;
@@ -1714,8 +1710,6 @@ body[data-app-state="manual"] #manual-mode {
 .steps > li:nth-child(1) { animation-delay: 540ms; }
 .steps > li:nth-child(2) { animation-delay: 640ms; }
 .steps > li:nth-child(3) { animation-delay: 740ms; }
-#strava-data-source { animation-delay: 880ms; }
-.drop              { animation-delay: 940ms; }
 .manual-mode       { animation-delay: 1000ms; }
 
 #results[data-revealed] {
@@ -1728,7 +1722,7 @@ body[data-app-state="manual"] #manual-mode {
     animation-iteration-count: 1 !important;
     transition-duration: 0.001ms !important;
   }
-  .lede > *, .steps > li, .drop, #strava-data-source, .manual-mode { opacity: 1; }
+  .lede > *, .steps > li, .manual-mode { opacity: 1; }
 }
 
 /* RESPONSIVE */

--- a/src/app.js
+++ b/src/app.js
@@ -192,7 +192,7 @@ async function refreshStravaUi() {
     document.getElementById('strava-sync-btn').addEventListener('click', triggerStravaSync);
     document.getElementById('strava-disconnect').addEventListener('click', handleDisconnect);
   } else {
-    statusEl.textContent = 'Sync the last 180 days from your Strava account — no archive download required.';
+    statusEl.textContent = '';
     actionsEl.innerHTML = `<button type="button" class="link-button" id="strava-connect-btn">Connect</button>`;
     document.getElementById('strava-connect-btn').addEventListener('click', (e) => {
       beginStravaConnect(e.currentTarget);


### PR DESCRIPTION
## Summary
- Reworked the landing-page onboarding. The Strava **Connect** and archive **Upload** actions now live *inside* the relevant step cells (01 Connect, 03 Extend), under the copy that explains them, instead of as two separate data-source rows below the triptych.
- Removed the standalone Strava/Archive rows and the box/centered-row experiments that preceded this.
- Each cell now reads as muted body text + one oxblood action. Cell 03's body sentence links to the archive guide in a **muted (non-red)** style, so only the actions (CONNECT / UPLOAD .ZIP) carry colour — and both now correctly render oxblood (CONNECT was previously stuck on `--ink-soft` via a leftover `.data-sources__actions` wrapper).
- JS untouched except the disconnected Strava status string (now empty, since the cell copy explains it). All ids/handlers (`#strava-data-source`, `#strava-status-*`, `#archive-drop`, `#archive-input`) preserved, so connect + drag/drop + click-to-browse still work.

## Test Plan
- [x] `npx vitest run` — 143/143 (presentation-only; one-line JS string change)
- [x] Built `dist/` and verified onboarding in-browser: actions inlined in cells 01/03, both actions oxblood, cell-03 guide link muted, no leftover rows/box
- [ ] Connected state: 01 cell shows "Connected." + Sync/Disconnect
- [ ] Results state still hides the steps