### PR TITLE
Filter ingestion to cycling rides only (exclude runs, e-bikes)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -396,6 +396,7 @@ async function handleArchive(file) {
   let lastActivitiesSeen = 0;
   let parseFailed = 0;
   let parseFailedSamples = [];
+  let parseSkippedNonRide = 0;
 
   const worker = new Worker('dist/archive-worker.js');
 
@@ -439,6 +440,7 @@ async function handleArchive(file) {
         } else if (msg.type === 'done') {
           parseFailed = msg.failed || 0;
           parseFailedSamples = msg.failedSamples || [];
+          parseSkippedNonRide = msg.skippedNonRide || 0;
           resolve();
         } else if (msg.type === 'error') {
           reject(new Error(msg.message));
@@ -469,10 +471,17 @@ async function handleArchive(file) {
     await saveActivities(newList);
   }
 
+  // Non-ride activities (runs, e-bikes, …) skipped at parse time —
+  // surfaced so the counts make sense (e.g. a runs-heavy archive that
+  // yields few or no rides).
+  const nonRideNote = parseSkippedNonRide > 0
+    ? ` · skipped ${parseSkippedNonRide} non-ride ${parseSkippedNonRide === 1 ? 'activity' : 'activities'}`
+    : '';
+
   const all = await loadActivities();
   if (all.length === 0) {
     showStatus(
-      `No power-equipped activities found (${lastActivitiesSeen} activity files seen)`,
+      `No power-equipped rides found (${lastActivitiesSeen} activity files seen${nonRideNote})`,
       { kind: 'success', dwellMs: 5000 },
     );
     clearStatus();
@@ -494,7 +503,7 @@ async function handleArchive(file) {
       { kind: 'error', dwellMs: 8000 },
     );
   } else {
-    showStatus(`Parsed ${newList.length} new activities`, { kind: 'success', dwellMs: 3000 });
+    showStatus(`Parsed ${newList.length} new activities${nonRideNote}`, { kind: 'success', dwellMs: 3000 });
   }
   renderCurves(all);
 }

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -14,6 +14,7 @@ import { parseFit } from './fit.js';
 import { parseTcx } from './tcx.js';
 import { extractMmp } from './mmp.js';
 import { normalizedPower } from './aggregate.js';
+import { isRideType } from './sport.js';
 
 const FIT_PATH = /^activities\/[^/]+\.fit(\.gz)?$/i;
 const TCX_PATH = /^activities\/[^/]+\.tcx(\.gz)?$/i;
@@ -38,6 +39,9 @@ async function parseArchive(file) {
   let parsedCount = 0;
   let withPower = 0;
   let failed = 0;
+  // Non-cycling activities (runs, walks, e-bikes, …) skipped via the
+  // activities.csv "Activity Type" column. Reported in the done event.
+  let skippedNonRide = 0;
   // Sample of basenames for the first few failures, for the post-parse
   // notice. Cap at 5 so a fully corrupt archive doesn't bloat the
   // postMessage payload.
@@ -127,14 +131,28 @@ async function parseArchive(file) {
     })();
   });
 
-  // ------- Parse activities.csv → filename → Strava ID map -------
+  // ------- Parse activities.csv → filename → Strava ID + type maps -------
   // The map keys are normalized: full path (`activities/X.fit.gz`)
   // and basename (`X.fit.gz`). Looking up a FIT entry tries both, so
   // small differences in CSV path formatting don't break linking.
   const idByName = csvBytes ? buildIdMap(csvBytes) : null;
+  const typeByName = csvBytes ? buildTypeMap(csvBytes) : null;
 
   // ------- Parse FIT and TCX files -------
   for (const { name, bytes, kind } of pendingFits) {
+    const base = name.split('/').pop() || name;
+    // Rides only. Skip non-cycling activities (runs, walks, e-bikes, …)
+    // whose power would corrupt the cycling CP fit. We classify via the
+    // activities.csv "Activity Type" column; when the type is unknown
+    // (no CSV, or this file isn't listed) we fall through and parse, to
+    // avoid dropping legitimate rides we simply couldn't classify.
+    const sportType = typeByName?.get(name) ?? typeByName?.get(base) ?? null;
+    if (sportType && !isRideType(sportType)) {
+      skippedNonRide++;
+      parsedCount++;
+      if (parsedCount % 5 === 0 || parsedCount === pendingFits.length) post({ phase: 'parsing' });
+      continue;
+    }
     let b = bytes;
     try {
       if (name.endsWith('.gz')) b = gunzipSync(b);
@@ -161,7 +179,6 @@ async function parseArchive(file) {
         // The number in the FIT filename is the upload ID — globally
         // unique but distinct from the activity ID a user URL uses,
         // so we can't fall back to the filename here.
-        const base = name.split('/').pop() || name;
         const stravaId = idByName?.get(name) ?? idByName?.get(base) ?? null;
         self.postMessage({
           type: 'activity',
@@ -189,10 +206,10 @@ async function parseArchive(file) {
   }
   pendingFits.length = 0;
 
-  self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower, failed, failedSamples });
+  self.postMessage({ type: 'done', activitiesSeen, parsedCount, withPower, failed, failedSamples, skippedNonRide });
 }
 
-export { buildIdMap, parseCsv };
+export { buildIdMap, buildTypeMap, parseCsv };
 
 // Build { fullPath, basename → activity_id } from activities.csv.
 // Strava export columns shift between versions, so we resolve them
@@ -216,6 +233,32 @@ function buildIdMap(csvBytes) {
     map.set(fn, id);
     const base = fn.split('/').pop();
     if (base && base !== fn) map.set(base, id);
+  }
+  return map;
+}
+
+// Build { fullPath, basename → "Activity Type" } from activities.csv,
+// so the FIT/TCX loop can skip non-cycling activities. Same dual-key
+// indexing and header-name resolution as buildIdMap. Returns null when
+// the Activity Type or Filename column is absent (older exports), in
+// which case the loop parses everything rather than dropping data.
+function buildTypeMap(csvBytes) {
+  const text = new TextDecoder().decode(csvBytes);
+  const rows = parseCsv(text);
+  if (!rows.length) return null;
+  const header = rows[0].map((s) => s.trim().toLowerCase());
+  const typeIdx = header.indexOf('activity type');
+  const fnIdx = header.indexOf('filename');
+  if (typeIdx < 0 || fnIdx < 0) return null;
+  const map = new Map();
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r];
+    const type = row[typeIdx]?.trim();
+    const fn = row[fnIdx]?.trim();
+    if (!type || !fn) continue;
+    map.set(fn, type);
+    const base = fn.split('/').pop();
+    if (base && base !== fn) map.set(base, type);
   }
   return map;
 }

--- a/src/sport.js
+++ b/src/sport.js
@@ -1,0 +1,32 @@
+// Decide whether a Strava activity is a cycling ride we should feed
+// into the power-duration model.
+//
+// Strava reports activity type in two shapes:
+//   - API summaries use camelCase `sport_type` ("VirtualRide",
+//     "MountainBikeRide"), with a legacy `type` ("Ride") alongside.
+//   - The archive's activities.csv uses spaced words in its
+//     "Activity Type" column ("Virtual Ride", "Mountain Bike Ride").
+//
+// We normalize both to lowercase letters-only and match a ride set, so
+// the same predicate serves the sync path and the archive path.
+//
+// E-bikes are excluded on purpose: motor assistance makes the recorded
+// power an unreliable basis for a critical-power model. Runs (including
+// running power), walks, hikes, swims, etc. are excluded outright —
+// running power in particular is not comparable to cycling power.
+const RIDE_TYPES = new Set(['ride', 'virtualride', 'gravelride', 'mountainbikeride']);
+
+export function normalizeType(t) {
+  return typeof t === 'string' ? t.toLowerCase().replace(/[^a-z]/g, '') : '';
+}
+
+export function isRideType(t) {
+  return RIDE_TYPES.has(normalizeType(t));
+}
+
+// From a Strava API activity summary: prefer the granular sport_type,
+// fall back to the legacy type when sport_type is absent.
+export function isRideActivity(a) {
+  if (!a) return false;
+  return isRideType(a.sport_type || a.type);
+}

--- a/tests/archive-worker.test.js
+++ b/tests/archive-worker.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildIdMap, parseCsv } from '../src/archive-worker.js';
+import { buildIdMap, buildTypeMap, parseCsv } from '../src/archive-worker.js';
 
 const enc = (s) => new TextEncoder().encode(s);
 
@@ -58,5 +58,31 @@ describe('buildIdMap', () => {
     const m = buildIdMap(csv);
     expect(m.size).toBe(2); // 7 → "activities/X.fit" + "X.fit"
     expect(m.get('activities/X.fit')).toBe('7');
+  });
+});
+
+describe('buildTypeMap', () => {
+  it('maps filename to Activity Type by full path and basename', () => {
+    const csv = enc(
+      'Activity ID,Activity Type,Filename\n' +
+      '1,Ride,activities/1.fit.gz\n' +
+      '2,Run,activities/2.fit.gz\n'
+    );
+    const m = buildTypeMap(csv);
+    expect(m.get('activities/1.fit.gz')).toBe('Ride');
+    expect(m.get('1.fit.gz')).toBe('Ride');
+    expect(m.get('activities/2.fit.gz')).toBe('Run');
+  });
+
+  it('resolves columns by header name (order-independent)', () => {
+    const csv = enc(
+      'Filename,Activity Type,Activity ID\n' +
+      'activities/A.fit.gz,Mountain Bike Ride,99\n'
+    );
+    expect(buildTypeMap(csv).get('activities/A.fit.gz')).toBe('Mountain Bike Ride');
+  });
+
+  it('returns null when the Activity Type column is missing', () => {
+    expect(buildTypeMap(enc('Activity ID,Filename\n1,activities/1.fit\n'))).toBeNull();
   });
 });

--- a/tests/sport.test.js
+++ b/tests/sport.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeType, isRideType, isRideActivity } from '../src/sport.js';
+
+describe('isRideType', () => {
+  it('accepts cycling types in both API camelCase and CSV spaced forms', () => {
+    for (const t of [
+      'Ride', 'VirtualRide', 'GravelRide', 'MountainBikeRide',
+      'Virtual Ride', 'Gravel Ride', 'Mountain Bike Ride',
+    ]) {
+      expect(isRideType(t)).toBe(true);
+    }
+  });
+
+  it('rejects runs, walks, and other non-cycling types', () => {
+    for (const t of ['Run', 'TrailRun', 'Virtual Run', 'Walk', 'Hike', 'Swim', 'Workout', '']) {
+      expect(isRideType(t)).toBe(false);
+    }
+  });
+
+  it('excludes e-bikes (motor-assisted)', () => {
+    for (const t of ['EBikeRide', 'E-Bike Ride', 'EMountainBikeRide', 'E-Mountain Bike Ride']) {
+      expect(isRideType(t)).toBe(false);
+    }
+  });
+
+  it('handles null / undefined / non-string input', () => {
+    expect(isRideType(null)).toBe(false);
+    expect(isRideType(undefined)).toBe(false);
+    expect(isRideType(123)).toBe(false);
+  });
+});
+
+describe('normalizeType', () => {
+  it('lowercases and strips non-letters', () => {
+    expect(normalizeType('Mountain Bike Ride')).toBe('mountainbikeride');
+    expect(normalizeType('E-Bike Ride')).toBe('ebikeride');
+  });
+});
+
+describe('isRideActivity', () => {
+  it('prefers sport_type over the legacy type', () => {
+    expect(isRideActivity({ sport_type: 'Run', type: 'Ride' })).toBe(false);
+    expect(isRideActivity({ sport_type: 'VirtualRide', type: 'Workout' })).toBe(true);
+  });
+
+  it('falls back to type when sport_type is absent', () => {
+    expect(isRideActivity({ type: 'Ride' })).toBe(true);
+    expect(isRideActivity({ type: 'Run' })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isRideActivity(null)).toBe(false);
+  });
+});

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -149,6 +149,35 @@ describe('runSyncSlice', () => {
     expect(out.cursor.pending[0].id).toBe(1001);
   });
 
+  it('excludes non-ride activities (runs, e-bikes) even when power-equipped', async () => {
+    const db = makeDb();
+    db.state.users.set(42, {
+      access_token: 'tok', refresh_token: 'r',
+      token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const fakeFetch = async (urlStr) => {
+      if (urlStr.includes('/athlete/activities')) {
+        return new Response(JSON.stringify([
+          // A real ride with power — kept.
+          { id: 1, type: 'Ride', sport_type: 'Ride', device_watts: true, average_watts: 200,
+            start_date: '2026-01-01T00:00:00Z', elapsed_time: 600, distance: 5000 },
+          // A run with a running power meter — dropped despite device_watts.
+          { id: 2, type: 'Run', sport_type: 'Run', device_watts: true, average_watts: 300,
+            start_date: '2026-01-02T00:00:00Z', elapsed_time: 600, distance: 5000 },
+          // E-bike (legacy type says Ride, sport_type reveals the assist) — dropped.
+          { id: 3, type: 'Ride', sport_type: 'EBikeRide', device_watts: true, average_watts: 250,
+            start_date: '2026-01-03T00:00:00Z', elapsed_time: 600, distance: 5000 },
+        ]), { status: 200 });
+      }
+      throw new Error('first slice should not fetch streams');
+    };
+    const env = { DB: db, RATE_LIMIT: makeKv(), STRAVA_CLIENT_ID: 'c', STRAVA_CLIENT_SECRET: 's' };
+    const out = await runSyncSlice({ env, athleteId: 42, fetchImpl: fakeFetch });
+    expect(out.totalSeen).toBe(3);
+    expect(out.totalWithPower).toBe(1);
+    expect(out.cursor.pending.map((p) => p.id)).toEqual([1]);
+  });
+
   it('second slice fetches streams and writes MMP rows', async () => {
     const db = makeDb();
     db.state.users.set(42, {

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -4,6 +4,7 @@
 
 import { extractMmp } from '../src/mmp.js';
 import { normalizedPower } from '../src/aggregate.js';
+import { isRideActivity } from '../src/sport.js';
 import { listActivitiesAfter, fetchPowerStream, hasRealPower } from './strava-api.js';
 import { refreshTokens } from './strava-oauth.js';
 
@@ -80,7 +81,11 @@ export async function runSyncSlice({
     const after = Math.floor(Date.now() / 1000) - days * 86400;
     const all = await listActivitiesAfter({ accessToken, afterEpoch: after }, fetchImpl);
     const totalSeen = all.length;
-    const powered = all.filter(hasRealPower);
+    // Rides only. A run/walk recorded with a power meter (e.g. Stryd)
+    // sets device_watts too, but running power isn't comparable to
+    // cycling power and would corrupt the CP fit — so filter by sport
+    // type before the power check. E-bikes are excluded as well.
+    const powered = all.filter((a) => isRideActivity(a) && hasRealPower(a));
     const totalWithPower = powered.length;
     // Skip the ones we've already ingested in D1, plus anything the
     // client tells us is already in its IndexedDB cache (archive


### PR DESCRIPTION
## Summary
- **Bug:** the app builds a *cycling* critical-power model, but neither ingestion path filtered by sport type. A run/walk recorded with a power meter (e.g. Stryd) sets Strava's `device_watts` flag, so it was ingested and its non-cycling power corrupted the CP fit.
- Added a shared `isRideType` / `isRideActivity` predicate (`src/sport.js`) that normalizes both Strava shapes — the API's camelCase `sport_type` ("VirtualRide") and the archive CSV's spaced "Activity Type" ("Virtual Ride") — and matches a cycling-ride set (Ride, VirtualRide, GravelRide, MountainBikeRide). **E-bikes excluded** (motor assist makes recorded power unreliable for CP).
- **Sync path** (`worker/sync.js`): filter the activity list on `isRideActivity` before the power check. `totalSeen` still counts all activities; only the worklist is ride-filtered.
- **Archive path** (`src/archive-worker.js`): classify via the `activities.csv` "Activity Type" column (new `buildTypeMap`) and skip non-rides in the parse loop. Unknown types (no CSV / unlisted file) still parse, so legitimate rides are never dropped. The skipped count surfaces in the parse-result toast.

## Note on existing data
Already-synced runs aren't retroactively removed (there's no stored sport type to filter on), so affected users should **Clear cache → Sync** (or re-upload the archive) to clean current data. A follow-up could store sport type per activity + a one-time purge.

## Test Plan
- [x] `npx vitest run` — 155/155 (12 new: `tests/sport.test.js`, plus sync + buildTypeMap coverage)
- [x] Sync test asserts a power-equipped Run and an EBikeRide (legacy `type: Ride`, `sport_type: EBikeRide`) are both dropped; only the Ride survives
- [x] Built `dist/`; ride-type logic confirmed present in the bundled archive worker
- [ ] Manual: sync an account with running-power runs → runs no longer appear; upload an archive with runs → "skipped N non-ride activities" shown