### PR TITLE
Reconcile previously-synced non-rides out of storage on sync

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ import {
   saveActivities,
   hasActivity,
   clearActivities,
+  removeActivitiesByStravaId,
   activityCount,
   loadSettings,
   saveSettings,
@@ -245,7 +246,7 @@ async function triggerStravaSync() {
     const knownIds = currentActivities
       .map((a) => a.stravaId)
       .filter((id) => id != null && id !== '');
-    await syncRecent({
+    const { removedIds } = await syncRecent({
       session: session.session,
       days: 180,
       knownIds,
@@ -254,6 +255,14 @@ async function triggerStravaSync() {
         setSync(`Syncing from Strava · <em>${processed}</em> / <em>${total}</em> activities · <em>${remaining}</em> remaining`);
       },
     });
+    // The worker reconciles previously-synced non-rides (runs/e-bikes)
+    // out of D1 and reports their ids; prune the matching rows from the
+    // local cache + in-memory list so they stop feeding the curve.
+    if (removedIds?.length) {
+      await removeActivitiesByStravaId(removedIds);
+      const removedSet = new Set(removedIds.map(String));
+      currentActivities = currentActivities.filter((a) => !removedSet.has(String(a.stravaId)));
+    }
     setSync('Loading synced data');
     const remoteActivities = await fetchSyncedActivities(session.session);
     if (remoteActivities.length === 0) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -74,6 +74,31 @@ export async function clearActivities() {
   return withStore(ACTIVITIES_STORE, 'readwrite', (store) => store.clear());
 }
 
+// Delete cached activities by Strava id. Used after a sync reconciles
+// previously-stored non-rides (runs/e-bikes) out of the server: the
+// worker reports the removed ids and we prune the matching IDB rows so
+// they stop feeding the curve. The store is keyed by startTime, so we
+// cursor the whole store and delete rows whose stravaId is in the set.
+// Returns the number of rows removed.
+export async function removeActivitiesByStravaId(stravaIds) {
+  const ids = new Set((stravaIds || []).map(String).filter((s) => s !== ''));
+  if (ids.size === 0) return 0;
+  return withStore(ACTIVITIES_STORE, 'readwrite', (store) =>
+    new Promise((resolve, reject) => {
+      let removed = 0;
+      const req = store.openCursor();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (!cursor) { resolve(removed); return; }
+        const sid = cursor.value?.stravaId;
+        if (sid != null && ids.has(String(sid))) { cursor.delete(); removed++; }
+        cursor.continue();
+      };
+      req.onerror = () => reject(req.error);
+    })
+  );
+}
+
 export async function activityCount() {
   return withStore(ACTIVITIES_STORE, 'readonly', (store) =>
     new Promise((resolve, reject) => {

--- a/src/strava-session.js
+++ b/src/strava-session.js
@@ -98,6 +98,11 @@ export function authorizeUrl(returnTo = '/') {
 export async function syncRecent({ session, days = 180, knownIds = [], onProgress }) {
   let cursor = null;
   let cumulativeProcessed = 0;
+  // Activities the worker reconciled out of D1 (e.g. previously-synced
+  // runs now excluded by the ride-only filter). Surfaced so the caller
+  // can prune them from the IndexedDB cache. Only the first slice
+  // reports these, but accumulate defensively.
+  const removedIds = [];
   while (true) {
     const res = await fetch(`${API_BASE}/sync/recent`, {
       method: 'POST',
@@ -120,6 +125,9 @@ export async function syncRecent({ session, days = 180, knownIds = [], onProgres
     }
     const slice = await res.json();
     cumulativeProcessed += slice.processed || 0;
+    if (Array.isArray(slice.removedIds) && slice.removedIds.length) {
+      removedIds.push(...slice.removedIds);
+    }
     if (typeof slice.elapsedMs === 'number') {
       // Visibility into per-slice wall time. Logged but not shown to
       // the user — useful when tuning ACTIVITIES_PER_CALL or chasing
@@ -132,7 +140,7 @@ export async function syncRecent({ session, days = 180, knownIds = [], onProgres
       remaining: slice.remaining,
       errors: slice.errors,
     });
-    if (slice.done) return { processed: cumulativeProcessed, totalWithPower: slice.totalWithPower };
+    if (slice.done) return { processed: cumulativeProcessed, totalWithPower: slice.totalWithPower, removedIds };
     cursor = slice.cursor;
   }
 }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -5,6 +5,7 @@ import {
   saveActivities,
   hasActivity,
   clearActivities,
+  removeActivitiesByStravaId,
   activityCount,
 } from '../src/storage.js';
 
@@ -40,6 +41,26 @@ describe('storage', () => {
   it('clearActivities empties the store', async () => {
     await saveActivities([{ startTime: 1, durationS: 1, mmp: {} }]);
     await clearActivities();
+    expect(await activityCount()).toBe(0);
+  });
+
+  it('removeActivitiesByStravaId prunes only the matching rows', async () => {
+    await saveActivities([
+      { startTime: 1000, stravaId: '1', durationS: 60, mmp: {} },
+      { startTime: 2000, stravaId: '2', durationS: 60, mmp: {} }, // the run
+      { startTime: 3000, stravaId: '3', durationS: 60, mmp: {} },
+      { startTime: 4000, durationS: 60, mmp: {} },                // archive upload, no stravaId
+    ]);
+    const removed = await removeActivitiesByStravaId(['2']);
+    expect(removed).toBe(1);
+    const left = (await loadActivities()).map((a) => a.startTime).sort((x, y) => x - y);
+    expect(left).toEqual([1000, 3000, 4000]);
+  });
+
+  it('removeActivitiesByStravaId matches numeric and string ids and no-ops on empty', async () => {
+    await saveActivities([{ startTime: 1000, stravaId: 12345, durationS: 60, mmp: {} }]);
+    expect(await removeActivitiesByStravaId([])).toBe(0);
+    expect(await removeActivitiesByStravaId(['12345'])).toBe(1);
     expect(await activityCount()).toBe(0);
   });
 });

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -41,6 +41,8 @@ function makeDb(state = {}) {
           state.activities.set(id, { id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, ingested_at, has_power: 1 });
         } else if (sql.startsWith('DELETE FROM mmp_records')) {
           state.mmp = state.mmp.filter((m) => m.activity_id !== b[0]);
+        } else if (sql.startsWith('DELETE FROM activities')) {
+          state.activities.delete(b[0]);
         } else if (sql.startsWith('UPDATE users SET last_sync_at')) {
           const u = state.users.get(b[1]) || {};
           state.users.set(b[1], { ...u, last_sync_at: b[0] });
@@ -175,6 +177,38 @@ describe('runSyncSlice', () => {
     const out = await runSyncSlice({ env, athleteId: 42, fetchImpl: fakeFetch });
     expect(out.totalSeen).toBe(3);
     expect(out.totalWithPower).toBe(1);
+    expect(out.cursor.pending.map((p) => p.id)).toEqual([1]);
+  });
+
+  it('reconciles previously-synced non-rides out of D1 and reports their ids', async () => {
+    const db = makeDb();
+    db.state.users.set(42, {
+      access_token: 'tok', refresh_token: 'r',
+      token_expires_at: Math.floor(Date.now() / 1000) + 3600,
+    });
+    // A run was synced before the ride-only filter existed — it's
+    // sitting in D1 with MMP rows.
+    db.state.activities.set(2, { id: 2, user_id: 42, has_power: 1, start_time: 0 });
+    db.state.mmp.push({ activity_id: 2, duration_s: 1200, power_w: 314 });
+    const fakeFetch = async (urlStr) => {
+      if (urlStr.includes('/athlete/activities')) {
+        return new Response(JSON.stringify([
+          { id: 1, type: 'Ride', sport_type: 'Ride', device_watts: true, average_watts: 200,
+            start_date: '2026-05-01T00:00:00Z', elapsed_time: 600, distance: 5000 },
+          { id: 2, type: 'Run', sport_type: 'Run', device_watts: true, average_watts: 314,
+            start_date: '2026-05-06T00:00:00Z', elapsed_time: 1200, distance: 8000 },
+        ]), { status: 200 });
+      }
+      throw new Error('first slice should not fetch streams');
+    };
+    const env = { DB: db, RATE_LIMIT: makeKv(), STRAVA_CLIENT_ID: 'c', STRAVA_CLIENT_SECRET: 's' };
+    const out = await runSyncSlice({ env, athleteId: 42, fetchImpl: fakeFetch });
+    // The run (id 2) is deleted from D1 along with its MMP rows, and
+    // reported back as a removed Strava id (string form).
+    expect(db.state.activities.has(2)).toBe(false);
+    expect(db.state.mmp.some((m) => m.activity_id === 2)).toBe(false);
+    expect(out.removedIds).toEqual(['2']);
+    // The fresh ride (id 1) is still queued for stream fetching.
     expect(out.cursor.pending.map((p) => p.id)).toEqual([1]);
   });
 

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -95,7 +95,29 @@ export async function runSyncSlice({
       .prepare('SELECT id FROM activities WHERE user_id = ?')
       .bind(athleteId)
       .all();
-    const skip = new Set((existing.results || []).map((r) => r.id));
+    const existingIds = new Set((existing.results || []).map((r) => r.id));
+
+    // Reconcile: drop previously-synced activities that the listing now
+    // classifies as non-rides (runs/walks/e-bikes) or otherwise not a
+    // ride-with-power. The listing covers the whole window, so a run
+    // ingested before the ride-only filter existed gets cleaned out of
+    // D1 here on the next sync. We return the removed Strava ids so the
+    // client can prune them from its IndexedDB cache too. Scoped to the
+    // listed window — older rows aren't re-listed, so aren't touched.
+    const validIds = new Set(powered.map((a) => a.id));
+    const removedIds = all
+      .filter((a) => !validIds.has(a.id) && existingIds.has(a.id))
+      .map((a) => a.id);
+    if (removedIds.length) {
+      const stmts = [];
+      for (const id of removedIds) {
+        stmts.push(env.DB.prepare('DELETE FROM mmp_records WHERE activity_id = ?').bind(id));
+        stmts.push(env.DB.prepare('DELETE FROM activities WHERE id = ? AND user_id = ?').bind(id, athleteId));
+      }
+      await env.DB.batch(stmts);
+    }
+
+    const skip = new Set(existingIds);
     for (const id of knownIds) {
       const n = Number(id);
       if (Number.isFinite(n)) skip.add(n);
@@ -115,6 +137,7 @@ export async function runSyncSlice({
       totalSeen,
       totalWithPower,
       remaining: pending.length,
+      removedIds: removedIds.map(String),
       errors: [],
       cursor: pending.length > 0 ? { pending, totalSeen, totalWithPower } : null,
     };


### PR DESCRIPTION
## Summary
Follow-up to #210. That filter only blocked **new** runs; a run synced **before** it stayed in the worker's D1 and was re-served on every sync (and persisted in the browser's IndexedDB cache, which sync never prunes) — so there was no way to remove it, and it kept showing up in the curve (e.g. a run's power as your 20-min best).

This makes sync **reconcile**: the first sync slice already re-lists every activity in the window with its type, so the worker now deletes previously-synced activities that are no longer valid rides-with-power (runs, e-bikes, no-power) from D1 + `mmp_records`, and returns their Strava ids. `syncRecent` surfaces those ids; the client prunes the matching rows from IndexedDB (`removeActivitiesByStravaId`) and the in-memory list.

Net effect: **a run synced before the filter is removed from both stores on the next sync, automatically** — no manual cache-clear. Provably safe: only ids that are in the listing *and* already in D1 *and* not a valid ride are deleted, scoped to the user. Scoped to the 180-day listing window (older rows aren't re-listed, so untouched — confirmed acceptable).

## To clear your current data
Just **Sync** once after this deploys — the May-6 run (and any other synced runs) will drop out of D1 and your local cache.

## Test Plan
- [x] `npx vitest run` — 158/158 (3 new: worker reconcile + 2 storage prune)
- [x] Worker test seeds a run already in D1, lists it as a Run, asserts it + its MMP rows are deleted and reported in `removedIds`, while the valid ride stays queued
- [x] Storage tests: only matching `stravaId` rows pruned; archive rows without a stravaId untouched; numeric/string id matching
- [ ] Manual after deploy: sync → the run disappears from the curve and the 20-min best reflects a real ride