### PR TITLE
Predict: headline the fresh estimate, demote form to subtext

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1541,9 +1541,10 @@ body[data-app-state="manual"] #manual-mode {
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--burnt);
-  margin-left: 0.5rem;
+  margin-left: 0.6rem;
   padding: 0.1rem 0.4rem;
   border: 1px solid currentColor;
+  vertical-align: middle;
 }
 .predict-output__error {
   font-family: var(--serif);

--- a/src/app.js
+++ b/src/app.js
@@ -1521,31 +1521,25 @@ function wirePredictForm() {
       out.innerHTML = `<p class="predict-output__error">Prediction failed.</p>`;
       return;
     }
-    // Apply the form-based multiplier to the predicted wattage and
-    // its confidence band. Capped at ±5% inside formMultiplier so
-    // it's a nudge, not a rewrite. We surface the applied delta on the
-    // output so the user can reconcile the predicted watts against the
-    // chart curve (which doesn't bake form in).
+    // The headline is the form-free "fresh" estimate. That's the number
+    // that matters for race planning — you'll be tapered and rested on
+    // the day — and it matches the chart, which also bakes no form in.
+    // Today's form adjustment (capped at ±5% inside formMultiplier) is
+    // demoted to a subtext line: informative, but it no longer drags the
+    // headline below what you'd actually hit fresh.
     const mult = currentLoad.hasFtp ? formMultiplier(currentLoad.tsb) : 1;
-    const result = mult === 1 ? raw : {
-      ...raw,
-      powerW: raw.powerW * mult,
-      low: raw.low * mult,
-      high: raw.high * mult,
-    };
     const adjPct = Math.round((mult - 1) * 100);
-    const formChip = adjPct === 0
+    const extrapChip = raw.extrapolated
+      ? '<span class="predict-output__flag">extrapolated</span>'
+      : '';
+    const formLine = adjPct === 0
       ? ''
-      : `<span class="predict-output__flag predict-output__flag--form" title="${formTooltip()}">${adjPct > 0 ? '+' : ''}${adjPct}% form</span>`;
+      : `<p class="predict-output__band" title="${formTooltip()}">At today's form (${adjPct > 0 ? '+' : ''}${adjPct}%): ${Math.round(raw.powerW * mult)} W</p>`;
     out.hidden = false;
     out.innerHTML = `
       <p class="predict-output__label">Predicted for ${formatDuration(seconds)}</p>
-      <p class="predict-output__value">${Math.round(result.powerW)}<span class="predict-output__unit">W</span></p>
-      <p class="predict-output__band">
-        Range ${Math.round(result.low)}–${Math.round(result.high)} W
-        ${result.extrapolated ? '<span class="predict-output__flag">extrapolated</span>' : ''}
-        ${formChip}
-      </p>
+      <p class="predict-output__value">${Math.round(raw.powerW)}<span class="predict-output__unit">W</span>${extrapChip}</p>
+      ${formLine}
     `;
   });
 }


### PR DESCRIPTION
## Summary

The 30m prediction headline was the *form-adjusted* wattage (e.g. 280 W), which sits below both the chart's extrapolation (292 W) and the observed MMP (295 W) whenever TSB is negative. That's backwards for the main use case — planning a race, where you'll be tapered and fresh.

This flips the default:
- **Headline is now the form-free "fresh" estimate** (e.g. 295 W), straight from `predictPower`. It matches the chart, which also bakes no form in.
- **Today's form adjustment is demoted to a subtext line** — `At today's form (−5%): 280 W` — shown only when form actually moves the number. Full TSB/CTL/ATL breakdown stays on hover via the existing tooltip.
- **Removed the range line.**
- **`EXTRAPOLATED` chip moved beside the wattage** (still conditional — only when the target is outside the fitted range).

Contained to `wirePredictForm()` in `src/app.js` plus one CSS line; no changes to `predictPower` or the chart.

## Test plan
- [ ] `npm test` passes (158 tests green locally)
- [ ] Predict 30m with negative TSB → headline shows fresh number, subtext shows `At today's form (−X%): … W`
- [ ] Predict a sub-20m duration → no EXTRAPOLATED chip
- [ ] Predict with no FTP / neutral form → no subtext line