### PR TITLE
Capture long endurance efforts: duration-scaled gate + 12h range + collapsible table

### DIFF
--- a/shared.css
+++ b/shared.css
@@ -1755,3 +1755,9 @@ body[data-app-state="manual"] #manual-mode {
   .mmp-table th:first-child, .mmp-table td:first-child { padding-left: 0; }
   .mmp-table th:last-child, .mmp-table td:last-child { padding-right: 0; }
 }
+
+.mmp-expand {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+}

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -4,6 +4,30 @@
 
 import { DURATIONS_S, dropAnomalies } from './mmp.js';
 
+// Effort-quality gate. A flat IF floor (e.g. 0.70) is only physiological
+// up to ~1h: a rider can hold high intensity for under an hour, so an
+// easy sub-hour ride should be dropped. Beyond 1h, sustainable whole-
+// ride IF falls, so the floor decays Riegel-style from the 1h anchor —
+// letting genuine multi-hour efforts through while still excluding easy
+// long rides. Continuous at the anchor (value unchanged; only the slope
+// bends), so there is no jump at 1h.
+export const EFFORT_GATE_ANCHOR_S = 3600; // floor is flat at/below 1h
+export const EFFORT_GATE_DECAY = 0.06;    // calibrated so 5.5h ≈ 0.63
+
+export function effortGateThreshold(minIF, durationS) {
+  if (!Number.isFinite(durationS) || durationS <= EFFORT_GATE_ANCHOR_S) return minIF;
+  return minIF * (EFFORT_GATE_ANCHOR_S / durationS) ** EFFORT_GATE_DECAY;
+}
+
+// True when the ride is hard enough to trust. No-op (returns true) when
+// the filter isn't configured (minIF/ftp not finite) or the activity has
+// no avgPower (legacy cache) — matching the prior all-or-nothing filter.
+export function passesEffortGate(avgPower, ftp, durationS, minIF) {
+  if (!Number.isFinite(minIF) || !Number.isFinite(ftp) || ftp <= 0) return true;
+  if (!Number.isFinite(avgPower)) return true;
+  return avgPower / ftp >= effortGateThreshold(minIF, durationS);
+}
+
 export function rollingBest(activityMmps, {
   windowDays = null,
   now = Date.now(),
@@ -11,11 +35,10 @@ export function rollingBest(activityMmps, {
   ftp = null,
 } = {}) {
   const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
-  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
   const best = {};
-  for (const { startTime, mmp, avgPower } of activityMmps) {
+  for (const { startTime, mmp, avgPower, durationS } of activityMmps) {
     if (startTime < cutoff) continue;
-    if (filterEnabled && Number.isFinite(avgPower) && avgPower / ftp < minIF) continue;
+    if (!passesEffortGate(avgPower, ftp, durationS, minIF)) continue;
     const cleaned = dropAnomalies(mmp);
     for (const d of DURATIONS_S) {
       const v = cleaned[d];
@@ -36,11 +59,10 @@ export function rollingBestWithOwners(activityMmps, {
   ftp = null,
 } = {}) {
   const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
-  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
   const best = {};
   for (const a of activityMmps) {
     if (a.startTime < cutoff) continue;
-    if (filterEnabled && Number.isFinite(a.avgPower) && a.avgPower / ftp < minIF) continue;
+    if (!passesEffortGate(a.avgPower, ftp, a.durationS, minIF)) continue;
     const cleaned = dropAnomalies(a.mmp);
     for (const d of DURATIONS_S) {
       const v = cleaned?.[d];
@@ -84,14 +106,10 @@ export function recencyWeightedBest(activityMmps, {
   const cutoff = windowDays ? now - windowDays * 86400_000 : 0;
   const halfLifeMs = halfLifeDays * 86400_000;
   const ln2 = Math.log(2);
-  const filterEnabled = Number.isFinite(minIF) && Number.isFinite(ftp) && ftp > 0;
   const winner = {}; // { [duration]: { raw, weighted } }
-  for (const { startTime, mmp, avgPower } of activityMmps) {
+  for (const { startTime, mmp, avgPower, durationS } of activityMmps) {
     if (startTime < cutoff) continue;
-    if (filterEnabled && Number.isFinite(avgPower)) {
-      const intensity = avgPower / ftp;
-      if (intensity < minIF) continue;
-    }
+    if (!passesEffortGate(avgPower, ftp, durationS, minIF)) continue;
     const ageMs = Math.max(0, now - startTime);
     const weight = Math.exp((-ln2 * ageMs) / halfLifeMs);
     for (const d of DURATIONS_S) {
@@ -136,7 +154,7 @@ export function effortQualityStats(activityMmps, { minIF, ftp }) {
   }
   for (const a of activityMmps) {
     if (!Number.isFinite(a.avgPower)) { unknown++; continue; }
-    if (a.avgPower / ftp < minIF) excluded++;
+    if (a.avgPower / ftp < effortGateThreshold(minIF, a.durationS)) excluded++;
     else included++;
   }
   return { included, excluded, unknown };

--- a/src/aggregate.js
+++ b/src/aggregate.js
@@ -15,6 +15,7 @@ export const EFFORT_GATE_ANCHOR_S = 3600; // floor is flat at/below 1h
 export const EFFORT_GATE_DECAY = 0.06;    // calibrated so 5.5h ≈ 0.63
 
 export function effortGateThreshold(minIF, durationS) {
+  if (!Number.isFinite(minIF)) return minIF;
   if (!Number.isFinite(durationS) || durationS <= EFFORT_GATE_ANCHOR_S) return minIF;
   return minIF * (EFFORT_GATE_ANCHOR_S / durationS) ** EFFORT_GATE_DECAY;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -17,6 +17,7 @@ import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints, DEFAULT_DECAY }
 import { parseDuration } from './duration.js';
 import { synthesizeFit } from './manual.js';
 import { computeLoadSeries, formMultiplier, tsbBand } from './load.js';
+import { partitionDurations } from './table.js';
 import {
   parseAuthHash, clearAuthHash, loadSession, saveSession, clearSession, authorizeUrl,
   syncRecent, fetchSyncedActivities, UnauthenticatedError, StravaUnavailableError,
@@ -758,16 +759,17 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   currentLoad = computeLoadSeries(activityMmps, ftpForLoad);
 
   const newSyncIds = new Set(currentSettings.lastSyncNewIds || []);
-  const rows = DURATIONS_S
-    .filter((d) => allTime[d] !== undefined)
-    .map((d) => `
+  const shownDurations = DURATIONS_S.filter((d) => allTime[d] !== undefined);
+  const { short, long } = partitionDurations(shownDurations);
+  const rowFor = (d) => `
       <tr>
         <td>${formatDuration(d)}</td>
         <td>${renderMmpCell(last30Owners[d], newSyncIds)}</td>
         <td class="featured">${renderMmpCell(last90Owners[d], newSyncIds)}</td>
         <td>${renderMmpCell(allTimeOwners[d], newSyncIds)}</td>
-      </tr>`)
-    .join('');
+      </tr>`;
+  const shortRows = short.map(rowFor).join('');
+  const longRows = long.map(rowFor).join('');
 
   // Preserve the predict input across re-renders so changing an
   // override (CP value, date range, preset) live-updates the existing
@@ -793,8 +795,10 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
           <th data-tooltip="Best across the entire local cache. Earlier rides may not be present if you only synced a recent window.">${allTimeLabel(activityMmps)}</th>
         </tr>
       </thead>
-      <tbody>${rows}</tbody>
+      <tbody>${shortRows}</tbody>
+      ${longRows ? `<tbody id="mmp-long" hidden>${longRows}</tbody>` : ''}
     </table>
+    ${longRows ? `<button type="button" class="link-button mmp-expand" id="mmp-expand" aria-expanded="false" aria-controls="mmp-long">Show longer efforts ▾</button>` : ''}
     <aside class="data-sources" aria-label="Data sources">
       <section class="data-sources__row">
         <p class="data-sources__line">${activityMmps.length.toLocaleString()} activities cached locally · ${latestActivityLabel(activityMmps)}</p>
@@ -821,6 +825,16 @@ function renderCurves(activityMmps, { fromCache = false } = {}) {
   resultsEl.hidden = false;
   resultsEl.dataset.revealed = '';
   document.getElementById('clear-cache').addEventListener('click', handleClearCache);
+  const expandBtn = document.getElementById('mmp-expand');
+  if (expandBtn) {
+    expandBtn.addEventListener('click', () => {
+      const body = document.getElementById('mmp-long');
+      const opening = body.hidden;
+      body.hidden = !opening;
+      expandBtn.setAttribute('aria-expanded', String(opening));
+      expandBtn.textContent = opening ? 'Show fewer ▴' : 'Show longer efforts ▾';
+    });
+  }
   document.getElementById('upload-another').addEventListener('click', () => {
     fileInput?.click();
   });

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -226,7 +226,7 @@ export const DEFAULT_DECAY = {
 };
 
 // Fit a personal Riegel exponent from MMP points in the long-duration
-// range (default 20 min – 4 h). The relation
+// range (default 20 min – 12 h). The relation
 //   P(t) = P_anchor × (t_anchor / t)^k
 // linearizes under log/log to log P = a − k · log t, so a least-squares
 // regression on (log t, log P) gives slope = −k.

--- a/src/cpfit.js
+++ b/src/cpfit.js
@@ -236,7 +236,7 @@ export const DEFAULT_DECAY = {
 // above ~0.20 implies catastrophic decay seen only in untrained or sick
 // riders. Outside that window we still report the clamped value with a
 // `clamped` flag so callers can distinguish "fitted" from "rail-pinned."
-export const DEFAULT_FATIGUE_RANGE = { minS: 1200, maxS: 14400 };
+export const DEFAULT_FATIGUE_RANGE = { minS: 1200, maxS: 43200 };
 const FATIGUE_K_MIN = 0.04;
 const FATIGUE_K_MAX = 0.20;
 const FATIGUE_MIN_POINTS = 3;

--- a/src/mmp.js
+++ b/src/mmp.js
@@ -8,6 +8,7 @@ export const DURATIONS_S = [
   1, 2, 3, 5, 10, 15, 30, 60, 90, 120, 180, 240, 300,
   360, 480, 600, 720, 900, 1200, 1800, 2700, 3600,
   4500, 5400, 7200, 10800, 14400,
+  18000, 21600, 25200, 28800, 32400, 36000, 39600, 43200,
 ];
 
 // Adjacent-duration ratio sanity checks. Real cycling power kinetics

--- a/src/table.js
+++ b/src/table.js
@@ -1,0 +1,15 @@
+// Presentation helper for the MMP table. Splits the displayed duration
+// buckets into the default-visible set (≤ splitS) and the collapsible
+// long-effort tail (> splitS). Only durations that already have data are
+// passed in, so the tail stays empty until the rider logs longer efforts.
+
+export const TABLE_SPLIT_S = 3600; // show through 1h by default
+
+export function partitionDurations(durationsWithData, splitS = TABLE_SPLIT_S) {
+  const short = [];
+  const long = [];
+  for (const d of durationsWithData) {
+    (d <= splitS ? short : long).push(d);
+  }
+  return { short, long };
+}

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -7,6 +7,8 @@ import {
   effortQualityStats,
   normalizedPower,
   avgPower,
+  effortGateThreshold,
+  passesEffortGate,
 } from '../src/aggregate.js';
 
 describe('rollingBest', () => {
@@ -162,5 +164,44 @@ describe('normalizedPower', () => {
     const np = normalizedPower(stream);
     const ap = avgPower(stream);
     expect(np).toBeGreaterThan(ap);
+  });
+});
+
+describe('effort gate', () => {
+  it('is flat at the anchor IF for rides up to 1h', () => {
+    expect(effortGateThreshold(0.70, 600)).toBe(0.70);
+    expect(effortGateThreshold(0.70, 1800)).toBe(0.70);
+    expect(effortGateThreshold(0.70, 3600)).toBe(0.70);
+  });
+
+  it('decays gently beyond 1h (continuous at the anchor)', () => {
+    expect(effortGateThreshold(0.70, 3601)).toBeCloseTo(0.70, 3);
+    // 5.5h ride: 0.70 * (3600/19872)^0.06
+    expect(effortGateThreshold(0.70, 19872)).toBeCloseTo(0.632, 3);
+    expect(effortGateThreshold(0.70, 32400)).toBeLessThan(0.632);
+  });
+
+  it('passes a hard 5.5h ride that the flat gate would drop', () => {
+    // avg 207 / ftp 300 = 0.69, below flat 0.70 but above the 0.63 long floor
+    expect(passesEffortGate(207, 300, 19872, 0.70)).toBe(true);
+  });
+
+  it('still drops an easy short ride and an easy long ride', () => {
+    expect(passesEffortGate(195, 300, 1800, 0.70)).toBe(false);   // 0.65 @ 30min
+    expect(passesEffortGate(165, 300, 19872, 0.70)).toBe(false);  // 0.55 @ 5.5h
+  });
+
+  it('is a no-op without a usable ftp/minIF or avgPower', () => {
+    expect(passesEffortGate(100, null, 19872, 0.70)).toBe(true);
+    expect(passesEffortGate(NaN, 300, 19872, 0.70)).toBe(true);
+  });
+
+  it('rollingBest keeps a hard long ride and drops an easy one', () => {
+    const acts = [
+      { startTime: 1, durationS: 19872, avgPower: 207, mmp: { 14400: 217, 1200: 291 } },
+      { startTime: 2, durationS: 19872, avgPower: 165, mmp: { 14400: 170 } },
+    ];
+    const best = rollingBest(acts, { minIF: 0.70, ftp: 300 });
+    expect(best[14400]).toBe(217);
   });
 });

--- a/tests/aggregate.test.js
+++ b/tests/aggregate.test.js
@@ -204,4 +204,14 @@ describe('effort gate', () => {
     const best = rollingBest(acts, { minIF: 0.70, ftp: 300 });
     expect(best[14400]).toBe(217);
   });
+
+  it('recencyWeightedBest keeps a hard long ride and drops an easy one', () => {
+    const acts = [
+      { startTime: 1000, durationS: 19872, avgPower: 207, mmp: { 14400: 217 } },
+      { startTime: 1000, durationS: 19872, avgPower: 165, mmp: { 10800: 180 } },
+    ];
+    const best = recencyWeightedBest(acts, { minIF: 0.70, ftp: 300, now: 1000 });
+    expect(best[14400]).toBe(217);   // hard ride kept
+    expect(best[10800]).toBeUndefined(); // easy ride dropped
+  });
 });

--- a/tests/cpfit.test.js
+++ b/tests/cpfit.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints } from '../src/cpfit.js';
+import { fitCp2, fitCp3, fitFatigueK, predictPower, mmpToPoints, DEFAULT_FATIGUE_RANGE } from '../src/cpfit.js';
 
 // Generate synthetic MMP points from a known CP/W' so we can verify
 // the fit recovers them.
@@ -327,5 +327,17 @@ describe('fitFatigueK', () => {
   it('returns null for non-array input', () => {
     expect(fitFatigueK(null)).toBeNull();
     expect(fitFatigueK(undefined)).toBeNull();
+  });
+});
+
+describe('fatigue-k range extension', () => {
+  it('consumes long-duration points up to the new ceiling', () => {
+    expect(DEFAULT_FATIGUE_RANGE.maxS).toBe(43200);
+    // P(t) = 300 * (1200/t)^0.1 — a clean k=0.1 decay
+    const p = (t) => ({ durationS: t, powerW: 300 * (1200 / t) ** 0.1 });
+    const points = [p(1200), p(7200), p(14400), p(28800)];
+    const fit = fitFatigueK(points);
+    expect(fit.nPoints).toBe(4); // 28800 included; would be 3 under the old 14400 cap
+    expect(fit.k).toBeCloseTo(0.1, 2);
   });
 });

--- a/tests/mmp.test.js
+++ b/tests/mmp.test.js
@@ -24,6 +24,24 @@ describe('extractMmp', () => {
   });
 });
 
+describe('extended duration range', () => {
+  it('includes hourly buckets from 5h to 12h, sorted ascending', () => {
+    for (const d of [18000, 21600, 25200, 28800, 32400, 36000, 39600, 43200]) {
+      expect(DURATIONS_S).toContain(d);
+    }
+    const sorted = [...DURATIONS_S].sort((a, b) => a - b);
+    expect(DURATIONS_S).toEqual(sorted);
+  });
+
+  it('fills only the buckets a ride is long enough for', () => {
+    const sixHours = new Array(21600).fill(200); // exactly 6h
+    const mmp = extractMmp(sixHours);
+    expect(mmp[18000]).toBe(200); // 5h reachable
+    expect(mmp[21600]).toBe(200); // 6h reachable
+    expect(mmp[25200]).toBeUndefined(); // 7h not reachable
+  });
+});
+
 describe('dropAnomalies', () => {
   it('passes a realistic sprint profile through unchanged', () => {
     const mmp = { 1: 900, 2: 870, 3: 830, 5: 780, 15: 600, 30: 500, 60: 380, 300: 280 };

--- a/tests/table.test.js
+++ b/tests/table.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { partitionDurations, TABLE_SPLIT_S } from '../src/table.js';
+
+describe('partitionDurations', () => {
+  it('splits at 1h by default, with 1h in the visible set', () => {
+    const { short, long } = partitionDurations([60, 1200, 3600, 7200, 14400]);
+    expect(short).toEqual([60, 1200, 3600]);
+    expect(long).toEqual([7200, 14400]);
+  });
+
+  it('leaves the long tail empty when no data passes the split', () => {
+    expect(partitionDurations([60, 1200, 3600]).long).toEqual([]);
+  });
+
+  it('exposes the split constant', () => {
+    expect(TABLE_SPLIT_S).toBe(3600);
+  });
+});


### PR DESCRIPTION
## Summary

Brings `healthReport/configurationFiles/README.md` back in line with the current code and config layout, and fills in undocumented config fields:

- **Implementation Details:** `loadConfigWithExtends()` was extracted into the shared `healthReport/src/configLoader.ts` and is now imported by `api/v1/report.ts`, `healthReport/src/AggregatedAlert.ts`, and the dry-run harness `healthReport/src/bin/dryRunAlert.ts`. The README still claimed it was implemented separately in `report.ts` and `AggregatedAlert.ts`.
- **`_base` listing:** updated to list all 7 base configs (the two `Unstable_And_Disabled_*` reminder configs were missing).
- **Heading:** the file had two identical `## Config Inheritance Pattern` H2 headings; renamed the examples section to `## Inheritance Examples`.
- **`slackTitle`:** documented the optional top-level field that sets the human-readable Slack title (falling back to the underscored `reportIdTemplate` when absent), how it inherits through `extends`, and its `{{readableTitle}}` placeholder. Added it to the "Creating New Configs" override list.
- **Message Templates:** new section covering the alert template fields (`headerTemplate`/`statsLineTemplate`/`lineTemplate`/`footerTemplate`), the `{{...}}` placeholder family and `url:`/`int:` prefixes, the `headerTemplate: ""` header-suppression idiom, and `useFullLinks`.

Docs-only; no code or config-value changes.

## Test plan

- [x] Verified `loadConfigWithExtends` is defined only in `configLoader.ts` and imported by the three listed sites
- [x] Verified `ios/_base/` contains exactly the 7 listed configs
- [x] Verified `slackTitle` semantics against `generateReadableTitle`, the `{{readableTitle}}` template wiring, and the example config
- [x] Verified template/placeholder claims against `parseTemplate`, `getHeaderMsg`/`getFooterMsg`/`getStatsLineMsg`, `getLineMsg`, and `useFullLinks`/`GO_LINK_DOMAINS`
- [x] Full test suite: 329 passing, 3 pending
- [ ] Render README on GitHub to confirm formatting
