### PR TITLE
Re-extract stored rides on MMP version change + fix worker deploy trigger

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'worker.js'
       - 'worker/**'
+      - 'src/**'
       - 'wrangler.toml'
       - 'migrations/**'
   workflow_dispatch:
@@ -23,6 +24,11 @@ jobs:
       # (devDependencies) instead of falling back to its own bundled
       # version. Keeps CI deploys on the same wrangler we run locally.
       - run: npm ci
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply power-predict --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/migrations/0002_mmp_version.sql
+++ b/migrations/0002_mmp_version.sql
@@ -1,0 +1,4 @@
+-- Track which MMP extraction version produced each activity's mmp_records.
+-- NULL on existing rows (pre-versioning); treated as stale so the next
+-- sync re-extracts them with the current DURATIONS_S bucket set.
+ALTER TABLE activities ADD COLUMN mmp_version INTEGER;

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
-import { DURATIONS_S } from './mmp.js';
+import { DURATIONS_S, MMP_VERSION } from './mmp.js';
+import { activitiesToRefresh } from './sync-merge.js';
 import { rollingBest, rollingBestWithOwners, estimateFtp } from './aggregate.js';
 import { normalizeForDrift } from './drift.js';
 import { renderCurveChart } from './curve-chart.js';
@@ -244,7 +245,11 @@ async function triggerStravaSync() {
     // Tell the worker which Strava ids the IDB cache already has so it
     // skips them in the worklist — no point re-fetching streams the
     // user already ingested via archive upload.
+    // Only rides already extracted at the current version are safe to
+    // declare "known" — a stale-version ride must NOT be suppressed, or
+    // the server would skip re-extracting it with the new bucket set.
     const knownIds = currentActivities
+      .filter((a) => a.mmpVersion === MMP_VERSION)
       .map((a) => a.stravaId)
       .filter((id) => id != null && id !== '');
     const { removedIds } = await syncRecent({
@@ -270,10 +275,9 @@ async function triggerStravaSync() {
       showStatus('No power-equipped rides in the synced window.', { kind: 'success', dwellMs: 3500 });
       return;
     }
-    const fresh = [];
-    for (const a of remoteActivities) {
-      if (!(await hasActivity(a.startTime))) fresh.push(a);
-    }
+    // Write rides that are new OR whose server-side mmpVersion changed
+    // (a re-extraction). hasActivity alone would miss the latter.
+    const fresh = activitiesToRefresh(remoteActivities, currentActivities);
     // Snapshot per-(duration, window) owners BEFORE saving the sync
     // results so we can diff afterwards. The diff catches any cell
     // whose owner activity changed — that's the right signal for
@@ -440,6 +444,7 @@ async function handleArchive(file) {
                 avgPower: msg.avgPower,
                 npW: msg.npW ?? msg.avgPower,
                 mmp: msg.mmp,
+                mmpVersion: msg.mmpVersion ?? MMP_VERSION,
                 stravaId: msg.stravaId ?? null,
               });
             }

--- a/src/archive-worker.js
+++ b/src/archive-worker.js
@@ -12,7 +12,7 @@
 import { Unzip, UnzipInflate, gunzipSync } from 'fflate';
 import { parseFit } from './fit.js';
 import { parseTcx } from './tcx.js';
-import { extractMmp } from './mmp.js';
+import { extractMmp, MMP_VERSION } from './mmp.js';
 import { normalizedPower } from './aggregate.js';
 import { isRideType } from './sport.js';
 
@@ -188,6 +188,7 @@ async function parseArchive(file) {
           avgPower,
           npW,
           mmp,
+          mmpVersion: MMP_VERSION,
           stravaId,
         });
         withPower++;

--- a/src/mmp.js
+++ b/src/mmp.js
@@ -11,6 +11,14 @@ export const DURATIONS_S = [
   18000, 21600, 25200, 28800, 32400, 36000, 39600, 43200,
 ];
 
+// Extraction version. Stamped onto each stored activity so a change to
+// the bucket set or extraction logic forces a re-extraction of already-
+// stored rides on the next sync (rather than silently serving stale
+// MMP rows). Bump this whenever DURATIONS_S or extractMmp changes.
+//   v1 — original bucket set capped at 4h
+//   v2 — extended to hourly buckets through 12h
+export const MMP_VERSION = 2;
+
 // Adjacent-duration ratio sanity checks. Real cycling power kinetics
 // bound how much shorter durations can exceed longer ones — even a
 // world-class sprinter's 1s peak sits roughly 1.5-1.8x their 5s peak.

--- a/src/sync-merge.js
+++ b/src/sync-merge.js
@@ -1,7 +1,7 @@
 // Decide which synced activities the client needs to (re)write to its
 // IndexedDB cache. A remote activity is written when it is new (no
 // cached row at that startTime) or when its mmpVersion differs from the
-// cached copy — the latter is how a server-side re-extraction (new
+// cached copy. The latter is how a server-side re-extraction (new
 // bucket set) propagates into the local cache. startTime (unix ms) is
 // the IDB key, so two rides can't collide on it.
 export function activitiesToRefresh(remoteActivities, cachedActivities) {

--- a/src/sync-merge.js
+++ b/src/sync-merge.js
@@ -1,0 +1,14 @@
+// Decide which synced activities the client needs to (re)write to its
+// IndexedDB cache. A remote activity is written when it is new (no
+// cached row at that startTime) or when its mmpVersion differs from the
+// cached copy — the latter is how a server-side re-extraction (new
+// bucket set) propagates into the local cache. startTime (unix ms) is
+// the IDB key, so two rides can't collide on it.
+export function activitiesToRefresh(remoteActivities, cachedActivities) {
+  const cachedVersionByStart = new Map();
+  for (const a of cachedActivities) cachedVersionByStart.set(a.startTime, a.mmpVersion);
+  return remoteActivities.filter((r) => {
+    if (!cachedVersionByStart.has(r.startTime)) return true;
+    return cachedVersionByStart.get(r.startTime) !== r.mmpVersion;
+  });
+}

--- a/tests/mmp.test.js
+++ b/tests/mmp.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractMmp, dropAnomalies, DURATIONS_S } from '../src/mmp.js';
+import { extractMmp, dropAnomalies, DURATIONS_S, MMP_VERSION } from '../src/mmp.js';
 
 describe('extractMmp', () => {
   it('returns empty for empty stream', () => {
@@ -80,5 +80,11 @@ describe('dropAnomalies', () => {
   it('handles missing pairs gracefully', () => {
     expect(dropAnomalies({})).toEqual({});
     expect(dropAnomalies({ 60: 250 })).toEqual({ 60: 250 });
+  });
+});
+
+describe('MMP_VERSION', () => {
+  it('is the current extraction version (bumped for the 12h bucket set)', () => {
+    expect(MMP_VERSION).toBe(2);
   });
 });

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -4,6 +4,7 @@ import {
   getValidAccessToken,
   runSyncSlice,
 } from '../worker/sync.js';
+import { MMP_VERSION } from '../src/mmp.js';
 
 // ---------- D1 stub ----------
 //
@@ -37,8 +38,8 @@ function makeDb(state = {}) {
           const u = state.users.get(id) || {};
           state.users.set(id, { ...u, access_token: accessToken, refresh_token: refreshToken, token_expires_at: expiresAt });
         } else if (sql.startsWith('INSERT OR REPLACE INTO activities')) {
-          const [id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, , , , , ingested_at] = b;
-          state.activities.set(id, { id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, ingested_at, has_power: 1 });
+          const [id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, ingested_at, mmp_version] = b;
+          state.activities.set(id, { id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power, ingested_at, mmp_version, has_power: 1 });
         } else if (sql.startsWith('DELETE FROM mmp_records')) {
           state.mmp = state.mmp.filter((m) => m.activity_id !== b[0]);
         } else if (sql.startsWith('DELETE FROM activities')) {
@@ -53,11 +54,8 @@ function makeDb(state = {}) {
       },
       async all() {
         const b = getBound();
-        if (sql.startsWith('SELECT id FROM activities')) {
-          const results = [...state.activities.values()]
-            .filter((a) => a.user_id === b[0])
-            .map((a) => ({ id: a.id }));
-          return { results };
+        if (sql.startsWith('SELECT id, mmp_version FROM activities')) {
+          return { results: [...state.activities.values()].map((a) => ({ id: a.id, mmp_version: a.mmp_version ?? null })) };
         }
         return { results: [] };
       },
@@ -245,7 +243,7 @@ describe('runSyncSlice', () => {
       access_token: 'tok', refresh_token: 'r',
       token_expires_at: Math.floor(Date.now() / 1000) + 3600,
     });
-    db.state.activities.set(1001, { id: 1001, user_id: 42, has_power: 1, start_time: 0 });
+    db.state.activities.set(1001, { id: 1001, user_id: 42, has_power: 1, start_time: 0, mmp_version: MMP_VERSION });
     const fakeFetch = async (urlStr) => {
       if (urlStr.includes('/athlete/activities')) {
         return new Response(JSON.stringify([
@@ -253,7 +251,7 @@ describe('runSyncSlice', () => {
             start_date: '2026-01-01T00:00:00Z', elapsed_time: 600, distance: 5000 },
         ]), { status: 200 });
       }
-      throw new Error('should not fetch streams for already-ingested rides');
+      throw new Error('should not fetch streams for current-version rides');
     };
     const env = { DB: db, RATE_LIMIT: makeKv(), STRAVA_CLIENT_ID: 'c', STRAVA_CLIENT_SECRET: 's' };
     const out = await runSyncSlice({ env, athleteId: 42, fetchImpl: fakeFetch });
@@ -287,5 +285,59 @@ describe('runSyncSlice', () => {
     expect(out.totalWithPower).toBe(2);
     expect(out.remaining).toBe(1);
     expect(out.cursor.pending[0].id).toBe(1002);
+  });
+});
+
+describe('mmp version re-extraction', () => {
+  // Minimal Strava listing + stream fetch stubs. One ride, in the window.
+  function makeFetchImpl(activityId, durationS) {
+    return async (url) => {
+      const u = String(url);
+      if (u.includes('/athlete/activities')) {
+        return new Response(JSON.stringify([{
+          id: activityId, type: 'Ride', start_date: '2026-06-20T13:00:00Z',
+          elapsed_time: durationS, distance: 100000, average_watts: 200, device_watts: true,
+        }]), { status: 200 });
+      }
+      if (u.includes('/streams')) {
+        return new Response(JSON.stringify({ watts: { data: new Array(durationS).fill(200) } }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    };
+  }
+
+  it('does NOT skip a ride whose stored mmp_version is stale (null)', async () => {
+    const state = {};
+    const db = makeDb(state);
+    state.users.set(7, { id: 7, access_token: 't', refresh_token: 'r', token_expires_at: 9e12 });
+    state.activities.set(555, { id: 555, user_id: 7, start_time: 1, duration_s: 100, mmp_version: null, has_power: 1 });
+    const env = { DB: db, STRAVA_CLIENT_ID: '1', STRAVA_CLIENT_SECRET: 's' };
+    const fetchImpl = makeFetchImpl(555, 120);
+    const first = await runSyncSlice({ env, athleteId: 7, days: 180, cursor: null, knownIds: [], fetchImpl });
+    expect(first.remaining).toBe(1); // stale ride queued for re-extraction, not skipped
+  });
+
+  it('skips a ride already at the current mmp_version', async () => {
+    const state = {};
+    const db = makeDb(state);
+    state.users.set(7, { id: 7, access_token: 't', refresh_token: 'r', token_expires_at: 9e12 });
+    state.activities.set(555, { id: 555, user_id: 7, start_time: 1, duration_s: 100, mmp_version: 2, has_power: 1 });
+    const env = { DB: db, STRAVA_CLIENT_ID: '1', STRAVA_CLIENT_SECRET: 's' };
+    const fetchImpl = makeFetchImpl(555, 120);
+    const first = await runSyncSlice({ env, athleteId: 7, days: 180, cursor: null, knownIds: [], fetchImpl });
+    expect(first.remaining).toBe(0); // current-version ride skipped
+  });
+
+  it('stamps MMP_VERSION on re-extracted rides', async () => {
+    const state = {};
+    const db = makeDb(state);
+    state.users.set(7, { id: 7, access_token: 't', refresh_token: 'r', token_expires_at: 9e12 });
+    state.activities.set(555, { id: 555, user_id: 7, start_time: 1, duration_s: 100, mmp_version: null, has_power: 1 });
+    const env = { DB: db, STRAVA_CLIENT_ID: '1', STRAVA_CLIENT_SECRET: 's' };
+    const fetchImpl = makeFetchImpl(555, 120);
+    const first = await runSyncSlice({ env, athleteId: 7, days: 180, cursor: null, knownIds: [], fetchImpl });
+    const second = await runSyncSlice({ env, athleteId: 7, days: 180, cursor: first.cursor, knownIds: [], fetchImpl });
+    expect(second.processed).toBe(1);
+    expect(state.activities.get(555).mmp_version).toBe(MMP_VERSION);
   });
 });

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -321,7 +321,7 @@ describe('mmp version re-extraction', () => {
     const state = {};
     const db = makeDb(state);
     state.users.set(7, { id: 7, access_token: 't', refresh_token: 'r', token_expires_at: 9e12 });
-    state.activities.set(555, { id: 555, user_id: 7, start_time: 1, duration_s: 100, mmp_version: 2, has_power: 1 });
+    state.activities.set(555, { id: 555, user_id: 7, start_time: 1, duration_s: 100, mmp_version: MMP_VERSION, has_power: 1 });
     const env = { DB: db, STRAVA_CLIENT_ID: '1', STRAVA_CLIENT_SECRET: 's' };
     const fetchImpl = makeFetchImpl(555, 120);
     const first = await runSyncSlice({ env, athleteId: 7, days: 180, cursor: null, knownIds: [], fetchImpl });

--- a/tests/strava-sync.test.js
+++ b/tests/strava-sync.test.js
@@ -55,7 +55,7 @@ function makeDb(state = {}) {
       async all() {
         const b = getBound();
         if (sql.startsWith('SELECT id, mmp_version FROM activities')) {
-          return { results: [...state.activities.values()].map((a) => ({ id: a.id, mmp_version: a.mmp_version ?? null })) };
+          return { results: [...state.activities.values()].filter((a) => a.user_id === b[0]).map((a) => ({ id: a.id, mmp_version: a.mmp_version ?? null })) };
         }
         return { results: [] };
       },

--- a/tests/sync-merge.test.js
+++ b/tests/sync-merge.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { activitiesToRefresh } from '../src/sync-merge.js';
+
+describe('activitiesToRefresh', () => {
+  it('includes activities not present in the cache', () => {
+    const remote = [{ startTime: 100, mmpVersion: 2 }];
+    expect(activitiesToRefresh(remote, [])).toEqual([{ startTime: 100, mmpVersion: 2 }]);
+  });
+
+  it('includes cached activities whose mmpVersion changed', () => {
+    const remote = [{ startTime: 100, mmpVersion: 2 }];
+    const cached = [{ startTime: 100, mmpVersion: 1 }];
+    expect(activitiesToRefresh(remote, cached)).toEqual([{ startTime: 100, mmpVersion: 2 }]);
+  });
+
+  it('excludes cached activities already at the same mmpVersion', () => {
+    const remote = [{ startTime: 100, mmpVersion: 2 }];
+    const cached = [{ startTime: 100, mmpVersion: 2 }];
+    expect(activitiesToRefresh(remote, cached)).toEqual([]);
+  });
+
+  it('treats a missing cached version as different from a stamped remote', () => {
+    const remote = [{ startTime: 100, mmpVersion: 2 }];
+    const cached = [{ startTime: 100 }]; // legacy record, no mmpVersion
+    expect(activitiesToRefresh(remote, cached)).toEqual([{ startTime: 100, mmpVersion: 2 }]);
+  });
+});

--- a/worker/sync.js
+++ b/worker/sync.js
@@ -2,7 +2,7 @@
 // MMP, writes to D1. Pure-ish: takes env + fetch + a session lookup
 // so it can be tested with stubbed dependencies.
 
-import { extractMmp } from '../src/mmp.js';
+import { extractMmp, MMP_VERSION } from '../src/mmp.js';
 import { normalizedPower } from '../src/aggregate.js';
 import { isRideActivity } from '../src/sport.js';
 import { listActivitiesAfter, fetchPowerStream, hasRealPower } from './strava-api.js';
@@ -92,10 +92,17 @@ export async function runSyncSlice({
     // ingest doesn't write to D1, so the worker would otherwise
     // re-fetch streams the client already has).
     const existing = await env.DB
-      .prepare('SELECT id FROM activities WHERE user_id = ?')
+      .prepare('SELECT id, mmp_version FROM activities WHERE user_id = ?')
       .bind(athleteId)
       .all();
-    const existingIds = new Set((existing.results || []).map((r) => r.id));
+    const existingRows = existing.results || [];
+    const existingIds = new Set(existingRows.map((r) => r.id));
+    // Only rides already extracted at the CURRENT version are safe to
+    // skip. Stale/NULL-version rides get re-fetched and re-extracted so
+    // a bucket-set change (DURATIONS_S) actually reaches stored history.
+    const currentVersionIds = new Set(
+      existingRows.filter((r) => r.mmp_version === MMP_VERSION).map((r) => r.id)
+    );
 
     // Reconcile: drop previously-synced activities that the listing now
     // classifies as non-rides (runs/walks/e-bikes) or otherwise not a
@@ -117,7 +124,7 @@ export async function runSyncSlice({
       await env.DB.batch(stmts);
     }
 
-    const skip = new Set(existingIds);
+    const skip = new Set(currentVersionIds);
     for (const id of knownIds) {
       const n = Number(id);
       if (Number.isFinite(n)) skip.add(n);
@@ -176,12 +183,12 @@ export async function runSyncSlice({
         .prepare(
           `INSERT OR REPLACE INTO activities
             (id, user_id, start_time, duration_s, distance_m, avg_power, normalized_power,
-             intensity_factor, tss, has_power, source, ingested_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, 1, 'api', ?)`
+             intensity_factor, tss, has_power, source, ingested_at, mmp_version)
+           VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, 1, 'api', ?, ?)`
         )
         .bind(
           a.id, athleteId, a.startTime, a.durationS, a.distanceM,
-          a.avgPower, npW, Math.floor(Date.now() / 1000),
+          a.avgPower, npW, Math.floor(Date.now() / 1000), MMP_VERSION,
         )
         .run();
       // Bulk insert the per-duration MMP records. We delete + insert
@@ -228,7 +235,7 @@ export async function runSyncSlice({
 // the same shape the frontend feeds into its renderCurves pipeline.
 export async function loadActivities(env, athleteId) {
   const acts = await env.DB
-    .prepare(`SELECT id, start_time, duration_s, distance_m, avg_power, normalized_power
+    .prepare(`SELECT id, start_time, duration_s, distance_m, avg_power, normalized_power, mmp_version
               FROM activities
               WHERE user_id = ? AND has_power = 1
               ORDER BY start_time ASC`)
@@ -260,5 +267,6 @@ export async function loadActivities(env, athleteId) {
     avgPower: r.avg_power,
     npW: r.normalized_power,
     mmp: mmpByActivity.get(r.id) || {},
+    mmpVersion: r.mmp_version ?? null,
   }));
 }


### PR DESCRIPTION
## Summary

The 4h→12h bucket extension (#213) never reached users: two server-side gaps swallowed it.

1. **Stale worker:** `deploy-worker.yml` only redeployed the worker on changes to `worker.js`/`worker/**`/`wrangler.toml`/`migrations/**` — **not `src/**`**. The worker bundles `src/mmp.js` via `worker/sync.js`, so the new `DURATIONS_S` never deployed.
2. **No re-extraction:** the sync worklist skips any ride already in D1, so stored rides were never re-extracted with the new buckets — and a client cache-clear doesn't touch server-side D1.

This PR adds an extraction-version stamp so a bucket-set change auto-re-extracts stored rides, and fixes the deploy trigger.

- **`src/mmp.js`** — export `MMP_VERSION` (=2; bump whenever `DURATIONS_S`/`extractMmp` changes).
- **`migrations/0002_mmp_version.sql`** — nullable `mmp_version` column on `activities` (NULL = stale).
- **`worker/sync.js`** — skip a ride only when its stored `mmp_version` equals `MMP_VERSION`; stale/NULL rides are re-fetched and re-extracted (existing `mmp_records` are deleted and rebuilt). Stamp the version on upsert; return `mmpVersion` from `loadActivities`.
- **`src/sync-merge.js` + `src/app.js`** — client sends only current-version ids as `knownIds` (so stale rides aren't suppressed from re-extraction) and rewrites any cached ride whose `mmpVersion` changed. `src/archive-worker.js` stamps the version on archive-extracted records.
- **`.github/workflows/deploy-worker.yml`** — watch `src/**`, and apply D1 migrations (`wrangler d1 migrations apply --remote`, idempotent) before deploy.

### Notes for reviewers
- First post-deploy sync per user re-fetches and re-extracts every in-window ride (up to 180 days) — a one-time heavier sync. Rides older than the 180-day listing window keep their v1 (4h-capped) data until listed again.
- Client `knownIds` filter and the server's own D1 version check are belt-and-suspenders; on the first post-deploy sync, cached records have no `mmpVersion`, so `knownIds` is empty and the server's NULL-version check drives re-extraction.

## Test plan

- [x] `npx vitest run` — full suite, 179/179 passing (new: MMP_VERSION, 3 worker re-extraction tests, 4 activitiesToRefresh tests)
- [x] Whole-branch review (Opus) traced the end-to-end re-extraction loop; migration + deploy ordering confirmed safe
- [ ] After merge: confirm the worker deploy + D1 migration ran (GitHub Actions), then re-sync from Strava and verify the table now shows the 5h bucket for the Detoor ride
