### PR TITLE
Hotfix: drop CI D1 migration step so the worker can deploy

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -24,11 +24,11 @@ jobs:
       # (devDependencies) instead of falling back to its own bundled
       # version. Keeps CI deploys on the same wrangler we run locally.
       - run: npm ci
-      - name: Apply D1 migrations
-        run: npx wrangler d1 migrations apply power-predict --remote
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      # D1 migrations are applied manually, not in CI: the deploy token is
+      # scoped to Workers only, and the database was initialised with a raw
+      # execute rather than the migrations framework, so `migrations apply`
+      # re-runs 0001 and fails. Apply schema changes by hand before merging:
+      #   npx wrangler d1 execute power-predict --remote --command "<DDL>"
       - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up hotfix to #214. The CI step `wrangler d1 migrations apply` added there fails on deploy and, because it runs before the deploy step, prevents the worker from redeploying at all (so the re-extraction fix never went live). Two root causes:

1. The CI `CLOUDFLARE_API_TOKEN` is scoped to Workers only, not D1.
2. Production D1 was initialised with a raw execute, so the `d1_migrations` tracking table has no record of `0001` — `migrations apply` re-runs `0001` and fails on "table already exists".

This removes the CI migration step (documented in a comment) and keeps migrations manual via `wrangler d1 execute`, which is how the schema was actually set up. The `src/**` deploy-trigger fix from #214 is preserved. The `0002` `mmp_version` column has already been applied to production D1 by hand.

## Test plan

- [x] YAML parses; steps are now checkout → setup-node → npm ci → wrangler-action; `paths:` still includes `src/**`
- [ ] After merge: manually dispatch the worker deploy and confirm it succeeds (the worker finally ships the version-aware re-extraction code)
